### PR TITLE
Fix delete latest text button

### DIFF
--- a/public/typewriter/typewriter.js
+++ b/public/typewriter/typewriter.js
@@ -65,11 +65,18 @@ addTextButton.addEventListener("click", () => {
 });
 
 deleteTextButton.addEventListener("click", () => {
+
     if (phrases.length > defaultPhrases.length) {
-        const lastUserPhrase = phrases.pop();
-        if (displayedPhrases.includes(lastUserPhrase)) {
-            displayedPhrases = displayedPhrases.filter(phrase => phrase !== lastUserPhrase);
-        }
+
+        phrases.pop();
+
+        displayedPhrases = [];
+
+        phraseIndex = 0;
+
+        clearTimeout(typingTimeout);
+
+        type();
     }
 });
 


### PR DESCRIPTION
## Related Issue


Fixes issue number #1565




## Description
Fixed the issue where clicking the "Delete Latest Text" button did not completely remove the latest phrase from the typewriter animation loop.

## Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other (specify): _______________


## Checklist
- [X] I have performed a self-review of my code.
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have followed the code style guidelines of this project.
- [X] I have checked for any existing open issues that my pull request may address.
- [X] I have ensured that my changes do not break any existing functionality.
- [X] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
- [X] I have read the resources for guidance listed below.
- [X] I have followed security best practices in my code changes.


## Additional Context

The issue occurred because the typewriter animation continued using stale phrase state after deletion. Resetting the animation state and restarting the typing cycle resolved the problem successfully.



