### PR TITLE
fix: wire color picker input event to live QR regeneration

### DIFF
--- a/public/qr generator/qr.js
+++ b/public/qr generator/qr.js
@@ -125,6 +125,7 @@ function addLogoToQRCode() {
 
 generateBtn.addEventListener('click', generateQRCode);
 qrColor.addEventListener('change', generateQRCode);
+qrColor.addEventListener('input', generateQRCode);
 qrShape.addEventListener('change', generateQRCode);
 errorCorrection.addEventListener('change', generateQRCode);
 logoUpload.addEventListener('change', generateQRCode);


### PR DESCRIPTION
The QR color picker only listened for the `change` event, which fires when the user closes the color picker. In some browsers this works, in others the QR code never updates because `change` doesn't fire reliably on color inputs.

Added an `input` event listener so the QR regenerates live as the user drags the color selector. One-line fix.

Closes #1575