### PR TITLE
fix: persist mood entries with localStorage

### DIFF
--- a/public/Mood Tracker/script.js
+++ b/public/Mood Tracker/script.js
@@ -15,7 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
     document.querySelector('.container').insertBefore(moodMessage, document.querySelector('.intensity-slider'));
 
     let selectedMood = null;
-    const moodData = [];
+    const moodData = JSON.parse(localStorage.getItem("moodTrackerEntries")) || [];
     let moodChart;
     let moodStreak = 0;
     const achievements = {
@@ -26,6 +26,19 @@ document.addEventListener('DOMContentLoaded', () => {
         reduceStress: 0,
         increaseHappiness: 0
     };
+
+    // Render any previously saved entries from localStorage
+    moodData.forEach(entry => {
+        removeDefaultMessages();
+        addEntryToList(entry);
+        addEntryDay(entry);
+    });
+    if (moodData.length > 0) {
+        updateMoodChart();
+        updateMoodSummary();
+        updateMoodStreak();
+        checkAchievements();
+    }
 
     if ('Notification' in window) {
         Notification.requestPermission().then(permission => {
@@ -62,6 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const entry = { mood: selectedMood, intensity, notes, date };
         console.log('Entry Saved:', entry);
         moodData.push(entry);
+        localStorage.setItem("moodTrackerEntries", JSON.stringify(moodData));
 
         // Remove default messages if present
         removeDefaultMessages();
@@ -119,6 +133,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const index = moodData.findIndex(e => e.date === entry.date && e.mood === entry.mood && e.intensity === entry.intensity && e.notes === entry.notes);
         if (index !== -1) {
             moodData.splice(index, 1);
+            localStorage.setItem("moodTrackerEntries", JSON.stringify(moodData));
         }
 
         // Remove the list item from the DOM


### PR DESCRIPTION
Mood entries disappeared on page refresh because they were only stored in memory. Added localStorage persistence:

- `moodData` initializes from `localStorage.getItem("moodTrackerEntries")` if available
- Every save or delete updates the stored data
- On page load, existing entries are re-rendered to the list, chart, and summary
- All existing functionality (delete, chart, streaks) works with persisted data

Closes #1607