### PR TITLE
feat: add search by name in GitHub Profile Finder - fixes #3120

### DIFF
--- a/public/github_profile_finder/script.js
+++ b/public/github_profile_finder/script.js
@@ -24,20 +24,32 @@ const elements = {
   profileLink: document.getElementById("profileLink")
 };
 
+let searchResultsContainer = document.getElementById("searchResultsContainer");
+if (!searchResultsContainer) {
+  searchResultsContainer = document.createElement("div");
+  searchResultsContainer.id = "searchResultsContainer";
+  searchResultsContainer.style.cssText = `
+    display: none;
+    margin: 1rem 0;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid var(--border, #ccc);
+  `;
+  form.parentNode.insertBefore(searchResultsContainer, profileCard);
+}
+
 function updateThemeIcon() {
   themeIcon.textContent = document.body.classList.contains("dark") ? "☀" : "☾";
 }
 
 function initTheme() {
   const savedTheme = localStorage.getItem("theme");
-
   if (savedTheme) {
     document.body.classList.toggle("dark", savedTheme === "dark");
   } else {
     const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
     document.body.classList.toggle("dark", prefersDark);
   }
-
   updateThemeIcon();
 }
 
@@ -55,6 +67,7 @@ function showLoading() {
   showStatus("Loading profile...", "success");
   profileCard.classList.add("hidden");
   reposSection.classList.add("hidden");
+  searchResultsContainer.style.display = "none";
 }
 
 function formatDate(dateString) {
@@ -72,7 +85,6 @@ function safeText(value, fallback = "—") {
 function renderProfile(user) {
   elements.avatar.src = user.avatar_url;
   elements.avatar.alt = `${user.login} avatar`;
-
   elements.name.textContent = safeText(user.name, user.login);
   elements.username.textContent = `@${user.login}`;
   elements.bio.textContent = safeText(user.bio, "No bio available.");
@@ -108,7 +120,6 @@ function renderRepos(repos) {
   repos.forEach((repo) => {
     const card = document.createElement("article");
     card.className = "repo-card";
-
     card.innerHTML = `
       <div class="repo-top">
         <h4 class="repo-name">
@@ -118,20 +129,58 @@ function renderRepos(repos) {
         </h4>
         ${repo.language ? `<span class="pill">${repo.language}</span>` : ""}
       </div>
-
       <p class="repo-description">${repo.description || "No description provided."}</p>
-
       <div class="repo-meta">
         <span class="pill">★ ${repo.stargazers_count}</span>
         <span class="pill">⑂ ${repo.forks_count}</span>
         <span class="pill">Updated ${formatDate(repo.updated_at)}</span>
       </div>
     `;
-
     reposList.appendChild(card);
   });
 
   reposSection.classList.remove("hidden");
+}
+
+function renderSearchResults(users) {
+  searchResultsContainer.innerHTML = "";
+
+  if (!users.length) {
+    searchResultsContainer.style.display = "none";
+    return;
+  }
+
+  const heading = document.createElement("p");
+  heading.textContent = `${users.length} matching profile(s) found. Click to view:`;
+  heading.style.cssText = "padding: 0.5rem 1rem; font-weight: bold; margin: 0;";
+  searchResultsContainer.appendChild(heading);
+
+  users.forEach((user) => {
+    const item = document.createElement("div");
+    item.style.cssText = `
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+      border-top: 1px solid var(--border, #ccc);
+      transition: background 0.2s;
+    `;
+    item.innerHTML = `
+      <img src="${user.avatar_url}" alt="${user.login}" style="width:36px;height:36px;border-radius:50%;">
+      <span>${user.login}</span>
+    `;
+    item.addEventListener("mouseover", () => item.style.background = "rgba(128,128,128,0.1)");
+    item.addEventListener("mouseout", () => item.style.background = "");
+    item.addEventListener("click", () => {
+      input.value = user.login;
+      searchResultsContainer.style.display = "none";
+      fetchUser(user.login);
+    });
+    searchResultsContainer.appendChild(item);
+  });
+
+  searchResultsContainer.style.display = "block";
 }
 
 async function fetchUser(username) {
@@ -147,35 +196,46 @@ async function fetchUser(username) {
   try {
     const userResponse = await fetch(`https://api.github.com/users/${encodeURIComponent(cleanName)}`);
 
-    if (!userResponse.ok) {
-      if (userResponse.status === 404) {
-        throw new Error("User not found.");
+    if (userResponse.ok) {
+      const user = await userResponse.json();
+      const repoResponse = await fetch(
+        `https://api.github.com/users/${encodeURIComponent(cleanName)}/repos?per_page=100&sort=updated`
+      );
+      const repos = await repoResponse.json();
+      const sortedRepos = repos
+        .sort((a, b) => b.stargazers_count - a.stargazers_count || new Date(b.updated_at) - new Date(a.updated_at))
+        .slice(0, 6);
+      renderProfile(user);
+      renderRepos(sortedRepos);
+      hideStatus();
+    } else {
+      const searchResponse = await fetch(
+        `https://api.github.com/search/users?q=${encodeURIComponent(cleanName)}&per_page=10`
+      );
+
+      if (!searchResponse.ok) {
+        throw new Error("Unable to search users.");
       }
-      throw new Error("Unable to fetch user data.");
+
+      const searchData = await searchResponse.json();
+
+      if (!searchData.items || searchData.items.length === 0) {
+        throw new Error("No users found matching your search.");
+      }
+
+      if (searchData.items.length === 1) {
+        await fetchUser(searchData.items[0].login);
+      } else {
+        hideStatus();
+        profileCard.classList.add("hidden");
+        reposSection.classList.add("hidden");
+        renderSearchResults(searchData.items);
+      }
     }
-
-    const user = await userResponse.json();
-
-    const repoResponse = await fetch(
-      `https://api.github.com/users/${encodeURIComponent(cleanName)}/repos?per_page=100&sort=updated`
-    );
-
-    if (!repoResponse.ok) {
-      throw new Error("Unable to fetch repositories.");
-    }
-
-    const repos = await repoResponse.json();
-
-    const sortedRepos = repos
-      .sort((a, b) => b.stargazers_count - a.stargazers_count || new Date(b.updated_at) - new Date(a.updated_at))
-      .slice(0, 6);
-
-    renderProfile(user);
-    renderRepos(sortedRepos);
-    hideStatus();
   } catch (error) {
     profileCard.classList.add("hidden");
     reposSection.classList.add("hidden");
+    searchResultsContainer.style.display = "none";
     showStatus(error.message || "Something went wrong.", "error");
   }
 }


### PR DESCRIPTION
### **## Related Issue**
Fixes #3120

**## Description**
Added search by name functionality in GitHub Profile Finder. Previously, only exact username search worked. Now users can search by name or partial username and see a list of matching profiles using the GitHub Search Users API.

**## Type of PR**
- [ ] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other (specify):

**## Checklist**
- [X] I have performed a self-review of my code.
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers.
- [X] I have ensured that my changes do not break any existing functionality.

## Screenshots / Videos
Before: Searching by name showed "User not found" error.
After: When a partial name is searched, matching GitHub profiles appear as a clickable list. Exact username search still works as before.

## Additional Context
Used GitHub Search API: https://api.github.com/search/users?q={query}