### PR TITLE
Fix empty rectangle appearing below digital clock

### DIFF
--- a/public/digital_clock/digitalclock.html
+++ b/public/digital_clock/digitalclock.html
@@ -11,15 +11,11 @@
   </head>
   <body class="bg-black flex flex-col items-center justify-center h-screen">
     <div class="text-center">
-      <div
-        id="display"
-        class="relative font-mono text-4xl md:text-5xl text-white border-4 border-green-500 rounded-lg p-4 mb-4"
-      ></div>
-      <div
-        id="clock"
-        class="relative font-mono text-4xl md:text-5xl text-green-500 border-4 border-green-500 rounded-lg p-4"
-      ></div>
-    </div>
+    <div
+      id="display"
+      class="relative font-mono text-4xl md:text-5xl text-white border-4 border-green-500 rounded-lg p-4 mb-4"
+    ></div>
+   </div>
     <div class="mt-10 flex space-x-4">
       <button
         class="clock-face-btn px-4 py-2 hover:bg-green-700 hover:text-white border-2 border-green-500 text-green-500 rounded-lg"

--- a/public/digital_clock/digitalclock.js
+++ b/public/digital_clock/digitalclock.js
@@ -90,9 +90,6 @@ function setClockStyleAndFormat(face, format) {
 function setClockFace(face) {
   const display = document.getElementById('display');
   display.className = `relative font-mono text-4xl md:text-5xl border-4 rounded-lg p-4 mb-4 ${face}`;
-
-  const clock = document.getElementById('clock');
-  clock.className = `relative font-mono text-4xl md:text-5xl border-4 rounded-lg p-4 ${face}`;
 }
 
 function getMonthName(monthNumber) {


### PR DESCRIPTION
## Related Issue

Fixes #923

## Description

Removed the duplicate display container in `digitalclock.html` that was causing an unused empty bordered rectangle to appear below the digital clock display.

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other (specify): _______________

## Screenshots / Videos (if applicable)

Before: An empty bordered rectangle appeared below the clock display.
<img width="1901" height="1001" alt="Screenshot 2026-05-15 102824" src="https://github.com/user-attachments/assets/bfb11e30-21c5-4622-9b40-8a420af2b6f4" />

After: The duplicate container was removed and the extra rectangle no longer appears.
<img width="1915" height="1007" alt="Screenshot 2026-05-15 102918" src="https://github.com/user-attachments/assets/7d83c68f-f4fd-4e49-9122-9c31c4e6269d" />

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have followed the code style guidelines of this project.
- [x] I have checked for any existing open issues that my pull request may address.
- [x] I have ensured that my changes do not break any existing functionality.
- [x] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
- [x] I have read the resources for guidance listed below.
- [x] I have followed security best practices in my code changes.

## Additional Context

This change improves the UI by removing an unnecessary empty container and makes the Digital Clock interface cleaner and more professional.