### PR TITLE
Bug Fix : modifying HTML for light mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     />
     <link rel="stylesheet" href="style.css" />
   </head>
-  <body>
+  <body class="light-mode">
     <div class="ambient ambient-left" aria-hidden="true"></div>
     <div class="ambient ambient-right" aria-hidden="true"></div>
     <div class="noise-layer" aria-hidden="true"></div>


### PR DESCRIPTION
## Changes Made
- Added `light-mode` class to the `<body>` tag in `index.html`
- This enables the light theme CSS to apply on page load

## Type of Change
- Bug fix / UI improvement

## Tested
- [x] Tested locally in browser