### PR TITLE
Fix: Remove duplicate scroll-to-top buttons, keep single scrollBtn

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,6 +287,8 @@
     </footer>
 
     <!-- ── SCROLL TO TOP ──────────────────────────────────── -->
+     <!-- Fix: Removed duplicate backToTop and scrollToTopBtn buttons. 
+     scrollBtn is the single scroll-to-top button with progress ring. -->
    <button id="scrollBtn" aria-label="Back to top">
     <svg class="progress-ring" viewBox="0 0 48 48">
         <circle class="ring-track" cx="24" cy="24" r="22"/>
@@ -299,27 +301,6 @@
     <script type="module" src="hero-terminal.js"></script>
     <script src="index.js"></script>
 
-    <!-- ── BACK TO TOP BUTTON ────────────────────────────────── -->
-    <button id="backToTop">↑</button>
-    <button id="scrollToTopBtn" title="Go to top">▲</button>
-
-    <script>
-      const scrollBtn = document.getElementById("scrollToTopBtn");
-
-      window.onscroll = function() {
-        if (document.body.scrollTop > 300 || document.documentElement.scrollTop > 300) {
-          scrollBtn.style.display = "block";
-        } else {
-          scrollBtn.style.display = "none";
-        }
-      };
-
-      scrollBtn.addEventListener("click", function() {
-        window.scrollTo({
-          top: 0,
-          behavior: "smooth"
-        });
-      });
-    </script>
+    
   </body>
 </html>


### PR DESCRIPTION
## Related Issue
None

## Description
The index.html file had three duplicate scroll-to-top buttons:
1. scrollBtn (with progress ring SVG and tooltip)
2. backToTop (simple ↑ button)
3. scrollToTopBtn (simple ▲ button with inline script)

Removed the duplicate backToTop and scrollToTopBtn buttons 
along with their inline script. Kept only scrollBtn which 
is the most complete implementation with progress ring and 
accessibility support.

## Type of PR
- [x] Bug fix

## Screenshots / Videos (if applicable)
No visual change — duplicate buttons were redundant.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have followed the code style guidelines of this project.
- [x] I have checked for any existing open issues that my pull request may address.
- [x] I have ensured that my changes do not break any existing functionality.

## Additional Context
The removed inline script was only controlling the deleted 
scrollToTopBtn button so removing it does not affect any 
existing functionality.