### PR TITLE
fix: clear input field when switching CAPTCHA type

### DIFF
--- a/public/captcha/captcha.html
+++ b/public/captcha/captcha.html
@@ -30,5 +30,5 @@
         </div>
     </div>
     <script src="captcha.js"></script>
-</body>
+</body> 
 </html>

--- a/public/captcha/captcha.js
+++ b/public/captcha/captcha.js
@@ -169,6 +169,8 @@ typeButtons.forEach(button =>{
         typeButtons.forEach(btn => btn.classList.remove("active"));
         button.classList.add("active");
         selectedType = button.dataset.type;
+        textInput.value = "";       //clears the text input field
+        selectedImageAnswer = "";   // resets the stored image answer too
         generateCaptcha();
     });
 });


### PR DESCRIPTION
## Related Issue

Fixes #2993 


## Description
Captcha Generator project (`public/capcha/capcha.js`), the answer input field was not being cleared when switching between CAPTCHA types using the dropdown. Added two lines in the type switch event listener:
- `textInput.value = ""` → clears the text input on type switch
- `selectedImageAnswer = ""` → resets the stored image answer on type switch

## Type of PR

- [ X ] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement

## Screenshots / Videos
Before change 
<img width="473" height="726" alt="Screenshot 2026-05-21 221854" src="https://github.com/user-attachments/assets/418b50c4-c21f-47e2-88d2-d4dad9e3a6b4" />


After change
https://github.com/user-attachments/assets/d9cd3519-0887-4f29-bb15-82aedd3e58f0



## Checklist
- [ X ] I have performed a self-review of my code.
- [ X ] I have read and followed the Contribution Guidelines.
- [ X ] I have tested the changes thoroughly before submitting this pull request.
- [ X ] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ X ] I have commented my code, particularly in hard-to-understand areas.
- [ X ] I have followed the code style guidelines of this project.
- [ X ] I have checked for any existing open issues that my pull request may address.
- [ X ] I have ensured that my changes do not break any existing functionality.
- [ X ] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
- [ X ] I have read the resources for guidance listed below.
- [ X ] I have followed security best practices in my code changes.


## Additional Context
- File changed: `public/capcha/capcha.js`
- Two lines added inside the type button click event listener
- Tested all 4 CAPTCHA types (Text, Image, Math, Audio) switching between them
- No existing functionality was broken by this fix
