### PR TITLE
fix(ui): make archive project cards fully clickable for enhanced UX

### DIFF
--- a/index.js
+++ b/index.js
@@ -542,12 +542,21 @@ function renderGrid() {
   pageItems.forEach(([day, name, url, tags]) => {
     const category = getCategoryFromTags(tags, name);
     const card = document.createElement('div');
+    
+    // FIX PART 1: Add a pointer cursor so users know it's clickable
     card.className = 'project-card';
+    card.style.cursor = 'pointer'; 
+    
+    // FIX PART 2: Make the whole card clickable to open the demo in a new tab
+    card.onclick = () => window.open(url.trim(), '_blank');
+
     const isBookmarked = bookmarkedProjects.some((item) => item[0] === day);
     const tagsArray = typeof tags === 'string' ? tags.split(/\s+/).filter((t) => t) : tags;
     const tagsHTML = tagsArray.map((t) => `<span class="tag">${t}</span>`).join('');
     const sourceUrl = getSourceUrl(url);
 
+    // FIX PART 3: Add onclick="event.stopPropagation()" to the Demo, Code, and Bookmark buttons
+    // This stops the click from "bubbling up" to the main card, preventing double-opening!
     card.innerHTML = `
             <div class="card-meta">
                 <span class="card-day">${day}</span>
@@ -557,14 +566,14 @@ function renderGrid() {
             <div class="card-tags">${tagsHTML}</div>
             <div class="card-footer">
                 <div class="card-actions-left">
-                    <a href="${url.trim()}" target="_blank" class="card-link open-project" data-id="${day}" rel="noopener noreferrer">
+                    <a href="${url.trim()}" target="_blank" class="card-link open-project" data-id="${day}" rel="noopener noreferrer" onclick="event.stopPropagation()">
                         Demo <i class="fas fa-arrow-right"></i>
                     </a>
-                    <a href="${sourceUrl}" target="_blank" class="card-link view-code-link" rel="noopener noreferrer">
+                    <a href="${sourceUrl}" target="_blank" class="card-link view-code-link" rel="noopener noreferrer" onclick="event.stopPropagation()">
                         <i class="fab fa-github"></i> Code
                     </a>
                 </div>
-                <button class="bookmark-btn ${isBookmarked ? 'active' : ''}" data-id="${day}">
+                <button class="bookmark-btn ${isBookmarked ? 'active' : ''}" data-id="${day}" onclick="event.stopPropagation()">
                     <i class="${isBookmarked ? 'fa-solid' : 'fa-regular'} fa-bookmark"></i>
                 </button>
             </div>


### PR DESCRIPTION
## Description
This PR addresses the user experience bug mentioned in issue #3034 regarding the unclickable project cards on the main Archive Index page. 

**Changes made in `index.js`:**
- Converted the entire project card into an interactive hit area by applying `cursor-pointer` and adding an `onclick` event to open the project demo URL.
- Implemented `event.stopPropagation()` on the nested "Code" (GitHub) and "Bookmark" buttons. This ensures that clicking the inner buttons works as intended without triggering the outer card's click event.

## Type of Change
- [ ] New project
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update

## Testing
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested on mobile
- [x] No console errors

## Screenshots/Video Recording 

https://github.com/user-attachments/assets/75538843-5c30-44bb-9304-9ec5df289c3c


## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Documentation updated *(N/A for this fix)*
- [x] No merge conflicts

---

### 💡 Additional Note to Maintainers regarding #3034:
Issue #3034 also mentioned a layout alignment bug with the **"Use this template"** buttons and varying card heights. 

After digging into this codebase, I realized the UI for the Templates page belongs to the sister application/repository (`github-readme.tech`), not this main `100_days_100_web_project` repo. 

I already have the CSS Flexbox fix (`flex-col h-full` and `mt-auto`) ready to go for those cards! Could you please link me to the correct repository where those template files reside so I can open a PR there as well?
