### PR TITLE
feat(contact-book): Add duplicate contact detection and merge suggest…

### DIFF
--- a/public/Contact Book/app.py
+++ b/public/Contact Book/app.py
@@ -1,6 +1,8 @@
 from flask import Flask, render_template, redirect, url_for, request, flash, session
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.security import generate_password_hash, check_password_hash
+import re
+import difflib
 
 app = Flask(__name__)
 app.config["SECRET_KEY"] = "your_secret_key"
@@ -20,6 +22,128 @@ class Contact(db.Model):
     email = db.Column(db.String(150), nullable=False)
     phone = db.Column(db.String(50), nullable=False)
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
+
+
+# Helper functions for duplicate detection
+def clean_phone(phone):
+    if not phone:
+        return ""
+    return re.sub(r"\D", "", phone)
+
+
+def clean_name_words(name):
+    # Remove non-alphanumeric except spaces, then split
+    cleaned = re.sub(r"[^a-zA-Z0-9\s]", "", name.lower())
+    return cleaned.split()
+
+
+def is_similar_name(name1, name2):
+    n1 = name1.strip().lower()
+    n2 = name2.strip().lower()
+    if not n1 or not n2:
+        return False
+    if n1 == n2:
+        return True
+
+    # Sequence matcher ratio (for minor spelling typos)
+    ratio = difflib.SequenceMatcher(None, n1, n2).ratio()
+    if ratio >= 0.8:
+        return True
+
+    # Word analysis
+    w1 = clean_name_words(name1)
+    w2 = clean_name_words(name2)
+    if not w1 or not w2:
+        return False
+
+    # Check if all words of the shorter name are prefixes of words in the longer name
+    shorter, longer = (w1, w2) if len(w1) <= len(w2) else (w2, w1)
+
+    if len(shorter) == 1:
+        return shorter[0] in longer and (shorter[0] == longer[0] or len(longer) == 1)
+
+    matched_indices = set()
+    for s_word in shorter:
+        found = False
+        for idx, l_word in enumerate(longer):
+            if idx not in matched_indices:
+                if l_word.startswith(s_word):
+                    matched_indices.add(idx)
+                    found = True
+                    break
+        if not found:
+            return False
+    return True
+
+
+def find_potential_duplicates(user_id, name, email, phone, exclude_id=None):
+    query = Contact.query.filter(Contact.user_id == user_id)
+    if exclude_id:
+        query = query.filter(Contact.id != exclude_id)
+    contacts = query.all()
+
+    duplicates = []
+    target_phone_clean = clean_phone(phone)
+    target_email_clean = email.strip().lower() if email else ""
+
+    for c in contacts:
+        reasons = []
+        # Check email
+        c_email_clean = c.email.strip().lower() if c.email else ""
+        if target_email_clean and c_email_clean and target_email_clean == c_email_clean:
+            reasons.append("Same email address")
+
+        # Check phone
+        c_phone_clean = clean_phone(c.phone)
+        if target_phone_clean and c_phone_clean and target_phone_clean == c_phone_clean:
+            reasons.append("Same phone number")
+
+        # Check name similarity
+        if is_similar_name(name, c.name):
+            reasons.append("Similar contact name")
+
+        if reasons:
+            duplicates.append({"contact": c, "reasons": ", ".join(reasons)})
+    return duplicates
+
+
+def scan_all_duplicates(user_id):
+    contacts = Contact.query.filter_by(user_id=user_id).order_by(Contact.name).all()
+    duplicates = []
+    seen = set()
+
+    for i in range(len(contacts)):
+        for j in range(i + 1, len(contacts)):
+            c1 = contacts[i]
+            c2 = contacts[j]
+
+            pair_key = tuple(sorted([c1.id, c2.id]))
+            if pair_key in seen:
+                continue
+
+            reasons = []
+            # Check email
+            c1_email_clean = c1.email.strip().lower() if c1.email else ""
+            c2_email_clean = c2.email.strip().lower() if c2.email else ""
+            if c1_email_clean and c2_email_clean and c1_email_clean == c2_email_clean:
+                reasons.append("Same email address")
+
+            # Check phone
+            c1_phone_clean = clean_phone(c1.phone)
+            c2_phone_clean = clean_phone(c2.phone)
+            if c1_phone_clean and c2_phone_clean and c1_phone_clean == c2_phone_clean:
+                reasons.append("Same phone number")
+
+            # Check name similarity
+            if is_similar_name(c1.name, c2.name):
+                reasons.append("Similar contact name")
+
+            if reasons:
+                seen.add(pair_key)
+                duplicates.append(
+                    {"contact1": c1, "contact2": c2, "reasons": ", ".join(reasons)}
+                )
+    return duplicates
 
 
 @app.route("/")
@@ -63,7 +187,11 @@ def dashboard():
         return redirect(url_for("login"))
     user_id = session["user_id"]
     contacts = Contact.query.filter_by(user_id=user_id).order_by(Contact.name).all()
-    return render_template("dashboard.html", contacts=contacts)
+    duplicates = scan_all_duplicates(user_id)
+    duplicate_count = len(duplicates)
+    return render_template(
+        "dashboard.html", contacts=contacts, duplicate_count=duplicate_count
+    )
 
 
 @app.route("/add_contact", methods=["GET", "POST"])
@@ -75,21 +203,22 @@ def add_contact():
         email = request.form.get("email")
         phone = request.form.get("phone")
 
-        # Check for duplicates
-        existing_contact = Contact.query.filter(
-            (Contact.email == email) | (Contact.phone == phone),
-            Contact.user_id == session["user_id"],
-        ).first()
-
-        if existing_contact:
-            flash("Email or phone number already exists for another contact.")
-            return redirect(url_for("add_contact"))
+        # Check for duplicates and warn
+        duplicates = find_potential_duplicates(session["user_id"], name, email, phone)
+        if duplicates:
+            session["pending_contact"] = {
+                "name": name,
+                "email": email,
+                "phone": phone,
+            }
+            return redirect(url_for("duplicate_warning", action="add"))
 
         new_contact = Contact(
             name=name, email=email, phone=phone, user_id=session["user_id"]
         )
         db.session.add(new_contact)
         db.session.commit()
+        flash("Contact added successfully.", "success")
         return redirect(url_for("dashboard"))
     return render_template("contact_form.html", action="Add")
 
@@ -104,23 +233,188 @@ def edit_contact(id):
         email = request.form.get("email")
         phone = request.form.get("phone")
 
-        # Check for duplicates
-        existing_contact = Contact.query.filter(
-            ((Contact.email == email) | (Contact.phone == phone)),
-            (Contact.id != id),
-            (Contact.user_id == session["user_id"]),
-        ).first()
-
-        if existing_contact:
-            flash("Email or phone number already exists for another contact.")
-            return redirect(url_for("edit_contact", id=id))
+        # Check for duplicates excluding this contact
+        duplicates = find_potential_duplicates(
+            session["user_id"], name, email, phone, exclude_id=id
+        )
+        if duplicates:
+            session["pending_contact"] = {
+                "name": name,
+                "email": email,
+                "phone": phone,
+                "edit_id": id,
+            }
+            return redirect(url_for("duplicate_warning", action="edit"))
 
         contact.name = name
         contact.email = email
         contact.phone = phone
         db.session.commit()
+        flash("Contact updated successfully.", "success")
         return redirect(url_for("dashboard"))
     return render_template("contact_form.html", contact=contact, action="Edit")
+
+
+@app.route("/duplicate_warning")
+def duplicate_warning():
+    if "user_id" not in session:
+        return redirect(url_for("login"))
+
+    pending = session.get("pending_contact")
+    if not pending:
+        return redirect(url_for("dashboard"))
+
+    action = request.args.get("action", "add")
+    edit_id = pending.get("edit_id")
+
+    conflicts = find_potential_duplicates(
+        session["user_id"],
+        pending["name"],
+        pending["email"],
+        pending["phone"],
+        exclude_id=edit_id,
+    )
+
+    if not conflicts:
+        return redirect(url_for("save_pending_contact"))
+
+    return render_template(
+        "duplicate_warning.html",
+        pending=pending,
+        conflicts=conflicts,
+        action=action,
+        edit_id=edit_id,
+    )
+
+
+@app.route("/save_pending")
+def save_pending_contact():
+    if "user_id" not in session:
+        return redirect(url_for("login"))
+
+    pending = session.pop("pending_contact", None)
+    if not pending:
+        return redirect(url_for("dashboard"))
+
+    edit_id = pending.get("edit_id")
+    if edit_id:
+        contact = Contact.query.get_or_404(edit_id)
+        contact.name = pending["name"]
+        contact.email = pending["email"]
+        contact.phone = pending["phone"]
+        db.session.commit()
+        flash("Contact updated successfully.", "success")
+    else:
+        new_contact = Contact(
+            name=pending["name"],
+            email=pending["email"],
+            phone=pending["phone"],
+            user_id=session["user_id"],
+        )
+        db.session.add(new_contact)
+        db.session.commit()
+        flash("Contact added successfully.", "success")
+
+    return redirect(url_for("dashboard"))
+
+
+@app.route("/cancel_pending")
+def cancel_pending():
+    session.pop("pending_contact", None)
+    return redirect(url_for("dashboard"))
+
+
+@app.route("/merge_suggestions")
+def merge_suggestions():
+    if "user_id" not in session:
+        return redirect(url_for("login"))
+    user_id = session["user_id"]
+    duplicates = scan_all_duplicates(user_id)
+    return render_template("merge_suggestions.html", duplicates=duplicates)
+
+
+@app.route("/merge", methods=["GET", "POST"])
+def merge_contacts():
+    if "user_id" not in session:
+        return redirect(url_for("login"))
+
+    user_id = session["user_id"]
+    id1 = request.args.get("id1", type=int)
+    id2 = request.args.get("id2", type=int)
+    is_pending = request.args.get("pending", "false") == "true"
+
+    contact1 = Contact.query.filter_by(id=id1, user_id=user_id).first_or_404()
+
+    contact2_data = None
+    contact2_id = None
+
+    if is_pending:
+        pending = session.get("pending_contact")
+        if not pending:
+            flash("No pending contact found to merge.", "error")
+            return redirect(url_for("dashboard"))
+        contact2_data = {
+            "name": pending["name"],
+            "email": pending["email"],
+            "phone": pending["phone"],
+        }
+    elif id2:
+        c2 = Contact.query.filter_by(id=id2, user_id=user_id).first_or_404()
+        contact2_id = c2.id
+        contact2_data = {"name": c2.name, "email": c2.email, "phone": c2.phone}
+    else:
+        flash("Invalid merge request.", "error")
+        return redirect(url_for("dashboard"))
+
+    if request.method == "POST":
+        merged_name = request.form.get("name")
+        merged_email = request.form.get("email")
+        merged_phone = request.form.get("phone")
+
+        # Update contact1
+        contact1.name = merged_name
+        contact1.email = merged_email
+        contact1.phone = merged_phone
+
+        # Delete contact2 if it's an existing DB contact
+        if contact2_id:
+            c2_to_delete = Contact.query.filter_by(
+                id=contact2_id, user_id=user_id
+            ).first()
+            if c2_to_delete:
+                db.session.delete(c2_to_delete)
+
+        db.session.commit()
+
+        if is_pending:
+            session.pop("pending_contact", None)
+
+        flash("Contacts merged successfully.", "success")
+
+        from_suggestions = request.args.get("from_suggestions", "false") == "true"
+        if from_suggestions:
+            return redirect(url_for("merge_suggestions"))
+        return redirect(url_for("dashboard"))
+
+    # Pre-fill with the best representation (e.g. longer name, non-empty phone/email)
+    prefilled = {
+        "name": (
+            contact1.name
+            if len(contact1.name or "") >= len(contact2_data.get("name") or "")
+            else contact2_data.get("name")
+        ),
+        "email": contact1.email if contact1.email else contact2_data.get("email"),
+        "phone": contact1.phone if contact1.phone else contact2_data.get("phone"),
+    }
+
+    return render_template(
+        "merge_form.html",
+        contact1=contact1,
+        contact2_data=contact2_data,
+        prefilled=prefilled,
+        is_pending=is_pending,
+        contact2_id=contact2_id,
+    )
 
 
 @app.route("/delete_contact/<int:id>")

--- a/public/Contact Book/templates/dashboard.html
+++ b/public/Contact Book/templates/dashboard.html
@@ -1,6 +1,23 @@
 {% extends 'base.html' %}
 {% block content %}
 <div class="mt-10">
+    {% if duplicate_count and duplicate_count > 0 %}
+    <div class="bg-yellow-50 border-l-4 border-yellow-400 p-4 mb-6 rounded shadow flex justify-between items-center">
+        <div class="flex items-center space-x-3">
+            <svg class="h-6 w-6 text-yellow-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+            </svg>
+            <div>
+                <p class="font-semibold text-yellow-800">Potential Duplicates Detected</p>
+                <p class="text-sm text-yellow-700">We found {{ duplicate_count }} potential duplicate contacts in your list.</p>
+            </div>
+        </div>
+        <a href="{{ url_for('merge_suggestions') }}" class="bg-yellow-500 hover:bg-yellow-600 text-white px-4 py-2 rounded text-sm font-semibold shadow">
+            Review & Merge
+        </a>
+    </div>
+    {% endif %}
+
     <h1 class="text-2xl font-bold mb-4">Dashboard</h1>
     <input type="text" id="search" placeholder="Search contacts..." class="w-full p-2 mb-4 border border-gray-300 rounded">
     <a href="{{ url_for('add_contact') }}" class="bg-blue-600 text-white px-4 py-2 rounded">Add Contact</a>

--- a/public/Contact Book/templates/duplicate_warning.html
+++ b/public/Contact Book/templates/duplicate_warning.html
@@ -1,0 +1,70 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="max-w-2xl mx-auto mt-10 bg-white p-8 rounded shadow">
+    <div class="flex items-center space-x-3 text-yellow-600 mb-6">
+        <svg class="h-8 w-8" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/>
+        </svg>
+        <h1 class="text-2xl font-bold">Duplicate Contact Warning</h1>
+    </div>
+    
+    <p class="text-gray-700 mb-6">
+        The contact details you are trying to {% if action == 'edit' %}save{% else %}add{% endif %} are very similar to one or more existing contacts in your list.
+    </p>
+
+    <!-- Pending Contact Details -->
+    <div class="bg-blue-50 border border-blue-200 p-4 rounded mb-6">
+        <h2 class="text-sm font-semibold text-blue-800 uppercase tracking-wider mb-2">New Contact Details</h2>
+        <div class="grid grid-cols-3 gap-4 text-sm">
+            <div>
+                <span class="block text-gray-500">Name</span>
+                <span class="font-bold text-gray-900">{{ pending.name }}</span>
+            </div>
+            <div>
+                <span class="block text-gray-500">Email</span>
+                <span class="font-bold text-gray-900">{{ pending.email }}</span>
+            </div>
+            <div>
+                <span class="block text-gray-500">Phone</span>
+                <span class="font-bold text-gray-900">{{ pending.phone }}</span>
+            </div>
+        </div>
+    </div>
+
+    <!-- Existing Conflicting Contacts -->
+    <h3 class="text-lg font-bold text-gray-800 mb-3">Matching Contacts</h3>
+    <div class="space-y-4 mb-8">
+        {% for conflict in conflicts %}
+        <div class="border border-gray-200 rounded p-4 flex flex-col md:flex-row justify-between items-start md:items-center bg-gray-50">
+            <div class="mb-4 md:mb-0">
+                <div class="flex items-center space-x-2">
+                    <span class="font-bold text-gray-800">{{ conflict.contact.name }}</span>
+                    <span class="text-xs px-2 py-0.5 bg-yellow-100 text-yellow-800 rounded-full font-medium">
+                        {{ conflict.reasons }}
+                    </span>
+                </div>
+                <div class="text-sm text-gray-600 mt-1">
+                    <p>Email: {{ conflict.contact.email }}</p>
+                    <p>Phone: {{ conflict.contact.phone }}</p>
+                </div>
+            </div>
+            <div>
+                <a href="{{ url_for('merge_contacts', id1=conflict.contact.id, pending='true') }}" class="inline-block bg-blue-600 text-white px-4 py-2 rounded text-sm hover:bg-blue-500 font-semibold shadow">
+                    Merge with this Contact
+                </a>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+
+    <!-- Actions -->
+    <div class="flex flex-col sm:flex-row justify-end space-y-2 sm:space-y-0 sm:space-x-3 pt-4 border-t border-gray-200">
+        <a href="{{ url_for('cancel_pending') }}" class="text-center bg-gray-200 text-gray-700 px-6 py-2 rounded hover:bg-gray-300 font-semibold">
+            Cancel
+        </a>
+        <a href="{{ url_for('save_pending_contact') }}" class="text-center bg-yellow-500 text-white px-6 py-2 rounded hover:bg-yellow-600 font-semibold shadow">
+            Save as Separate Duplicate
+        </a>
+    </div>
+</div>
+{% endblock %}

--- a/public/Contact Book/templates/merge_form.html
+++ b/public/Contact Book/templates/merge_form.html
@@ -1,0 +1,102 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="max-w-4xl mx-auto mt-10 bg-white p-8 rounded shadow">
+    <h1 class="text-2xl font-bold mb-6 text-gray-800">Merge Contacts</h1>
+    
+    <p class="text-gray-600 mb-8">
+        Review the details of the two duplicate contacts and customize the final merged contact below.
+    </p>
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+        <!-- Contact A -->
+        <div class="border border-gray-200 p-5 rounded-lg bg-gray-50">
+            <h2 class="font-bold text-gray-700 border-b pb-2 mb-4">Contact A (Existing)</h2>
+            <div class="space-y-3 text-sm">
+                <div>
+                    <span class="text-gray-500 block">Name:</span>
+                    <span class="font-semibold text-gray-900 text-base">{{ contact1.name }}</span>
+                </div>
+                <div>
+                    <span class="text-gray-500 block">Email:</span>
+                    <span class="font-semibold text-gray-900 text-base">{{ contact1.email }}</span>
+                </div>
+                <div>
+                    <span class="text-gray-500 block">Phone:</span>
+                    <span class="font-semibold text-gray-900 text-base">{{ contact1.phone }}</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Contact B -->
+        <div class="border border-gray-200 p-5 rounded-lg bg-gray-50">
+            <h2 class="font-bold text-gray-700 border-b pb-2 mb-4">
+                {% if is_pending %}Contact B (New Details){% else %}Contact B (Existing Duplicate){% endif %}
+            </h2>
+            <div class="space-y-3 text-sm">
+                <div>
+                    <span class="text-gray-500 block">Name:</span>
+                    <span class="font-semibold text-gray-900 text-base">{{ contact2_data.name }}</span>
+                </div>
+                <div>
+                    <span class="text-gray-500 block">Email:</span>
+                    <span class="font-semibold text-gray-900 text-base">{{ contact2_data.email }}</span>
+                </div>
+                <div>
+                    <span class="text-gray-500 block">Phone:</span>
+                    <span class="font-semibold text-gray-900 text-base">{{ contact2_data.phone }}</span>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Final Merged Form -->
+    <form method="POST" class="border-t border-gray-200 pt-6 space-y-4">
+        <h2 class="text-xl font-bold text-gray-800 mb-4">Merged Result</h2>
+        
+        <div>
+            <label for="name" class="block text-gray-700 font-semibold mb-1">Name:</label>
+            <input type="text" id="name" name="name" value="{{ prefilled.name }}" class="w-full p-3 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500" required>
+            <div class="flex space-x-2 mt-1 text-xs text-blue-600">
+                <button type="button" class="underline hover:text-blue-800" onclick="document.getElementById('name').value='{{ contact1.name | replace("'", "\\'") }}'">Use Contact A's</button>
+                <span>|</span>
+                <button type="button" class="underline hover:text-blue-800" onclick="document.getElementById('name').value='{{ contact2_data.name | replace("'", "\\'") }}'">Use Contact B's</button>
+            </div>
+        </div>
+        
+        <div>
+            <label for="email" class="block text-gray-700 font-semibold mb-1">Email:</label>
+            <input type="email" id="email" name="email" value="{{ prefilled.email }}" class="w-full p-3 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500" required>
+            <div class="flex space-x-2 mt-1 text-xs text-blue-600">
+                <button type="button" class="underline hover:text-blue-800" onclick="document.getElementById('email').value='{{ contact1.email | replace("'", "\\'") }}'">Use Contact A's</button>
+                <span>|</span>
+                <button type="button" class="underline hover:text-blue-800" onclick="document.getElementById('email').value='{{ contact2_data.email | replace("'", "\\'") }}'">Use Contact B's</button>
+            </div>
+        </div>
+        
+        <div>
+            <label for="phone" class="block text-gray-700 font-semibold mb-1">Phone:</label>
+            <input type="text" id="phone" name="phone" value="{{ prefilled.phone }}" class="w-full p-3 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500" required>
+            <div class="flex space-x-2 mt-1 text-xs text-blue-600">
+                <button type="button" class="underline hover:text-blue-800" onclick="document.getElementById('phone').value='{{ contact1.phone | replace("'", "\\'") }}'">Use Contact A's</button>
+                <span>|</span>
+                <button type="button" class="underline hover:text-blue-800" onclick="document.getElementById('phone').value='{{ contact2_data.phone | replace("'", "\\'") }}'">Use Contact B's</button>
+            </div>
+        </div>
+
+        <div class="flex flex-col sm:flex-row justify-end space-y-2 sm:space-y-0 sm:space-x-3 pt-6 border-t border-gray-100">
+            {% if is_pending %}
+                <a href="{{ url_for('duplicate_warning') }}" class="text-center bg-gray-200 text-gray-700 px-6 py-2 rounded hover:bg-gray-300 font-semibold">
+                    Back
+                </a>
+            {% else %}
+                <a href="{{ url_for('merge_suggestions') }}" class="text-center bg-gray-200 text-gray-700 px-6 py-2 rounded hover:bg-gray-300 font-semibold">
+                    Back
+                </a>
+            {% endif %}
+            <button type="submit" class="bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-500 font-semibold shadow">
+                Confirm & Merge
+            </button>
+        </div>
+    </form>
+</div>
+{% endblock %}

--- a/public/Contact Book/templates/merge_suggestions.html
+++ b/public/Contact Book/templates/merge_suggestions.html
@@ -1,0 +1,57 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="mt-10 max-w-4xl mx-auto">
+    <div class="flex justify-between items-center mb-6">
+        <h1 class="text-2xl font-bold text-gray-800">Duplicate Merge Suggestions</h1>
+        <a href="{{ url_for('dashboard') }}" class="bg-gray-200 text-gray-700 px-4 py-2 rounded hover:bg-gray-300 font-medium">
+            Back to Dashboard
+        </a>
+    </div>
+
+    <p class="text-gray-600 mb-6">
+        The contacts listed below have similar or matching details. Review each match to merge them and keep your contact book clean.
+    </p>
+
+    {% if duplicates %}
+        <div class="space-y-4">
+            {% for dup in duplicates %}
+            <div class="bg-white p-6 rounded shadow border-l-4 border-yellow-500 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 flex-1">
+                    <!-- Contact 1 Details -->
+                    <div class="p-3 bg-gray-50 rounded">
+                        <span class="block text-xs font-semibold text-gray-500 uppercase font-mono">Contact A</span>
+                        <p class="font-bold text-gray-900">{{ dup.contact1.name }}</p>
+                        <p class="text-sm text-gray-600">Email: {{ dup.contact1.email }}</p>
+                        <p class="text-sm text-gray-600">Phone: {{ dup.contact1.phone }}</p>
+                    </div>
+                    <!-- Contact 2 Details -->
+                    <div class="p-3 bg-gray-50 rounded">
+                        <span class="block text-xs font-semibold text-gray-500 uppercase font-mono">Contact B</span>
+                        <p class="font-bold text-gray-900">{{ dup.contact2.name }}</p>
+                        <p class="text-sm text-gray-600">Email: {{ dup.contact2.email }}</p>
+                        <p class="text-sm text-gray-600">Phone: {{ dup.contact2.phone }}</p>
+                    </div>
+                </div>
+                
+                <div class="flex flex-col items-stretch md:items-end gap-2 w-full md:w-auto">
+                    <span class="text-xs px-2.5 py-1 bg-yellow-100 text-yellow-800 rounded-full font-semibold text-center">
+                        Match: {{ dup.reasons }}
+                    </span>
+                    <a href="{{ url_for('merge_contacts', id1=dup.contact1.id, id2=dup.contact2.id, from_suggestions='true') }}" class="bg-blue-600 text-white px-4 py-2 rounded text-sm text-center hover:bg-blue-500 font-semibold shadow">
+                        Merge Contacts
+                    </a>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="bg-white p-10 rounded shadow text-center">
+            <svg class="mx-auto h-12 w-12 text-green-500 mb-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+            </svg>
+            <p class="text-lg font-bold text-gray-800 mb-1">No duplicates detected!</p>
+            <p class="text-gray-500">Your contact list is completely clean.</p>
+        </div>
+    {% endif %}
+</div>
+{% endblock %}


### PR DESCRIPTION
Closes #2959 

# feat(contact-book): Duplicate Contact Detection and Merge Suggestions

## Description
Currently, the ContactBook application allows users to add and manage contacts but does not check for duplicate entries. This PR introduces a Duplicate Contact Detection and Merge Suggestions feature to identify similar contacts and provide a user-friendly UI to review and merge them.

## Proposed Improvements
* **Duplicate Detection Rules**: Detects potential duplicates using:
  * Exact email addresses (case-insensitive).
  * Normalized phone numbers (cleans hyphens, brackets, spaces, and prefixes to find matching records).
  * Similar contact names (utilizes `difflib.SequenceMatcher` with a threshold of `0.8` to catch minor spelling typos, name-swapping, and initial abbreviations like "Alice S." vs. "Alice Smith").
* **Add/Edit Warning Screen**: Intercepts contact creation/updates when potential duplicates exist, rendering a comparison table where users can choose to merge, save anyway, or cancel.
* **Merge Dashboard & Suggestions**:
  * Displays a persistent dashboard warning banner when duplicates exist in the contact list.
  * Adds a dedicated review page to inspect all detected duplicates.
  * Provides a side-by-side field-picker comparison form to merge details seamlessly (with copy-field shortcut buttons) before updating one record and deleting the duplicate.

