### PR TITLE
fix: update copyright year to display dynamically

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
         </div>
 
         <div class="footer-bottom">
-            <span>© 2024 100 Days, 100 Projects — Dhairya &amp; Contributors</span>
+            <span>© <span id="currentYear"></span> 100 Days, 100 Projects — Dhairya &amp; Contributors</span>
             <button id="themeToggle" title="Toggle theme" aria-label="Toggle theme">
                 <i class="fas fa-moon"></i>
             </button>
@@ -171,5 +171,6 @@
 
     <script type="module" src="hero-terminal.js"></script>
     <script src="index.js"></script>
+    <script>document.getElementById("currentYear").textContent = new Date().getFullYear();</script>
 </body>
 </html>


### PR DESCRIPTION
The footer copyright was hardcoded to 2024. Replaced it with a `span` populated by `new Date().getFullYear()` so it always reflects the current year. No more yearly maintenance.

Closes #1654