### PR TITLE
fix: correct typo in Wordle instruction modal

### DIFF
--- a/public/WORDLE/index.html
+++ b/public/WORDLE/index.html
@@ -39,7 +39,7 @@
         <img class='example__img' src="img/rules.png" alt="">
         <p>The letter <strong>A</strong> is in the word and in the correct spot.</p>
         <p>The letters <strong>L</strong> and <strong>E</strong> are in the word but are not in the correct spot.</p>
-        <p>The letter <strong>F</strong> and <strong>E</strong> are not in the word.</p>
+        <p>The letter <strong>F</strong> and <strong>T</strong> are not in the word.</p>
         <hr>
         <p><strong>A new WORDLE will be available each day!</strong></p>
     </div>


### PR DESCRIPTION
## Related Issue
Closes #2750 

## Description

Fixed a typo in the Wordle game instruction modal.

The final example incorrectly stated:
"The letter F and E are not in the word."

Since the tile for E is yellow and T is gray in the visual example, the text was corrected to:
"The letter F and T are not in the word."

## Type of PR

- [x] Bug fix


## Screenshots 

<img width="948" height="736" alt="image" src="https://github.com/user-attachments/assets/11f737ae-41b1-4637-a7eb-e93ca8ad5311" />

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have followed the code style guidelines of this project.
- [x] I have checked for any existing open issues that my pull request may address.
- [x] I have ensured that my changes do not break any existing functionality.
- [x] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
- [x] I have read the resources for guidance listed below.
- [x] I have followed security best practices in my code changes.


## Additional Context

This change only updates the instructional text and does not affect gameplay or functionality.




