### PR TITLE
fix: Dark mode not working properly in Simon Says Game #1818

### DIFF
--- a/public/Simon_Says_Game/script.js
+++ b/public/Simon_Says_Game/script.js
@@ -102,7 +102,7 @@ function checkAns(idx) {
 function gameOver() {
   h2.innerHTML = `💀 Game Over! Score: <b>${level}</b><br>Press Start to play again.`;
   document.body.style.backgroundColor = "red";
-  setTimeout(() => (document.body.style.backgroundColor = "white"), 200);
+  setTimeout(() => (document.body.style.backgroundColor = ""), 200);
   updateHighScore();
   resetGame();
 }

--- a/public/Simon_Says_Game/style.css
+++ b/public/Simon_Says_Game/style.css
@@ -102,3 +102,6 @@ body.dark .btn.red { background-color: #ff6666; }
 body.dark .btn.yellow { background-color: #ffe066; }
 body.dark .btn.green { background-color: #66ff66; }
 body.dark .btn.purple { background-color: #b366ff; }
+body.dark .slider{background-color:#555;}
+body.dark h3 {color: #aaa;}
+body.dark #start-btn {background-color: #444;color: #f7f7f7;border: 1px solid #888;}


### PR DESCRIPTION
Fixes #1818

Changes made:
- Fixed h3 (High Score) visibility in dark mode
- Fixed Start button styling in dark mode
- Fixed toggle slider color in dark mode
- Fixed background reset on game over in script.js