### PR TITLE
fix: stop typing test timer after sentence completion

### DIFF
--- a/public/typing_test/test.html
+++ b/public/typing_test/test.html
@@ -61,6 +61,17 @@
             }
         }, 1000);
 
+        const textInput = document.getElementById('text-input');
+        const textDisplay = document.getElementById('text-display');
+
+        textInput.addEventListener('input', () => {
+            if (textInput.value.trim() === textDisplay.textContent.trim()) {
+                clearInterval(interval);
+                textInput.disabled = true;
+                timerElement.textContent = `Completed with ${timeLeft} seconds remaining`;
+            }
+        });
+
         document.getElementById('restart').addEventListener('click', function () {
             window.location.href = 'main.html';
         });


### PR DESCRIPTION
## Related Issue

Fixes #1041

---

## Description

Fixed the issue in the `typing_test` project where the timer continued counting down even after the sentence was completed successfully.

### Changes Made

* Added sentence completion detection logic
* Stopped timer immediately after successful completion
* Preserved remaining time display
* Disabled input field after completion

---

## Type of PR

* [x] Bug fix
* [ ] Feature enhancement
* [ ] Documentation update
* [ ] Security enhancement
* [ ] Other (specify): _______________

---

## Screenshots :
<img width="935" height="921" alt="image" src="https://github.com/user-attachments/assets/81aca3e4-1072-4020-b09c-ceb4a25e2bcc" />

---

## Checklist

* [x] I have performed a self-review of my code.
* [x] I have read and followed the Contribution Guidelines.
* [x] I have tested the changes thoroughly before submitting this pull request.
* [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [x] I have followed the code style guidelines of this project.
* [x] I have checked for any existing open issues that my pull request may address.
* [x] I have ensured that my changes do not break any existing functionality.
* [x] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
* [x] I have read the resources for guidance listed below.
* [x] I have followed security best practices in my code changes.

---

## Additional Context

The fix was tested locally using Live Server. After successful sentence completion, the timer now stops instantly and displays the remaining time correctly.
