### PR TITLE
fix: prevent multiple decimal points in a single number term in calcu…

### DIFF
--- a/public/Vanilla-JavaScript-Calculator-master/script.js
+++ b/public/Vanilla-JavaScript-Calculator-master/script.js
@@ -59,7 +59,11 @@ class Calculator {
   }
 
   appendNumber(number) {
-    if (number === '.' && this.currentOperand.includes('.')) return;
+    if (number === '.') {
+        const tokens = this.currentOperand.toString().split(/[+\-×÷*/]/);
+        const lastToken = tokens[tokens.length - 1];
+        if (lastToken.includes('.')) return;
+    }
 
     const input = this.currentOperandTextElement;
     const start = this.lastSelectionStart;


### PR DESCRIPTION
Fixes #3437 

**Problem**
The decimal guard only checked this.currentOperand.includes('.')
but currentOperand resets to '' after every operator.
So typing 1.5 + 2.3 and pressing '.' again would accept 
the second dot making expression like "1.5 + 2.3.4" which 
causes a silent Error on compute.

**Fix**
Instead of checking currentOperand directly, the fix splits 
the expression by operators and checks the last token for 
an existing decimal point before allowing another one.

**Testing**
- 1.5 + 2.3. → second dot blocked ✅
- 3.14 → only one dot accepted ✅
- 1.5 + 2.3 = → shows 3.8 ✅