### PR TITLE
fix: make MemoryGame win modal dismissible

### DIFF
--- a/public/MemoryGame/index.html
+++ b/public/MemoryGame/index.html
@@ -66,6 +66,7 @@
   <!-- Win Modal -->
   <div class="modal-overlay" id="winModal">
     <div class="modal">
+      <button class="modal-close" id="closeWinModal" type="button" aria-label="Close win dialog">&times;</button>
       <span class="modal-emoji">🎉</span>
       <h2 class="modal-title">You Won!</h2>
       <p class="modal-sub" id="modalSub">Amazing memory!</p>

--- a/public/MemoryGame/script.js
+++ b/public/MemoryGame/script.js
@@ -29,6 +29,7 @@ const bestEl     = document.getElementById('bestVal');
 const progressEl = document.getElementById('progressBar');
 const winModal   = document.getElementById('winModal');
 const toastEl    = document.getElementById('toast');
+const closeWinModalBtn = document.getElementById('closeWinModal');
 
 // ── Event Listeners ───────────────────────────────────────
 document.querySelectorAll('.diff-btn').forEach(btn => {
@@ -45,6 +46,15 @@ document.querySelectorAll('.diff-btn').forEach(btn => {
 document.getElementById('startBtn').addEventListener('click', startGame);
 document.getElementById('hintBtn').addEventListener('click', useHint);
 document.getElementById('playAgainBtn').addEventListener('click', startGame);
+closeWinModalBtn.addEventListener('click', hideWinModal);
+winModal.addEventListener('click', (event) => {
+  if (event.target === winModal) hideWinModal();
+});
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && winModal.classList.contains('visible')) {
+    hideWinModal();
+  }
+});
 
 // ── Utility Helpers ───────────────────────────────────────
 
@@ -91,6 +101,14 @@ function showToast(msg, dur = 1800) {
   toastEl.textContent = msg;
   toastEl.classList.add('show');
   setTimeout(() => toastEl.classList.remove('show'), dur);
+}
+
+/**
+ * Hide the win modal without resetting the completed board.
+ */
+function hideWinModal() {
+  winModal.classList.remove('visible');
+  document.getElementById('confettiContainer').innerHTML = '';
 }
 
 // ── Timer ─────────────────────────────────────────────────

--- a/public/MemoryGame/style.css
+++ b/public/MemoryGame/style.css
@@ -399,6 +399,34 @@ header {
   transform: scale(1);
 }
 
+.modal-close {
+  position: absolute;
+  top: 14px;
+  right: 14px;
+  width: 34px;
+  height: 34px;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: rgba(255,255,255,0.06);
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 1.4rem;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.2s, border-color 0.2s, color 0.2s, transform 0.2s;
+}
+
+.modal-close:hover,
+.modal-close:focus-visible {
+  background: rgba(124,58,237,0.18);
+  border-color: var(--accent);
+  color: var(--text);
+  outline: none;
+  transform: scale(1.05);
+}
+
 .modal::before {
   content: '';
   position: absolute;


### PR DESCRIPTION
## Description\nFixes the Memory Match win modal so players are not forced to click Play Again just to leave the result dialog.\n\nChanges made:\n- added an accessible close button to the win modal\n- added backdrop-click dismissal\n- added Escape key dismissal\n- clears active confetti when the modal is dismissed without resetting the completed board\n\nCloses #2576\n\n## Type of Change\n- [x] Bug fix\n- [x] Feature enhancement\n\n## Testing\n- [x] `node --check public/MemoryGame/script.js`\n- [x] `npx -y htmlhint public/MemoryGame/index.html`\n- [x] `git diff --check`\n\n## Suggested GSSoC labels\nPlease add `gssoc:approved`, `level:beginner`, `quality:clean`, `type:bug`, and `type:accessibility` if this is accepted.