### PR TITLE
fix: validate factorial input to handle negative and decimal numbers …

### DIFF
--- a/public/Vanilla-JavaScript-Calculator-master/script.js
+++ b/public/Vanilla-JavaScript-Calculator-master/script.js
@@ -250,6 +250,12 @@ class Calculator {
         break;
       case 'factorial':
         result = this.factorial(current);
+        if (result === null) {
+        this.currentOperand = 'Error';
+        this.expression = 'Error';
+        this.updateDisplay();
+        return;
+        }
         break;
       case 'percent':
         result = current / 100;
@@ -303,6 +309,7 @@ class Calculator {
   }
 
   factorial(n) {
+    if (!Number.isInteger(n) || n < 0) return null;
     if (n === 0) return 1;
     let result = 1;
     for (let i = 1; i <= n; i++) {


### PR DESCRIPTION
Fixes #3443 

**Problem**
- factorial(-3) returns 1 instead of Error because the loop 
  never executes for negative numbers
- factorial(4.7) silently floors to 4 and returns 24 instead 
  of Error because the loop works on floats too
Neither case was guarded or communicated to the user.

**Fix**
- Added Number.isInteger(n) check to catch decimal inputs
- Added n < 0 check to catch negative inputs
- Both cases now return null which triggers Error display
- Updated factorial case in computeFunction() to handle null return

**Testing**
- factorial(-3) → shows Error ✅
- factorial(4.7) → shows Error ✅
- factorial(0) → shows 1 ✅
- factorial(5) → shows 120 ✅