### PR TITLE
fix: prevent HTTP 405 on Day 12 Nodemailer contact form

### DIFF
--- a/public/gmail_nodemailer/public/mail.html
+++ b/public/gmail_nodemailer/public/mail.html
@@ -76,7 +76,7 @@ padding: 8px;
 
     <div class="contact">
         <h3>Subscribe to our emails</h3>
-        <form method="POST" action="/">
+        <form id="contactForm" method="POST" action="/">
             <div class="contact01">
         <label>CONTACT-FORM</label>
         <input class="email" name="name" type="text" placeholder="Enter your name " value required autocomplete="off" >
@@ -86,7 +86,16 @@ padding: 8px;
             <input class="submit" type="submit" name="submit" value="Sign Up">
             </div>
             </form>
+            <div id="successMessage" style="display:none; padding:20px; text-align:center; color:#00b6d1; font-size:18px;">
+                Thank you for subscribing! This is a demo, so no real email will be sent.
+            </div>
     </div>
- <script src="/app.js"></script>
+<script>
+document.getElementById("contactForm").addEventListener("submit", function(e) {
+    e.preventDefault();
+    document.getElementById("contactForm").style.display = "none";
+    document.getElementById("successMessage").style.display = "block";
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
The Nodemailer contact form sends a POST request to `/` on a static Vercel deployment that doesn't have a server to handle it. Result: HTTP 405 error page instead of any kind of user feedback.

Fix is straightforward:
- Added an `id` to the form
- Intercepted the submit event with `e.preventDefault()`
- Hid the form and showed a demo success message explaining no real email was sent

No backend needed. The form still looks and works the same visually, just doesn't crash on submit.

Closes #1600