### PR TITLE
feat: add single player mode with computer logic and UI toggle

### DIFF
--- a/public/TicTacToe/index.html
+++ b/public/TicTacToe/index.html
@@ -19,7 +19,13 @@
       <button id="win-btn">Play Again</button>
     </div>
 
-    <div id="sidebar">
+   <div id="sidebar">
+      <div id="sb-title">Game Mode</div>
+      <div class="mode-container">
+        <button class="sb-btn active" id="btn-pvp">2 Players</button>
+        <button class="sb-btn" id="btn-pvc">Vs Computer</button>
+      </div>
+
       <div id="sb-title">Scoreboard</div>
       <div class="sb-row">Player X Wins<br><span class="sb-val val-x" id="score-x">0</span></div>
       <div class="sb-row">Player O Wins<br><span class="sb-val val-o" id="score-o">0</span></div>
@@ -28,7 +34,6 @@
       <button class="sb-btn btn-o" id="btn-restart">Restart Game</button>
       <div id="status-bar" class="sx">X's turn!</div>
     </div>
-
     <div id="board-wrap">
       <div id="turn-bar">
         <span class="turn-pill x-pill active" id="pill-x">&#10005; X</span>

--- a/public/TicTacToe/script.js
+++ b/public/TicTacToe/script.js
@@ -10,6 +10,7 @@
   var board     = Array(9).fill(null);
   var current   = "X";
   var gameOver  = false;
+  var isVsComputer = false; // New variable to track game mode
   var scores    = { X: 0, O: 0, D: 0 };
   var particles = [];
   var animFrame = null;
@@ -29,6 +30,10 @@
   var canvas   = document.getElementById("confetti-canvas");
   var ctx      = canvas.getContext("2d");
 
+  // Mode Selection Elements
+  var btnPvP   = document.getElementById("btn-pvp");
+  var btnPvC   = document.getElementById("btn-pvc");
+
   /* ── Build board ──────────────────────── */
   function buildBoard() {
     boardEl.innerHTML = "";
@@ -47,7 +52,98 @@
   /* ── Handle cell click ────────────────── */
   function handleClick(i) {
     if (gameOver || board[i]) return;
+    
+    // Prevent human clicking if it's the computer's turn
+    if (isVsComputer && current === "O") return;
+
     board[i] = current;
+    buildBoard();
+
+    var win = checkWin();
+    if (win) {
+      highlightWin(win);
+      scores[current]++;
+      updateScores();
+      setTimeout(function () { showWinOverlay(current); }, 320);
+      gameOver = true;
+    } else if (board.every(Boolean)) {
+      scores.D++;
+      updateScores();
+      setTimeout(showDrawOverlay, 200);
+      gameOver = true;
+    } else {
+      current = current === "X" ? "O" : "X";
+      setUI(current);
+
+      // Trigger computer turn if mode is PvC and it's O's turn
+      if (isVsComputer && current === "O" && !gameOver) {
+        setTimeout(makeComputerMove, 500); // 500ms delay for natural feeling
+      }
+    }
+  }
+
+  /* ── Smart Computer ──────────────── */
+  function makeComputerMove() {
+    if (gameOver) return;
+
+    var emptyIndices = [];
+    board.forEach(function (val, index) {
+      if (val === null) emptyIndices.push(index);
+    });
+
+    if (emptyIndices.length === 0) return;
+
+    var chosenCell = null;
+
+    //Check if computer can win in this move.
+    for (var i = 0; i < WIN_LINES.length; i++) {
+      var line = WIN_LINES[i];
+      var oCount = 0;
+      var nullIndex = null;
+
+      line.forEach(function (pos) {
+        if (board[pos] === "O") oCount++;
+        else if (board[pos] === null) nullIndex = pos;
+      });
+
+      if (oCount === 2 && nullIndex !== null) {
+        chosenCell = nullIndex;
+        break;
+      }
+    }
+
+    //If cant win, check if it can block oponent.
+    if (chosenCell === null) {
+      for (var i = 0; i < WIN_LINES.length; i++) {
+        var line = WIN_LINES[i];
+        var xCount = 0;
+        var nullIndex = null;
+
+        line.forEach(function (pos) {
+          if (board[pos] === "X") xCount++;
+          else if (board[pos] === null) nullIndex = pos;
+        });
+
+        if (xCount === 2 && nullIndex !== null) {
+          chosenCell = nullIndex;
+          break;
+        }
+      }
+    }
+
+    //Else, center prefered
+    if (chosenCell === null && board[4] === null) {
+      chosenCell = 4;
+    }
+
+    // 4.Pick random
+    if (chosenCell === null) {
+      var randomIndex = Math.floor(Math.random() * emptyIndices.length);
+      chosenCell = emptyIndices[randomIndex];
+    }
+
+    // Execute the calculated smart move
+    board[chosenCell] = current;
     buildBoard();
 
     var win = checkWin();
@@ -200,6 +296,23 @@
   document.getElementById("btn-reset").addEventListener("click", resetAll);
   document.getElementById("btn-restart").addEventListener("click", nextRound);
   document.getElementById("win-btn").addEventListener("click", nextRound);
+
+  // Hooking up the Game Mode Button Actions
+  if (btnPvP && btnPvC) {
+    btnPvP.addEventListener("click", function () {
+      isVsComputer = false;
+      btnPvP.classList.add("active");
+      btnPvC.classList.remove("active");
+      resetAll();
+    });
+
+    btnPvC.addEventListener("click", function () {
+      isVsComputer = true;
+      btnPvC.classList.add("active");
+      btnPvP.classList.remove("active");
+      resetAll();
+    });
+  }
 
   /* ── Init ─────────────────────────────── */
   buildBoard();

--- a/public/TicTacToe/style.css
+++ b/public/TicTacToe/style.css
@@ -258,6 +258,44 @@ body {
 .cell.win-cell.x-mark { color: var(--x-color); }
 .cell.win-cell.o-mark { color: var(--o-color); }
 
+/* ── Game Mode Selection Toggles ─────────── */
+.mode-container {
+  display: flex;
+  gap: 8px;
+  width: 100%;
+  margin-top: -4px;
+}
+
+.mode-container .sb-btn {
+  background: var(--bg-neutral);
+  color: var(--text-mid);
+  border: 2px solid var(--border-light);
+  font-size: 11px; /* Slightly compact for clear contrast */
+  padding: 8px 0;
+  transition: all 0.2s ease;
+}
+
+.mode-container .sb-btn:hover {
+  border-color: var(--border-mid);
+  color: var(--text-dark);
+}
+
+/* Style for when a game mode button is active/selected */
+.mode-container .sb-btn.active {
+  background: var(--text-dark);
+  color: #ffffff;
+  border-color: var(--text-dark);
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.15);
+}
+
+/* Adjust responsiveness inside the mobile breakpoint */
+@media (max-width: 600px) {
+  .mode-container {
+    width: 100%;
+    order: -1; /* Pushes mode selection to the top in mobile layout */
+  }
+}
+
 /* ── Animations ──────────────────────────── */
 @keyframes pop {
   from { transform: scale(0.3);  opacity: 0; }


### PR DESCRIPTION
## Related Issue

Closes #2281 

## Description
Added a Game Mode selector UI (2 Players / Vs Computer) in the sidebar.
Implemented smart computer logic for 'O' that blocks the player, takes winning moves, and checks the center space.
Cleaned up UI styles to keep it fully responsive.

## Type of PR

- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other (specify): _______________


[Working perfectly in local environment]

## Checklist
- [X] I have performed a self-review of my code.
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have followed the code style guidelines of this project.
- [X] I have checked for any existing open issues that my pull request may address.
- [X] I have ensured that my changes do not break any existing functionality.
- [X] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
- [X] I have read the resources for guidance listed below.
- [X] I have followed security best practices in my code changes.

## Additional Context

The single-player feature implements a heuristic AI approach. The computer dynamically evaluates the winning combinations to prioritize its own winning moves, block the human player from winning, or claim the center cell, falling back to a random move only when no strategic spots are available.