### PR TITLE
[Bug Fix]: Updated incorrect browser tab title on Login pageUpdate login page title for 100 Days 100 Web Projects

### DIFF
--- a/public/Login.html
+++ b/public/Login.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Sammu Trial Login Page</title>
+    <title>Login — 100 Days 100 Web Projects</title>
 
     <link
       rel="stylesheet"


### PR DESCRIPTION
## 📝 What does this PR do?
Updated the `<title>` tag in `public/Login.html` from `"Sammu Trial Login Page"` to `"Login — 100 Days 100 Web Projects"` to match the site's branding.

## 🐛 Related Issue
Fixes #(your issue number)

##  Changes Made
- Updated `<title>` tag in `public/Login.html`

##  Before & After
| Before | After |
|--------|-------|
| `Sammu Trial Login Page` | `Login — 100 Days 100 Web Projects` |

## 📸 Screenshots
Before
<img width="210" height="42" alt="Screenshot 2026-05-23 122819" src="https://github.com/user-attachments/assets/079a8042-4072-4e9e-803c-cda907b23948" />
After
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/9d7afec9-ff8c-4a1e-9eae-c2fff03472a3" />

