### PR TITLE
ci: automate contributor list generation in README

### DIFF
--- a/.github/workflows/update-contributors.yml
+++ b/.github/workflows/update-contributors.yml
@@ -1,0 +1,25 @@
+name: Update Contributors in README
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  update-readme:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Update Contributors
+        uses: akhilmhdh/contributors-readme-action@v2.3.10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          readme_path: "README.md"
+          commit_message: "docs(readme): auto-update contributor list [skip ci]"

--- a/README.md
+++ b/README.md
@@ -363,9 +363,8 @@ Thanks to all these amazing people who have contributed to this project:
 
 <div align="center">
 
-<a href="https://github.com/dhairyagothi/100_days_100_web_project/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=dhairyagothi/100_days_100_web_project" />
-</a>
+<!-- readme: contributors -start -->
+<!-- readme: contributors -end -->
 
 </div>
 


### PR DESCRIPTION
Fixes #1421 

## Description
This PR enhances the existing CI/CD workflows by automating the contributor management process in the repository. Whenever a pull request is merged into the `main` branch, the `Update Contributors in README` workflow will automatically trigger, fetch the latest contributors, and seamlessly format and commit them into the README.

### Changes Made:
- **Added GitHub Action:** Created `.github/workflows/update-contributors.yml` to trigger on pull requests closed/merged to `main`.
- **Integrated Action:** Utilized `akhilmhdh/contributors-readme-action` to ensure beautifully formatted, deduplicated contributor records.
- **Updated README.md:** Replaced the static `contrib.rocks` image with the `<!-- readme: contributors -start/end -->` markers required by the new workflow to auto-inject the contributor list.

## Checklist:
- [x] I have read and followed the Contribution Guidelines.
- [x] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
- [x] Tested the workflow logic locally/conceptually to ensure it commits with `[skip ci]` to prevent infinite loops.