### PR TITLE
fix: update vercel.json trailingSlash configuration for sub-projects

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,8 @@
 {
   "buildCommand": null,
   "outputDirectory": ".",
-  "trailingSlash": false,
+  "cleanUrls": true,
+  "trailingSlash": true,
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Description

This Pull Request fixes the routing and asset loading issues where multi-level sub-projects (such as `Nykaa-clone`, `EchoNotes`, `expense_Tracker`, etc.) were losing their CSS/JS styles and rendering a broken layout on live Vercel deployments.

### What Changed?
- Added `"trailingSlash": true` inside `vercel.json` to enforce consistent routing paths.
- This configuration ensures that Vercel automatically appends a trailing slash to directory URLs. As a result, relative asset paths (like `style.css`) resolve correctly instead of failing with 404 errors.

### QA / Testing Proof
I have thoroughly tested these changes locally using the Vercel CLI development server. All sub-project directories now append the trailing slash automatically, and assets load seamlessly with `200 OK` and `304 Not Modified` status codes.

Here are the local server logs confirming successful asset resolution:

<img width="554" height="461" alt="Screenshot 2026-05-18 195305" src="https://github.com/user-attachments/assets/4bd43b06-cc45-4296-8bb8-08f536137a80" />
<img width="554" height="461" alt="Screenshot 2026-05-18 195328" src="https://github.com/user-attachments/assets/071939c4-fbd4-4127-9467-52e476b22331" />


### Closes
Closes #2124 
