### PR TITLE
Fix responsive layout and win state overflow issues

### DIFF
--- a/public/Stone-Paper-Scissor/index.html
+++ b/public/Stone-Paper-Scissor/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Stone-Paper-Scissors Game</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   </head>
   <link rel="stylesheet" href="style.css" class="rel" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/public/Stone-Paper-Scissor/index1.html
+++ b/public/Stone-Paper-Scissor/index1.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <title>Stone-Paper-Scissor-Game</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="style1.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/public/Stone-Paper-Scissor/style.css
+++ b/public/Stone-Paper-Scissor/style.css
@@ -3,7 +3,9 @@
 }
 body {
   background: linear-gradient(0deg, #12c2e9 0%, #c471ed 50%, #f64f59 100%);
-  overflow: hidden;
+  overflow-x: hidden;
+  min-height: 100vh;
+  margin: 0;
 }
 
 .container {
@@ -28,11 +30,16 @@ label, input, button {
   margin-top: 30px;
   display: flex;
   justify-content: space-between;
+  align-items: center;
   border-radius: 13px;
   border: 8px solid #fff;
   padding: 15px;
-  width: 800px;
-  height: 120px;
+  width: 90%;
+  max-width: 800px;
+  min-height: 120px;
+  box-sizing: border-box;
+  gap: 20px;
+  flex-wrap: wrap;
 }
 .heading {
   color: #fff;
@@ -70,7 +77,9 @@ label, input, button {
 }
 .game {
   margin-top: 5vh;
+  
 }
+
 .export {
   display: none;
 }
@@ -244,13 +253,15 @@ ul li::before {
   background: none;
 }
 .you-win {
-  display: flex;
+  display: none;
   justify-content: center;
   align-items: center;
-  margin-right: 7%;
-  margin-bottom: -80px;
-  gap: 80px;
-  display: none;
+  flex-wrap: wrap;
+  gap: 40px;
+  width: 100%;
+  padding: 20px;
+  box-sizing: border-box;
+  text-align: center;
 }
 .you-lost {
   display: flex;
@@ -363,7 +374,7 @@ ul li::before {
   margin-top: 35px;
 }
 .result1 {
-  margin-left: -140px;
+  margin: 0;
   background: none;
   z-index: 1;
 }
@@ -394,7 +405,7 @@ ul li::before {
   margin-left: 155px;
 }
 .result2 {
-  margin-right: -150px;
+  margin: 0;
   background: none;
   z-index: 1;
 }
@@ -419,6 +430,8 @@ ul li::before {
   margin-left: 30px;
   margin-top: 30px;
 }
+
+
 .next {
   border: 2px solid white;
   color: white;
@@ -431,11 +444,10 @@ ul li::before {
   font-weight: bold;
 }
 .btn {
-  text-align: right;
-  
-  margin-left: 85vw;
-  margin-bottom: 20vh;
-  
+  position: fixed;
+  bottom: 20px;
+  right: 140px;
+  z-index: 100;
 }
 .rules {
   border: 2px solid white;
@@ -451,11 +463,10 @@ ul li::before {
   height: 60px;
 }
 .btn1 {
-  text-align: right;
-  position: absolute;
-  margin-left: 60vw;
-  margin-top: 91vh;
-  
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 100;
 }
 #nxt {
   color: #fff;
@@ -498,3 +509,70 @@ ul li::before {
   justify-content: center;
 }
 
+@media screen and (max-width: 768px) {
+
+  .display {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    height: auto;
+  }
+
+  .scoreboard {
+    width: 100%;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .score {
+    width: 110px;
+    height: 100px;
+  }
+
+  .game {
+    transform: scale(0.75);
+    margin-top: -30px;
+  }
+
+  .you-win,
+  .you-lost,
+  .tie-up {
+    flex-direction: column;
+    gap: 20px;
+  }
+
+  .result h2 {
+    font-size: 28px;
+  }
+
+  .result h3 {
+    font-size: 18px;
+  }
+
+  .result button {
+    width: 150px;
+    height: 40px;
+  }
+
+  .box {
+    width: 85%;
+    height: auto;
+    right: 5%;
+    top: 20%;
+    padding-bottom: 20px;
+  }
+
+  .btn,
+  .btn1 {
+    position: fixed;
+    bottom: 10px;
+  }
+
+  .btn {
+    right: 120px;
+  }
+
+  .btn1 {
+    right: 10px;
+  }
+}


### PR DESCRIPTION
## Description

This PR fixes [#1128](https://github.com/dhairyagothi/100_days_100_web_project/issues/1128)  multiple UI responsiveness and overflow issues in the Rock Paper Scissors game.

### Changes Made

* Fixed user win screen overflowing outside viewport
* Improved mobile responsiveness
* Removed horizontal scrolling issues
* Added responsive media queries
* Improved alignment of game result sections
* Fixed layout scaling on smaller devices
* Updated viewport handling for mobile screens

### Tested On

* Desktop view
* Mobile responsive mode
* iPhone 14 Pro Max viewport
* Tablet viewport

Issue images
<img width="1920" height="1080" alt="Screenshot 2026-05-15 100857" src="https://github.com/user-attachments/assets/bde5ba12-f7bd-4595-ad56-b0560c9028e8" />
<img width="1920" height="1080" alt="Screenshot 2026-05-15 101919" src="https://github.com/user-attachments/assets/89eabc32-0873-41d4-aa69-8eb0da543edd" />


Fixed issues output
<img width="1920" height="1080" alt="Screenshot 2026-05-18 101640" src="https://github.com/user-attachments/assets/98b8b61d-13d0-4cc6-8707-cf86f70b670e" />
<img width="1920" height="1080" alt="Screenshot 2026-05-18 101738" src="https://github.com/user-attachments/assets/fba099e3-31ac-464e-a892-10eb7d62c2de" />

