### PR TITLE
Add favicon link to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
       content="A curated archive of frontend experiments — UI systems, motion studies, creative coding, and interactive concepts built with HTML, CSS, and JavaScript."
     />
     <title>100 Days · 100 Web Projects</title>
+    <link rel="icon" type="image/png" href="./public/favv.png">
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Related Issue
#2187 

## Description
This PR resolves the issue where the website's favicon was not visible in the browser tab. The root cause was a missing `<link>` tag within the `<head>` section of the HTML. I have added the appropriate tag pointing to the existing `favv.png` asset located in the public directory, ensuring the branding now displays correctly across browser tabs.

## Type of PR

- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other (specify): _______________

## Screenshots / Videos (if applicable)
### After Fix:
<img width="308" height="53" alt="image" src="https://github.com/user-attachments/assets/4fdc0ae3-2bed-4009-a7be-8e15b27bb741" />

## Checklist
- [X] I have performed a self-review of my code.
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have followed the code style guidelines of this project.
- [X] I have checked for any existing open issues that my pull request may address.
- [X] I have ensured that my changes do not break any existing functionality.
- [X] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
- [X] I have read the resources for guidance listed below.
- [X] I have followed security best practices in my code changes.

## Additional Context
The fix uses the `favv.png` file already present in the `/public` folder structure. Tested locally to verify that it loads properly on page initialization. Cache clearing might be required for some reviewers to see the live update immediately.