### PR TITLE
Fix snake game level progression for bonus food scoring

### DIFF
--- a/public/snake_game/script.js
+++ b/public/snake_game/script.js
@@ -11,7 +11,7 @@ let foodX, foodY, bonusFoodX, bonusFoodY, powerUpX, powerUpY;
 let bonusFoodVisible = false, powerUpVisible = false;
 let snakeX = 5, snakeY = 5;
 let velocityX = 0, velocityY = 0;
-let snakeBody = [];
+let snakeBody = [[snakeX, snakeY]];
 let setIntervalId, powerUpTimerId;
 let score = 0;
 let level = 1;
@@ -148,10 +148,11 @@ const initGame = () => {
     }
   }
 
-  if (score !== 0 && score % 10 === 0 && score / 10 === level) {
+  if (score / 10 >= level) {
     level++;
     levelElement.innerText = `Level: ${level}`;
-    gameSpeed -= 20;
+    // Prevent speed from becoming too fast
+    gameSpeed = Math.max(80, 300 - (level - 1) * 20);
     updateObstacles();
     clearInterval(setIntervalId);
     setIntervalId = setInterval(initGame, gameSpeed);
@@ -165,7 +166,7 @@ const startNewGame = () => {
   score = 0;
   level = 1;
   gameSpeed = 300;
-  snakeBody = [];
+  snakeBody = [[snakeX, snakeY]];
   velocityX = 0;
   velocityY = 0;
   snakeX = 5;
@@ -184,7 +185,7 @@ const startNewGame = () => {
 const restartGame = () => {
   gameOver = false;
   score = 0;
-  snakeBody = [];
+  snakeBody = [[snakeX, snakeY]];
   velocityX = 0;
   velocityY = 0;
   snakeX = 5;


### PR DESCRIPTION

## Issue
The snake game level progression depended on score values being exact multiples of 10.

## Problem
Bonus food awards 5 points, allowing score jumps that skipped level thresholds. As a result, levels, speed scaling, and obstacle spawning did not update correctly.

## Fix
Updated the level progression logic to calculate levels dynamically using score thresholds instead of exact modulo checks.

Also improved snake body update handling to ensure consistent rendering and movement.

## Result
- Level progression now works correctly even when bonus food skips thresholds.
- Speed scaling and obstacle spawning update properly.
- Snake rendering remains stable after level transitions.

Fixes #1291