### PR TITLE
fix: add solvability check and fix win condition in slide puzzle

### DIFF
--- a/public/Slide puzzle Game/puzzle.js
+++ b/public/Slide puzzle Game/puzzle.js
@@ -45,6 +45,26 @@ function createBoard() {
     }
 }
 
+
+function isSolvable(order) {
+    // convert strings to numbers
+    let tiles = order.map(Number);
+
+    let inversions = 0;
+
+    for (let i = 0; i < tiles.length; i++) {
+        for (let j = i + 1; j < tiles.length; j++) {
+            if (tiles[i] > tiles[j]) {
+                inversions++;
+            }
+        }
+    }
+
+    // even = solvable, odd = unsolvable
+    return inversions % 2 === 0;
+}
+
+
 function randomizeBoard() {
 
     for (let i = imgOrder.length - 1; i > 0; i--) {
@@ -52,6 +72,12 @@ function randomizeBoard() {
         let j = Math.floor(Math.random() * (i + 1));
 
         [imgOrder[i], imgOrder[j]] = [imgOrder[j], imgOrder[i]];
+    }
+
+    // check if solvable
+    if (!isSolvable(imgOrder)) {
+        alert("This arrangement is not solvable! Click Randomize again.");
+        return;
     }
 
     createBoard();
@@ -156,7 +182,7 @@ function dragEnd() {
 
 function checkWin() {
 
-    let tiles = document.getElementsByTagName("img");
+    let tiles = document.querySelectorAll("#board img");
 
     for (let i = 0; i < tiles.length; i++) {
 


### PR DESCRIPTION
## Related Issue
closes issue #1815 

## Description
Fixed two bugs in the Slide Puzzle Game:

1. Unsolvable Shuffles -Added an `isSolvable()` function that counts 
inversions in the shuffled `imgOrder` array. In a 3x3 sliding puzzle, a 
configuration is solvable only when the inversion count is even. If the 
count is odd, an alert fires telling the player the arrangement is 
unsolvable and to randomize again.

2. Logo Included in Win Check- `checkWin()` was using 
`getElementsByTagName("img")` which included the Doraemon logo along 
with the puzzle tiles. Changed to `querySelectorAll("#board img")` to 
scope the selection to only the 9 puzzle tiles inside `#board`.

Note: Bug 1 (hardcoded 3.jpg) was investigated - after checking the 
actual image files, 3.jpg is intentionally a blank image. No changes 
needed here.

## Type of PR
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other (specify): _______________

## Screenshots / Videos (if applicable)
[Attach any relevant screenshots or videos demonstrating the changes]

## Checklist
- [X] I have performed a self-review of my code.
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have followed the code style guidelines of this project.
- [X] I have checked for any existing open issues that my pull request may address.
- [X] I have ensured that my changes do not break any existing functionality.
- [X] Each contributor is allowed to create a maximum of 4 issues per day.
- [X] I have read the resources for guidance listed below.
- [X] I have followed security best practices in my code changes.

## Additional Context
The isSolvable() fix ensures players are never silently given an 
impossible puzzle. The checkWin() fix was an additional bug discovered 
during code analysis that was not in the original issue — without it 
the win condition could never trigger even on a correctly solved board.