### PR TITLE
Fix/simon darkmode UI

### DIFF
--- a/public/Simon_Says_Game/index.html
+++ b/public/Simon_Says_Game/index.html
@@ -12,20 +12,28 @@
   <h3 id="highscore">High Score: 0</h3>
 
   <div class="controls">
-    <button id="start-btn">▶ Start Game</button>
+
+  <button id="start-btn">▶ Start Game</button>
+
+  <div class="toggle-group">
+    <span class="toggle-label">⚡ Strict Mode</span>
 
     <label class="switch">
       <input type="checkbox" id="strict-toggle" />
       <span class="slider"></span>
     </label>
-    <span>⚡ Strict Mode</span>
+  </div>
+
+  <div class="toggle-group">
+    <span class="toggle-label">🌙 Dark Mode</span>
 
     <label class="switch">
       <input type="checkbox" id="theme-toggle" />
       <span class="slider"></span>
     </label>
-    <span>🌙 Dark Mode</span>
   </div>
+
+</div>
 
   <div class="btn-container">
     <div class="line-one">

--- a/public/Simon_Says_Game/index.html
+++ b/public/Simon_Says_Game/index.html
@@ -7,6 +7,14 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+
+  <div class="theme-toggle-wrapper">
+  <label class="theme-switch">
+    <input type="checkbox" id="theme-toggle" />
+    <span class="theme-icon">🌙</span>
+  </label>
+</div>
+
   <h1>Simon Says</h1>
   <h2>Press Start to play</h2>
   <h3 id="highscore">High Score: 0</h3>
@@ -20,15 +28,6 @@
 
     <label class="switch">
       <input type="checkbox" id="strict-toggle" />
-      <span class="slider"></span>
-    </label>
-  </div>
-
-  <div class="toggle-group">
-    <span class="toggle-label">🌙 Dark Mode</span>
-
-    <label class="switch">
-      <input type="checkbox" id="theme-toggle" />
       <span class="slider"></span>
     </label>
   </div>

--- a/public/Simon_Says_Game/script.js
+++ b/public/Simon_Says_Game/script.js
@@ -139,7 +139,17 @@ startBtn.addEventListener("click", startGame);
 strictToggle.addEventListener("change", (e) => {
   strictMode = e.target.checked;
 });
+
+const themeIcon = document.querySelector(".theme-icon");
+
 themeToggle.addEventListener("change", () => {
   document.body.classList.toggle("dark");
+
+  if (document.body.classList.contains("dark")) {
+    themeIcon.innerText = "☀️";
+  } else {
+    themeIcon.innerText = "🌙";
+  }
 });
+
 allBtns.forEach((btn) => btn.addEventListener("click", btnPress));

--- a/public/Simon_Says_Game/style.css
+++ b/public/Simon_Says_Game/style.css
@@ -69,25 +69,29 @@ h3 {
   justify-content: center;
   align-items: center;
   gap: 20px;
-  flex-wrap: wrap;
   margin-top: 25px;
-  padding: 18px 25px;
+  flex-wrap: wrap;
 }
 
-.toggle-group {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  background: rgba(255, 255, 255, 0.7);
-  padding: 10px 16px;
-  border-radius: 14px;
-  box-shadow: 0 4px 10px rgba(0,0,0,0.08);
-  backdrop-filter: blur(8px);
+.theme-toggle-wrapper {
+  position: absolute;
+  top: 20px;
+  right: 25px;
 }
 
-.toggle-label {
-  font-size: 0.95rem;
-  font-weight: 500;
+.theme-switch input {
+  display: none;
+}
+
+.theme-icon {
+  font-size: 2rem;
+  cursor: pointer;
+  transition: transform 0.3s ease;
+  display: inline-block;
+}
+
+.theme-icon:hover {
+  transform: rotate(15deg) scale(1.1);
 }
 
 .switch {
@@ -142,21 +146,6 @@ body.dark h3 {
   color: #cbd5e1;
 }
 
-body.dark .toggle-group {
-  background: rgba(30, 41, 59, 0.9);
-  color: #f8fafc;
-  box-shadow: 0 4px 15px rgba(0,0,0,0.3);
-}
-
-body.dark #start-btn {
-  background: #f8fafc;
-  color: #111827;
-}
-
-body.dark #start-btn:hover {
-  background: #e2e8f0;
-}
-
 body.dark .btn.red {
   background-color: #ff6b6b;
 }
@@ -173,6 +162,7 @@ body.dark .btn.purple {
   background-color: #b784ff;
 }
 
+
 @media (max-width: 600px) {
 
   h1 {
@@ -188,10 +178,5 @@ body.dark .btn.purple {
     width: 95px;
     height: 95px;
     margin: 8px;
-  }
-
-  .toggle-group {
-    width: 220px;
-    justify-content: space-between;
   }
 }

--- a/public/Simon_Says_Game/style.css
+++ b/public/Simon_Says_Game/style.css
@@ -2,14 +2,29 @@
 body {
   font-family: "Poppins", sans-serif;
   text-align: center;
-  background-color: #f7f7f7;
-  color: #333;
-  transition: background-color 0.3s, color 0.3s;
+  background: linear-gradient(135deg, #f5f7fa, #e4ecf5);
+  color: #222;
+  min-height: 100vh;
+  margin: 0;
+  transition: all 0.3s ease;
 }
 
-h1 { font-size: 3rem; margin-top: 20px; }
-h2 { font-size: 1.5rem; margin-top: 10px; }
-h3 { margin-top: 5px; color: #555; }
+h1 {
+  font-size: 3rem;
+  margin-top: 25px;
+  font-weight: 700;
+}
+
+h2 {
+  font-size: 1.4rem;
+  margin-top: 10px;
+  font-weight: 500;
+}
+
+h3 {
+  margin-top: 8px;
+  color: #666;
+}
 
 /* ----- Buttons ----- */
 .btn-container {
@@ -53,52 +68,130 @@ h3 { margin-top: 5px; color: #555; }
   display: flex;
   justify-content: center;
   align-items: center;
-  gap: 15px;
-  margin-top: 20px;
+  gap: 20px;
+  flex-wrap: wrap;
+  margin-top: 25px;
+  padding: 18px 25px;
+}
+
+.toggle-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(255, 255, 255, 0.7);
+  padding: 10px 16px;
+  border-radius: 14px;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.08);
+  backdrop-filter: blur(8px);
+}
+
+.toggle-label {
+  font-size: 0.95rem;
+  font-weight: 500;
 }
 
 .switch {
   position: relative;
   display: inline-block;
-  width: 50px;
-  height: 24px;
+  width: 54px;
+  height: 28px;
 }
+
 .switch input {
   opacity: 0;
   width: 0;
   height: 0;
 }
+
 .slider {
   position: absolute;
+  inset: 0;
   cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: #ccc;
+  background-color: #d1d5db;
   transition: 0.4s;
-  border-radius: 34px;
+  border-radius: 40px;
 }
+
 .slider:before {
   position: absolute;
   content: "";
-  height: 18px;
-  width: 18px;
-  left: 4px;
+  height: 22px;
+  width: 22px;
+  left: 3px;
   bottom: 3px;
   background-color: white;
   transition: 0.4s;
   border-radius: 50%;
 }
-input:checked + .slider { background-color: #4caf50; }
-input:checked + .slider:before { transform: translateX(26px); }
+
+input:checked + .slider {
+  background-color: #22c55e;
+}
+
+input:checked + .slider:before {
+  transform: translateX(26px);
+}
 
 /* ----- Dark Mode ----- */
 body.dark {
-  background-color: #222;
-  color: #f7f7f7;
+  background: linear-gradient(135deg, #0f172a, #1e293b);
+  color: #f8fafc;
 }
-body.dark .btn.red { background-color: #ff6666; }
-body.dark .btn.yellow { background-color: #ffe066; }
-body.dark .btn.green { background-color: #66ff66; }
-body.dark .btn.purple { background-color: #b366ff; }
+
+body.dark h3 {
+  color: #cbd5e1;
+}
+
+body.dark .toggle-group {
+  background: rgba(30, 41, 59, 0.9);
+  color: #f8fafc;
+  box-shadow: 0 4px 15px rgba(0,0,0,0.3);
+}
+
+body.dark #start-btn {
+  background: #f8fafc;
+  color: #111827;
+}
+
+body.dark #start-btn:hover {
+  background: #e2e8f0;
+}
+
+body.dark .btn.red {
+  background-color: #ff6b6b;
+}
+
+body.dark .btn.yellow {
+  background-color: #ffd93d;
+}
+
+body.dark .btn.green {
+  background-color: #6bcB77;
+}
+
+body.dark .btn.purple {
+  background-color: #b784ff;
+}
+
+@media (max-width: 600px) {
+
+  h1 {
+    font-size: 2.2rem;
+  }
+
+  .controls {
+    flex-direction: column;
+    gap: 15px;
+  }
+
+  .btn {
+    width: 95px;
+    height: 95px;
+    margin: 8px;
+  }
+
+  .toggle-group {
+    width: 220px;
+    justify-content: space-between;
+  }
+}


### PR DESCRIPTION
## Related Issue
Fixes #2183 

## Description

Improved the dark mode toggle UI in the Simon Says Game with a cleaner and more modern design.

## Changes Made

* Added minimalist floating dark mode toggle
* Improved toggle positioning and responsiveness
* Added smooth hover animation for theme icon
* Simplified controls layout
* Improved dark mode visual consistency
* Removed bulky toggle card styling for a cleaner UI

## Issue Type

UI/UX Enhancement

## Screenshots

### Before

<img width="1362" height="681" alt="image" src="https://github.com/user-attachments/assets/8d49b9f0-4b49-4777-a17d-da310c64a1f8" />

Old boxed toggle UI with inconsistent spacing.

### After

<img width="683" height="342" alt="image" src="https://github.com/user-attachments/assets/1c184207-fe1b-46ff-b530-5b716ca430df" />

<img width="683" height="342" alt="image" src="https://github.com/user-attachments/assets/ce6d05ff-b400-40e6-bb26-4e07c3f1cc91" />

Modern floating theme toggle with cleaner responsive design.

## Notes

* No gameplay logic was modified
* Changes are focused only on dark mode toggle enhancement
