### PR TITLE
fix: reset typewriter animation state after deleting latest phrase

### DIFF
--- a/public/typewriter/typewriter.js
+++ b/public/typewriter/typewriter.js
@@ -70,6 +70,13 @@ deleteTextButton.addEventListener("click", () => {
         if (displayedPhrases.includes(lastUserPhrase)) {
             displayedPhrases = displayedPhrases.filter(phrase => phrase !== lastUserPhrase);
         }
+        if (phraseIndex >= phrases.length) {
+            phraseIndex = phrases.length - 1;
+        }
+        clearTimeout(typingTimeout);
+        isDeleting = false;
+        charIndex = 0;
+        type();
     }
 });
 


### PR DESCRIPTION
The Delete Latest Text button calls `pop()` on the phrases array but doesn't reset the animation state. After deleting, `phraseIndex` could be out of bounds and the animation keeps cycling through stale data.

Fix clamps `phraseIndex` after pop, resets the deletion flag, clears the character position, and restarts `type()`. The UI immediately reflects the change.

Closes #1565