### PR TITLE
[Bug Fix]: Add rel="noopener noreferrer" to external social links in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,13 +87,13 @@
             <div>
                 <h3>Connect With Us</h3>
                 <div class="social-links">
-                    <a href="https://www.instagram.com/dhairyaa__31/" target="_blank" class="social-btn">
+                    <a href="https://www.instagram.com/dhairyaa__31/" target="_blank" rel="noopener noreferrer" class="social-btn">
                         <i class="fab fa-instagram"></i>
                     </a>
-                    <a href="https://github.com/dhairyagothi/100_days_100_web_project" target="_blank" class="social-btn">
+                    <a href="https://github.com/dhairyagothi/100_days_100_web_project" target="_blank" rel="noopener noreferrer" class="social-btn">
                         <i class="fab fa-github"></i>
                     </a>
-                    <a href="https://www.linkedin.com/in/dhairya-gothi-65945b288/" target="_blank" class="social-btn">
+                    <a href="https://www.linkedin.com/in/dhairya-gothi-65945b288/" target="_blank" rel="noopener noreferrer" class="social-btn">
                         <i class="fab fa-linkedin"></i>
                     </a>
                 </div>


### PR DESCRIPTION
## Description
Added `rel="noopener noreferrer"` to all three external social media anchor tags in the footer of `index.html` that were using `target="_blank"` without the rel attribute.

Fixes #869 

## Type of Change
- [ ] New project
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update

## Testing
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested on mobile
- [x] No console errors

## Screenshots
Not applicable — no visual changes were made.

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Documentation updated
- [x] No merge conflicts