### PR TITLE
fix: prevent typewriter crash by safely resetting phraseIndex on dele…

### DIFF
--- a/public/typewriter/typewriter.js
+++ b/public/typewriter/typewriter.js
@@ -67,8 +67,18 @@ addTextButton.addEventListener("click", () => {
 deleteTextButton.addEventListener("click", () => {
     if (phrases.length > defaultPhrases.length) {
         const lastUserPhrase = phrases.pop();
+        
         if (displayedPhrases.includes(lastUserPhrase)) {
             displayedPhrases = displayedPhrases.filter(phrase => phrase !== lastUserPhrase);
+        }
+        if (phraseIndex >= phrases.length) {
+            clearTimeout(typingTimeout);
+            phraseIndex = 0;
+            charIndex = 0;
+            isDeleting = false;
+            if (!isPaused) {
+                type();
+            }
         }
     }
 });


### PR DESCRIPTION
Closes #1565

### Description
Fixed a runtime crash where deleting a phrase while it was actively being animated caused an `undefined` reference error during the `substring` calculation. 

### Changes Made
Added a boundary check inside the delete event listener to safely reset `phraseIndex` and `charIndex` if the active phrase is the one popped, restarting the typewriter loop cleanly.