### PR TITLE
fix: sign in button navigation

### DIFF
--- a/public/Netflix_Cloning/Index.html
+++ b/public/Netflix_Cloning/Index.html
@@ -11,7 +11,7 @@
     <!-- ============= NAVBAR ============= -->
     <header class="navbar">
         <img src="./img/logo.svg" alt="Netflix Logo" class="logo">
-        <a href="https://www.netflix.com/login" class="signin-btn">Sign In</a>
+        <a href="../login.html" class="signin-btn">Sign In</a>
     </header>
 
     <!-- ============= HERO SECTION ============= -->


### PR DESCRIPTION
## Related Issue
Fixes #2756  

## Description
Fixed the Sign In button navigation issue in Netflix Clone.

The button was previously redirecting to an external Netflix URL.  
Now it correctly redirects to the local login page using proper relative path.

## Type of PR
- [x] Bug fix

## Changes Made
- Updated Sign In button href path
- Changed external link to local login page

## Checklist
- [x] I have tested the changes locally
- [x] I have ensured no existing functionality is broken