### PR TITLE
fix: show Error instead of Infinity on division by zero in calculator

### DIFF
--- a/public/Vanilla-JavaScript-Calculator-master/script.js
+++ b/public/Vanilla-JavaScript-Calculator-master/script.js
@@ -166,12 +166,22 @@ class Calculator {
         const exponent = parseFloat(powerMatch[2]);
         this.currentOperand = Math.pow(base, exponent);
       } else {
-        this.currentOperand = eval(formattedExpression);
+        const result = eval(formattedExpression);
+        if (!isFinite(result)) {
+          this.currentOperand = 'Error';
+          this.expression = 'Error';
+          this.operation = undefined;
+          this.previousOperand = '';
+          this.updateDisplay();
+          return;
+        }
+        this.currentOperand = result;
       }
-      this.latestAnswer = this.currentOperand; // Store the latest answer
+      this.latestAnswer = this.currentOperand;
       this.expression = this.currentOperand.toString();
     } catch (error) {
       this.currentOperand = 'Error';
+      this.expression = 'Error';
     }
     this.operation = undefined;
     this.previousOperand = '';


### PR DESCRIPTION
Fixes #3155 

**Problem**
Dividing by zero displayed "Infinity" because JavaScript's eval() 
returns Infinity without throwing an exception, so the try/catch 
block didn't catch it.

**Fix**
Added isFinite() check after eval(). If the result is not finite 
(Infinity or -Infinity), the display now shows "Error" instead.

**Testing**
- 5 ÷ 0 = → shows Error ✅
- 10 ÷ 2 = → shows 5 ✅