### PR TITLE
Fix typewriter loop freeze on delete button click

### DIFF
--- a/public/typewriter/typewriter.js
+++ b/public/typewriter/typewriter.js
@@ -64,15 +64,31 @@ addTextButton.addEventListener("click", () => {
     }
 });
 
+
 deleteTextButton.addEventListener("click", () => {
     if (phrases.length > defaultPhrases.length) {
         const lastUserPhrase = phrases.pop();
+
         if (displayedPhrases.includes(lastUserPhrase)) {
             displayedPhrases = displayedPhrases.filter(phrase => phrase !== lastUserPhrase);
         }
+
+        if (phraseIndex >= phrases.length) {
+            phraseIndex = 0;
+        }
+
+        charIndex = 0;
+        isDeleting = false;
+
+
+        clearTimeout(typingTimeout);
+        if (!isPaused) {
+            type();
+        } else {
+            typewriter.textContent = phrases[phraseIndex];
+        }
     }
 });
-
 pauseResumeButton.addEventListener("click", () => {
     isPaused = !isPaused;
     pauseResumeButton.textContent = isPaused ? "Resume" : "Pause";


### PR DESCRIPTION
### Describe the changes
This PR fixes the typewriter animation freeze bug that occurs when clicking the "Delete Latest Text" button by adding boundary validation checks and clearing active timing functions.

### Implementation Details
- Added an index boundary clamping check (`if (phraseIndex >= phrases.length)`) to safely reset the pointer back to `0` when an array mutation shortens the array length.
- Reset the tracking metrics (`charIndex = 0` and `isDeleting = false`) to smoothly clear partial character string fragments.
- Cleared the scheduled background timing frame task using `clearTimeout(typingTimeout)` and instantly forced a new asynchronous UI state redraw loop via `type()`.

Closes #1565