### PR TITLE
fix:resolve inverted left and right movement logic

### DIFF
--- a/public/2048_game/script.js
+++ b/public/2048_game/script.js
@@ -193,7 +193,7 @@ function doMove (dir) {
   prevBoard = copyBoard(board);
   prevScore = score;
 
-  const rotTurns = { right: 0, down: 1, left: 2, up: 3 };
+  const rotTurns = { right: 2, down: 1, left: 0, up: 3 };
   let tmp = rotateBoard(board, rotTurns[dir]);
   let pts = 0;
   let moved = false;


### PR DESCRIPTION
## Related Issue

issue no. #1452 


## Description
Swapped the rotation angles for 'left' and 'right' movements inside
the core doMove engine. The previous matrix configuration was causing 
horizontal movements to visually shift tiles in the opposite direction

## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other (specify): _______________


## Checklist
- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have followed the code style guidelines of this project.
- [x] I have checked for any existing open issues that my pull request may address.
- [x] I have ensured that my changes do not break any existing functionality.
- [x] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
- [x] I have read the resources for guidance listed below.
- [x] I have followed security best practices in my code changes.

