### PR TITLE
fix: add restart functionality and center win modal

### DIFF
--- a/public/MemoryGame/index.html
+++ b/public/MemoryGame/index.html
@@ -13,6 +13,13 @@
     <div id="game-container" class="grid"></div>
     <p id="score-board">Matches: 0</p>
 
+    <div class="modal" id="winModal">
+    <div class="modal-content">
+        <p id="resultMessage">🎉 You Win!</p>
+        <button id="newGame">Play Again</button>
+    </div>
+</div>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/public/MemoryGame/script.js
+++ b/public/MemoryGame/script.js
@@ -76,7 +76,28 @@ function unflipCards() {
 function updateScore() {
     matchesCount++;
     document.getElementById('score-board').innerText = `Matches: ${matchesCount}`;
+
+    if (matchesCount === colors.length) {
+        setTimeout(() => {
+            document.getElementById('winModal').style.display = 'flex';
+        }, 300);
+    }
 }
+
+// Restart the game fully
+function restartGame() {
+    matchesCount = 0;
+    firstCard = secondCard = null;
+    lockBoard = false;
+    gameContainer.innerHTML = '';
+    document.getElementById('score-board').innerText = 'Matches: 0';
+    createCards();
+}
+
+document.getElementById('newGame').addEventListener('click', () => {
+    document.getElementById('winModal').style.display = 'none';
+    restartGame();
+});
 
 // Reset variables and unlock board
 function resetBoard() {

--- a/public/MemoryGame/style.css
+++ b/public/MemoryGame/style.css
@@ -96,3 +96,61 @@ h1 {
         grid-template-rows: repeat(2, 80px);
     }
 }
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 1;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    justify-content: center;  /* add */
+    align-items: center;      /* add */
+}
+.modal-content {
+    background: linear-gradient(135deg, #1d3557, #457b9d);
+    padding: 40px 30px;
+    border: none;
+    width: 80%;
+    max-width: 350px;
+    text-align: center;
+    border-radius: 20px;
+    box-shadow: 0px 0px 40px rgba(0, 0, 0, 0.5);
+    animation: fadeIn 0.3s ease;
+}
+
+#resultMessage {
+    color: #fff;
+    font-size: 28px;
+    font-weight: bold;
+    margin-bottom: 20px;
+}
+
+#newGame {
+    background-color: #2ecc71;
+    color: white;
+    border: none;
+    padding: 12px 30px;
+    font-size: 16px;
+    border-radius: 30px;
+    cursor: pointer;
+    transition: background 0.2s, transform 0.1s;
+}
+
+#newGame:hover {
+    background-color: #27ae60;
+    transform: scale(1.05);
+}
+
+.close {
+    color: rgba(255,255,255,0.6);
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.close:hover {
+    color: white;
+}


### PR DESCRIPTION
### **Related Issue**
None

### **Description**
Fixed the Memory Matching Game by adding a restart/play again functionality and centering the win modal on the screen. The "Play Again" button now fully resets the board, score, and card state. The modal was also repositioned to appear centered on the page using flexbox.

### **Type of PR**
- [X]  Bug fix
- [X]  Feature enhancement

### **Screenshots** 
<img width="1023" height="628" alt="Screenshot 2026-05-16 173042" src="https://github.com/user-attachments/assets/1f4231bf-3c2e-451d-b073-c77daab8dc37" />
