### PR TITLE
fix: corrected Neptune image alt text accessibility issue

### DIFF
--- a/public/Carousel Solar System/index.html
+++ b/public/Carousel Solar System/index.html
@@ -314,7 +314,7 @@
           </div>
 
           <div class="center-col">
-            <img src="./images/Neptune.png" alt="Sun" class="planet-img blue-glow planet-large" />
+            <img src="./images/Neptune.png" alt="Neptune" class="planet-img blue-glow planet-large" />
           </div>
 
           <div class="right-col">


### PR DESCRIPTION
## Related Issue
Fixes #2268

## Description
Fixed incorrect alt text on Neptune's image in the Solar System Carousel (Day 18). 
The alt text was mistakenly set to "Sun" instead of "Neptune".

## Type of PR
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other (specify): _______________

## Screenshots / Videos (if applicable)

<img width="1389" height="274" alt="Screenshot 2026-05-19 162014" src="https://github.com/user-attachments/assets/9ee1879a-6241-449c-b9bf-723a0f87d396" />
3ebbd690" />

## Checklist
- [X] I have performed a self-review of my code.
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have followed the code style guidelines of this project.
- [X] I have checked for any existing open issues that my pull request may address.
- [X] I have ensured that my changes do not break any existing functionality.
- [X] Each contributor is allowed to create a maximum of 4 issues per day.
- [X] I have read the resources for guidance listed below.
- [X] I have followed security best practices in my code changes.

## Additional Context
This is a minor but important accessibility fix. Incorrect alt text can mislead 
screen reader users. The fix is a one-line change in the HTML file.


