### PR TITLE
fix: resolve archive index category filtering bug for games

### DIFF
--- a/index.js
+++ b/index.js
@@ -906,8 +906,10 @@ function renderGrid() {
   const noResults = document.getElementById('noResults');
   if (!grid) return;
 
-  const filtered = PROJECTS.filter(([day, name, , , cat]) => {
-    const matchesFilter = activeFilter === 'all' || cat === activeFilter;
+  const filtered = PROJECTS.filter(([day, name, , tags, cat]) => {
+    const matchesFilter = activeFilter === 'all' || 
+                          cat === activeFilter || 
+                          (typeof tags === 'string' && tags.split(/\s+/).includes(activeFilter));
     const q = searchQuery.toLowerCase();
     const matchesSearch =
       !q || name.toLowerCase().includes(q) || day.toLowerCase().includes(q);


### PR DESCRIPTION
Related Issue
None (Found and fixed directly on the main index portfolio page)
Description
Fixed a bug in `index.js` where clicking the "Games" filter chip returned zero results. The code was strictly checking the difficulty column (`cat`) instead of scanning the `tags` column. Updated `renderGrid()` to split the tags string and check for the active filter value
Type of PR: [X] Bug fix closes issue #2083