### PR TITLE
fix: add missing 'advanced' key to CATEGORY_LABEL

### DIFF
--- a/index.js
+++ b/index.js
@@ -345,6 +345,7 @@ const INITIAL_VISIBLE_ITEMS = 3;
 const CATEGORY_LABEL = {
   beginner: 'Beginner',
   intermediate: 'Intermediate',
+  advanced: 'Advanced',
 };
 console.log('CATEGORY_LABEL defined:', CATEGORY_LABEL);
 


### PR DESCRIPTION
## 📋 Description

`CATEGORY_LABEL` in `index.js` only defines `beginner` and `intermediate` keys.
Three projects use `'advanced'` or `'Advanced'` as their difficulty:
- Day 7 — Typewriter (`'advanced'`)
- Day 122 — AstronomyDashboard (`'Advanced'`)  
- Day 140 — Big Sales Prediction (`'advanced'`)

`renderGrid()` safely falls back with `CATEGORY_LABEL[cat] || cat` so the main
grid is unaffected. But `renderBookmarks()` and `renderRecentProjects()` have
no fallback — they render the raw JavaScript value `undefined` as the visible
category badge text whenever an advanced project is bookmarked or recently viewed.

---

## 🔗 Related Issues
Fixes #(your issue number here)

---

## 🛠️ Changes Made

**`index.js` (~line 192):** Added missing `advanced` key to `CATEGORY_LABEL`

**Before:**
```js
const CATEGORY_LABEL = {
  beginner: 'Beginner',
  intermediate: 'Intermediate',
};
```

**After:**
```js
const CATEGORY_LABEL = {
  beginner: 'Beginner',
  intermediate: 'Intermediate',
  advanced: 'Advanced',
};
```

---

## ✅ Testing Done
- Bookmarked **Day 7 (Typewriter)** → category badge showed `undefined` before fix ✓
- After fix → badge correctly shows `Advanced` in Bookmarks section ✓
- Bookmarked **Day 122 (AstronomyDashboard)** → same result confirmed ✓
- Main project grid unaffected (fallback was already there) ✓
- `beginner` and `intermediate` badges still render correctly ✓

---

## 🧩 Environment
- Browser: All browsers (internal state bug, not rendering-specific)
- OS: All
- Device: Desktop and Mobile

---

## ✅ Contributor Checklist
- [x] I am participating via GSSoC
- [x] I have read the contribution guidelines
- [x] I checked for existing issues before creating this
- [x] Commits are signed off with `git commit -s`