### PR TITLE
Fix README generation for string-based project tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,6 +176,18 @@ async function fetchRepoStats() {
 // NOTE (difficulty): Generating content client-side must sanitize URLs and
 // avoid heavy sync work; large project lists may block the main thread.
 
+function normalizeTags(tags) {
+    if (Array.isArray(tags)) {
+        return tags.map(tag => String(tag).trim()).filter(Boolean);
+    }
+
+    if (typeof tags === 'string') {
+        return tags.split(/\s+/).filter(Boolean);
+    }
+
+    return [];
+}
+
 function generateReadme() {
     try {
         const lines = [];
@@ -185,7 +197,7 @@ function generateReadme() {
         lines.push('## Projects');
         PROJECTS.forEach(([day, name, url, tags, cat]) => {
             const safeUrl = url || '';
-            const tagList = (tags || []).join(', ');
+            const tagList = normalizeTags(tags).join(', ');
             lines.push(`- **${day} — ${name}** — ${safeUrl} — _${cat}_ — ${tagList}`);
         });
 
@@ -236,7 +248,7 @@ function renderGrid() {
         const card = document.createElement('div');
         card.className = 'project-card';
 
-        const tagsArray = typeof tags === 'string' ? tags.split(/\s+/).filter(t => t) : tags;
+        const tagsArray = normalizeTags(tags);
         const tagsHTML = tagsArray.map(t => `<span class="tag">${t}</span>`).join('');
 
         card.innerHTML = `


### PR DESCRIPTION
Fixes #1904

## Description
Fixes the Generate README button crash caused by calling .join() on string-based project tags. Adds shared tag normalization so README generation and project card rendering handle string, array, and empty tag values consistently.

## Type of PR
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other

## Testing
- Verified README generation succeeds with string tags.
- Verified project grid rendering still produces all 116 cards.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers.
- [x] I have ensured that my changes do not break any existing functionality.