### PR TITLE
Improved the text saving logic and ui : Text_Saver_Extension

### DIFF
--- a/public/Text_Saver_Ext/content.js
+++ b/public/Text_Saver_Ext/content.js
@@ -9,13 +9,10 @@ function sendSelection() {
       });
     }
   }
-  
-  // Listen for double-click
-  document.addEventListener("dblclick", sendSelection);
-  
-  // Listen for a specific keypress (e.g., pressing "S")
+
+  // Listen for Ctrl+C key combination to trigger text saving
   document.addEventListener("keydown", (event) => {
-    if (event.key === "s") {
+    if (event.ctrlKey &&event.key.toLowerCase() === "c") {
       sendSelection();
     }
   });

--- a/public/Text_Saver_Ext/manifest.json
+++ b/public/Text_Saver_Ext/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Text Saver",
-    "description": "Save selected text and its source with a keypress or double-click.",
+    "description": "Select text and press Ctrl+C to save it.",
     "version": "1.0",
     "permissions": ["storage", "activeTab", "scripting"],
     "background": {

--- a/public/Text_Saver_Ext/popup.html
+++ b/public/Text_Saver_Ext/popup.html
@@ -5,18 +5,51 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Saved Texts</title>
   <style>
-    body { font-family: Arial, sans-serif; padding: 10px; width: 300px; }
-    .text-entry { margin-bottom: 10px; padding: 5px; border-bottom: 1px solid #ccc; }
-    .url { color: blue; font-size: 0.9em; }
-    #clearButton, #downloadButton { margin-top: 10px; padding: 5px; cursor: pointer; background-color: #4CAF50; color: white; border: none; width: 100%; }
-    #clearButton { background-color: #f44336; }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: Arial, sans-serif; width: 320px; background: #f9f9f9; color: #222; }
+
+    .header { display: flex; align-items: center; justify-content: space-between;
+      padding: 12px 14px; border-bottom: 1px solid #eee; background: white; }
+    .header h2 { font-size: 14px; font-weight: 600; }
+    #itemCount { font-size: 11px; background: #eee; color: #666;
+      border-radius: 20px; padding: 2px 8px; }
+
+    #textList { max-height: 300px; overflow-y: auto; padding: 8px;
+      display: flex; flex-direction: column; gap: 6px; }
+
+    .text-entry { background: white; border: 1px solid #eee; border-radius: 8px; padding: 10px 12px; }
+    .saved-text { font-size: 13px; line-height: 1.5; margin-bottom: 6px;
+      display: -webkit-box; -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical; overflow: hidden; }
+    .url { font-size: 11px; color: #2563eb; text-decoration: none;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis; display: block; }
+
+    .empty-state { text-align: center; padding: 28px 16px; color: #999; font-size: 13px; }
+
+    .hint { font-size: 11px; color: #999; text-align: center; padding: 4px 10px 8px; }
+
+    .actions { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; padding: 10px;
+      border-top: 1px solid #eee; background: white; }
+    button { padding: 8px; border-radius: 7px; font-size: 12px; font-weight: 600;
+      border: none; cursor: pointer; }
+    #downloadButton { background: #dcfce7; color: #166534; }
+    #clearButton { background: #fee2e2; color: #991b1b; }
   </style>
 </head>
 <body>
-  <h2>Saved Texts</h2>
+  <div class="header">
+    <h2>Saved texts</h2>
+    <span id="itemCount">0 items</span>
+  </div>
+
   <div id="textList"></div>
-  <button id="downloadButton">Download as File</button>
-  <button id="clearButton">Clear Saved Texts</button>
+  <p class="hint">Press <strong>Ctrl+C</strong> to save highlighted text</p>
+
+  <div class="actions">
+    <button id="downloadButton">⬇ Download</button>
+    <button id="clearButton">🗑 Clear all</button>
+  </div>
+
   <script src="popup.js"></script>
 </body>
 </html>

--- a/public/Text_Saver_Ext/popup.js
+++ b/public/Text_Saver_Ext/popup.js
@@ -5,6 +5,8 @@ function displaySavedTexts() {
       const textListDiv = document.getElementById("textList");
       textListDiv.innerHTML = "";
   
+      document.getElementById("itemCount").textContent = `${textList.length} item${textList.length !== 1 ? "s" : ""}`;
+
       if (textList.length === 0) {
         textListDiv.innerHTML = "<p>No saved texts found.</p>";
         return;
@@ -32,10 +34,11 @@ function displaySavedTexts() {
   
   // Function to clear saved texts
   function clearSavedTexts() {
-    chrome.storage.local.clear(() => {
+    chrome.storage.local.remove("savedTexts", () => {
       alert("All saved texts have been cleared.");
-      displaySavedTexts(); // Refresh the display to show no saved texts
-    });
+      displaySavedTexts();
+    }
+    );
   }
   
   // Function to download saved texts as a file
@@ -75,5 +78,5 @@ function displaySavedTexts() {
   document.getElementById("clearButton").addEventListener("click", clearSavedTexts);
   
   // Run when popup opens
-  document.addEventListener("DOMContentLoaded", displaySavedTexts);
+  displaySavedTexts();
   


### PR DESCRIPTION
## Description
I have updated the text saving logic to a simpler "ctrl + c" based approach . Additionally, I improved the ui of the extension to provide a clean and more user-friendly experience.

## Type of Change
- [ ] New project
- [x] Bug fix
- [x] Feature enhancement
- [ ] Documentation update

## Testing
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested on mobile
- [x] No console errors

## Screenshots
<img width="1917" height="922" alt="image" src="https://github.com/user-attachments/assets/e289b3b7-f1d4-472f-9d02-55c162c56293" />

<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/688515ec-ecee-4511-b8bf-51d22b6bedcc" />

<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/4b5b50aa-9ee0-4b4f-a454-03aaa2c8a70a" />

<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/3a718ad3-0697-4adc-bafc-ac7f48972c79" />


## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Documentation updated
- [x] No merge conflicts