### PR TITLE
fix: correct URL shortener API endpoint

### DIFF
--- a/public/url_shortener/backend/server.js
+++ b/public/url_shortener/backend/server.js
@@ -29,7 +29,7 @@ app.get("/health", (req, res) => {
 
 app.use('/login', Login_route)
 app.use('/signup', SignUp_route)
-app.use('/api/shortern/', API_shortner)
+app.use('/api/shorten/', API_shortner)
 app.use('/', Redirect_route)
 app.use('/api/', Logged_user)
 

--- a/public/url_shortener/frontend/src/utils/api.js
+++ b/public/url_shortener/frontend/src/utils/api.js
@@ -3,7 +3,7 @@ const BASE_URL = process.env.REACT_APP_API_URL;
 // 🔹 Static endpoints
 export const endpoints = {
   ME: `${BASE_URL}/api/me`,
-  SHORTEN: `${BASE_URL}/api/shortern`,
+  SHORTEN: `${BASE_URL}/api/shorten`,
   LOGOUT: `${BASE_URL}/api/logout`,
   LOGIN: `${BASE_URL}/login`,
   SIGNUP: `${BASE_URL}/signup`,


### PR DESCRIPTION
## Summary
- Correct the URL shortener backend route from /api/shortern/ to /api/shorten/.
- Update the frontend API constant to call /api/shorten.
- Align implementation with existing URL shortener documentation.

## Related Issue
Closes #1340

## Testing
- Ran node --check public/url_shortener/backend/server.js.
- Verified no remaining shortern references in public/url_shortener.