### PR TITLE
Fix Spotify Clone demo link and direct project access issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The website features:
 | 66 | Flask Auth App | Python, Flask | 🔐 Backend | [GitHub](https://github.com/dhairyagothi/100_days_100_web_project/tree/Main/public/flask_auth_app) |
 | 67 | Blog Website | HTML, CSS, JS | 📝 Blog | [View Demo](https://100-days-100-web-project.vercel.app/public/blog/main) |
 | 68 | 3D Rotating Card | HTML, CSS | 🎲 3D Animation | [View Demo](https://100-days-100-web-project.vercel.app/public/3d%20cards) |
-| 69 | Spotify Clone | HTML, CSS, JS | 🎵 Clone | [View Demo](https://100-days-100-web-project.vercel.app/public/spotify-clone%20-project) |
+| 69 | Spotify Clone | HTML, CSS, JS | 🎵 Clone | [View Demo](https://100-days-100-web-project.vercel.app/public/spotify-clone%20-project/index.html) |
 | 70 | Insect Catch Game | HTML, CSS, JS | 🐛 Game | [View Demo](https://100-days-100-web-project.vercel.app/public/Insect-Catch-Game) |
 | 71 | Quotely Laughs | HTML, CSS, JS | 😂 Entertainment | [View Demo](https://100-days-100-web-project.vercel.app/public/Quotely-Laughs) |
 | 72 | Contact Book | Node.js, Express | 📞 Backend | [GitHub](https://github.com/dhairyagothi/100_days_100_web_project/tree/Main/public/Contact%20Book) |


### PR DESCRIPTION
## Issue 

Fixes #2461 

## Description

Fixed the Spotify Clone project demo link to ensure the project loads correctly when accessed directly from the README/demo URL.

## Changes Made

* Updated Spotify Clone demo link
* Fixed direct project access path
* Ensured correct rendering when opening the project independently

## Issue Fixed

Previously, accessing the Spotify Clone project directly resulted in broken styling and missing assets due to an incorrect/incomplete URL path.

## Result

The Spotify Clone project now renders correctly from:

* Main website navigation
* Direct README/demo link


## Before

<img width="1366" height="675" alt="image" src="https://github.com/user-attachments/assets/28edb636-93a3-48f3-bf72-1f0131f203c9" />

## After

<img width="1366" height="683" alt="image" src="https://github.com/user-attachments/assets/33c98da1-3b63-49a5-b8bc-8847edeb8ce2" />
