### PR TITLE
Fix DocNow asset loading issue caused by missing trailing slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ const PROJECT_DATA = [
   ['Day 104', 'Debug-Website', './public/Debug-Website/index.html', 'css', 'beginner'],
   ['Day 105', 'Periodic Table', './public/Periodic Table/index.html', 'css javascript', 'beginner'],
   ['Day 106', 'Plants Website', './public/Plants Website/index.html', 'css', 'beginner'],
-  ['Day 107', 'DocNow', './public/DocNow/index.html', 'api javascript', 'intermediate'],
+['Day 107', 'DocNow', './public/DocNow/', 'api javascript', 'intermediate'],
   ['Day 108', 'expense_Tracker', './public/expense_Tracker/index.html', 'todo javascript', 'intermediate'],
   ['Day 109', 'Mood Tracker', './public/Mood Tracker/index.html', 'todo javascript', 'intermediate'],
   ['Day 110', 'CRYPTOSHOW', './public/CRYPTOSHOW/index.html', 'api javascript', 'intermediate'],

--- a/public/DocNow/docstyle.css
+++ b/public/DocNow/docstyle.css
@@ -81,7 +81,7 @@ body {
     height: 100vh;
 }
 
-.landingtext.h1 {
+.landingtext h1 {
     font-size: 6vw;
     margin: 0 !important;
 }
@@ -157,7 +157,7 @@ ol li {
 }
 
 li p {
-    font: 16px;
+    font-size: 16px;
     color: #000;
     padding-left: 60px;
     line-height: 30px;

--- a/public/DocNow/index.html
+++ b/public/DocNow/index.html
@@ -4,7 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>DocNow</title>
-    <link rel="stylesheet" href="docstyle.css">
+    <!-- <link rel="stylesheet" href="docstyle.css"> -->
+  <link rel="stylesheet" href="./docstyle.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.3.1/aos.css">
     <link rel="icon" href="../favv.png" type="image/x-icon" />
 </head>
@@ -12,15 +13,15 @@
     <div class="wrapper">
         <div class="nav">
             <div class="logo">
-                <img src="images\docnow.png" alt="DocNow Logo">
+                <img src="./images/docnow.png" alt="DocNow Logo">
             </div>
             <div class="link">
                 <a href="#" class="mainlink">Home</a>
-                <a href="pages/about.html">About</a>
-                <a href="pages/services.html">Services</a>
+                <a href="./pages/about.html">About</a>
+                <a href="./pages/services.html">Services</a>
                 <a href="#">Chat</a>
                 <a href="#">News</a>
-                <a href="pages/contact.html">Contact-us</a>
+                <a href="./pages/contact.html">Contact-us</a>
                 <a href="#" class="button">Learn more</a>
             </div>
         </div>
@@ -36,14 +37,14 @@
                 </div>
             </div>
             <div class="landingImage" data-aos="fade-down" data-aos-duration="2000">
-                <img src="images/banner_img.jpg" alt="Banner Image">
+                <img src="./images/banner_img.jpg" alt="Banner Image">
             </div>
         </div>
         <!-- Service section -->
         <div class="about">
             <div class="abouttext" data-aos="fade-down" data-aos-duration="2000">
                 <h1>Our patients are everything to us. They are the <span style="color: darkslateblue; font-size: 3px;">center of everything</span></h1>
-                <img src="images/ability_img.png" alt="Ability Image" style="height: 500px;width: 500px;">
+                <img src="./images/ability_img.png" alt="Ability Image" style="height: 500px;width: 500px;">
             </div>
             <div class="aboutlist" data-aos="fade-left" data-aos-duration="1500">
                 <ol>
@@ -78,66 +79,66 @@
             </div>
             <div class="infocards">
                 <div class="card one" data-aos="fade-up" data-aos-duration="2000">
-                    <img src="images/banner_img.jpg" class="cardone" data-aos="fade-up" data-aos-duration="1100" alt="Card One">
+                    <img src="./images/banner_img.jpg" class="cardone" data-aos="fade-up" data-aos-duration="1100" alt="Card One">
                     <div class="cardbgone"></div>
                     <div class="cardcontent">
                         <h2>Health Service</h2>
                         <p>The best services in the area </p>
-                        <a href="services.html">
+                        <a href="./pages/services.html">
                             <div class="cardbtn">
-                                <img src="images/next.png" class="cardicon" alt="Next Icon">
+                                <img src="./images/next.png" class="cardicon" alt="Next Icon">
                             </div>
                         </a>
                     </div>
                 </div>
                 <div class="card two" data-aos="fade-up" data-aos-duration="2200">
-                    <img src="images/banner_img.jpg" class="cardtwo" data-aos="fade-up" data-aos-duration="1100" alt="Card Two">
+                    <img src="./images/banner_img.jpg" class="cardtwo" data-aos="fade-up" data-aos-duration="1100" alt="Card Two">
                     <div class="cardbgtwo"></div>
                     <div class="cardcontent">
                         <h2>Appointment</h2>
                         <p>Book an appointment</p>
-                        <a href="appointment.html">
+                        <a href="./pages/appointment.html">
                             <div class="cardbtn">
-                                <img src="images/next.png" class="cardicon" alt="Next Icon">
+                                <img src="./images/next.png" class="cardicon" alt="Next Icon">
                             </div>
                         </a>
                     </div>
                 </div>
                 <div class="card three" data-aos="fade-up" data-aos-duration="2400">
-                    <img src="images/banner_img.jpg" class="cardthree" data-aos="fade-up" data-aos-duration="1100" alt="Card Three">
+                    <img src="./images/banner_img.jpg" class="cardthree" data-aos="fade-up" data-aos-duration="1100" alt="Card Three">
                     <div class="cardbgthree"></div>
                     <div class="cardcontent">
                         <h2>List of Doctors</h2>
                         <p>List of the best doctors in the region.</p>
-                        <a href="doctors.html">
+                        <a href="./pages/doctors.html">
                             <div class="cardbtn">
-                                <img src="images/next.png" class="cardicon" alt="Next Icon">
+                                <img src="./images/next.png" class="cardicon" alt="Next Icon">
                             </div>
                         </a>
                     </div>
                 </div>
                 <div class="card four" data-aos="fade-up" data-aos-duration="2000">
-                    <img src="images/banner_img.jpg" class="cardfour" data-aos="fade-up" data-aos-duration="1100" alt="Card Four">
+                    <img src="./images/banner_img.jpg" class="cardfour" data-aos="fade-up" data-aos-duration="1100" alt="Card Four">
                     <div class="cardbgfour"></div>
                     <div class="cardcontent">
                         <h2>Chat</h2>
                         <p>Chat with our experts 24/7</p>
                         <a href="#">
                             <div class="cardbtn">
-                                <img src="images/next.png" class="cardicon" alt="Next Icon">
+                                <img src="./images/next.png" class="cardicon" alt="Next Icon">
                             </div>
                         </a>
                     </div>
                 </div>
                 <div class="card five" data-aos="fade-up" data-aos-duration="2000">
-                    <img src="images/banner_img.jpg" class="cardfive" data-aos="fade-up" data-aos-duration="1100" alt="Card Five">
+                    <img src="./images/banner_img.jpg" class="cardfive" data-aos="fade-up" data-aos-duration="1100" alt="Card Five">
                     <div class="cardbgfive"></div>
                     <div class="cardcontent">
                         <h2>Medical Records</h2>
                         <p>Access your medical records with ease</p>
                         <a href="#">
                             <div class="cardbtn">
-                                <img src="images/next.png" class="cardicon" alt="Next Icon">
+                                <img src="./images/next.png" class="cardicon" alt="Next Icon">
                             </div>
                         </a>
                     </div>
@@ -148,11 +149,11 @@
         <div class="banner">
             <div class="bannertext" data-aos="fade-right" data-aos-duration="1000">
                 <h1>Download <span style="color:blue; font-size: 1.4px;">today</span></h1>
-                <a href="#"><img src="images/AndroidPNG.png" alt="Android Download"></a>
-                <a href="#"><img src="images/iosPNG.png" alt="iOS Download"></a>
+                <a href="#"><img src="./images/AndroidPNG.png" alt="Android Download"></a>
+                <a href="#"><img src="./images/iosPNG.png" alt="iOS Download"></a>
             </div>
             <div class="bannerimg" data-aos="fade-up" data-aos-duration="1300">
-                <img src="images/app.png" alt="App Image">
+                <img src="./images/app.png" alt="App Image">
             </div>
         </div>
         <div class="footer">

--- a/public/digital_clock/digitalclock.css
+++ b/public/digital_clock/digitalclock.css
@@ -800,9 +800,7 @@ input[type="time"] {
 
   letter-spacing: 4px;
 
-  font-family:
-    'Orbitron',
-    sans-serif;
+   font-family: "Orbitron", sans-serif;
 }
 
 .classic-theme,
@@ -897,6 +895,9 @@ input[type="time"] {
 .classic-clock .clock-time,
 .modern-clock .clock-time,
 .future-clock .clock-time {
+
+
+  font-family: "Orbitron", sans-serif;
 
   margin-top: 35px;
 


### PR DESCRIPTION
Related Issue

Fixes #2619 

Description

Fixed the DocNow asset loading issue caused by incorrect route resolution when opening the project from the main 100 Days Project page.

Updated the project link path to include a trailing slash (/) so that relative paths for images and stylesheets resolve correctly.

This fix restores:

Proper image rendering
Correct CSS loading
Accurate relative asset path resolution