### PR TITLE
Add password visibility toggle to login and signup forms (#3361)

### DIFF
--- a/public/Login.html
+++ b/public/Login.html
@@ -57,6 +57,7 @@
                 autocomplete="current-password"
                 required
               />
+              <span class="toggle-password" onclick="togglePassword()">👁</span>
             </div>
 
             <button type="submit" class="button home-btn">
@@ -77,6 +78,22 @@
     </section>
 
     <script>
+      // Show password toggle
+      function togglePassword() {
+        const passwordInput = document.getElementById("password");
+        const toggleIcon = document.querySelector(".toggle-password");
+
+        if (passwordInput.type === "password") {
+            passwordInput.type = "text";
+            toggleIcon.classList.add("active");
+            // toggleIcon.textContent = "..";
+        } else {
+            passwordInput.type = "password";
+            toggleIcon.classList.remove("active");
+            // toggleIcon.textContent = "👁";
+        }
+      }
+      
       document
         .getElementById("loginForm")
         .addEventListener("submit", function (event) {

--- a/public/SignUp.html
+++ b/public/SignUp.html
@@ -77,6 +77,7 @@
                 class="form-input"
                 required
               />
+              <span class="toggle-password" onclick="togglePassword()">👁</span>
             </div>
 
             <button type="submit" class="button home-btn signup-btn">
@@ -88,11 +89,28 @@
           <p class="already-signed-up">
             Already signed up? <a href="Login.html">Login</a>
           </p>
+          
         </div>
       </div>
     </section>
 
     <script>
+      // Show password toggle
+      function togglePassword() {
+        const passwordInput = document.getElementById("password");
+        const toggleIcon = document.querySelector(".toggle-password");
+
+        if (passwordInput.type === "password") {
+            passwordInput.type = "text";
+            toggleIcon.classList.add("active");
+            // toggleIcon.textContent = "..";
+        } else {
+            passwordInput.type = "password";
+            toggleIcon.classList.remove("active");
+            // toggleIcon.textContent = "👁";
+        }
+      }
+
       document
         .getElementById("signupForm")
         .addEventListener("submit", function (event) {
@@ -110,6 +128,7 @@
             alert("Username already exists.");
             return;
           }
+
 
           // Strong password validation
           const passwordRegex = /^(?=.*[A-Z])(?=.*[0-9])(?=.*[!@#$%^&*]).{6,}$/;

--- a/public/style.css
+++ b/public/style.css
@@ -205,6 +205,26 @@ a {
   font-size: 14px;
 }
 
+.form-group input {
+  padding-right: 45px;
+}
+
+.toggle-password {
+    position: absolute;
+    right: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    cursor: pointer;
+
+    opacity: 0.4;
+    transition: 0.3s ease;
+}
+
+.toggle-password.active {
+    opacity: 1;
+    filter: drop-shadow(0 0 5px white);
+}
+
 /*Button styling*/
 .button {
   background: var(--glass-bg);


### PR DESCRIPTION
# Fixes #3361

Implemented a password visibility toggle feature for both login and signup forms to improve usability and authentication UX.

## Changes made:
- Added interactive eye icon inside password input fields
- Implemented toggle functionality to switch input type between "password" and "text"
- Added dynamic icon state switching for better visual feedback
- Added glow effect on toggle interaction to maintain consistency with the existing UI theme
- Ensured responsiveness and clean alignment across authentication forms

[Attached images: Before and After]

BEFORE
<img width="448" height="665" alt="image" src="https://github.com/user-attachments/assets/098ceb0d-43f7-4b1f-a507-bbe684de1c67" />

AFTER
<img width="504" height="682" alt="image" src="https://github.com/user-attachments/assets/dab99257-991b-4a89-9799-3b770a2c6a62" />
<img width="496" height="682" alt="image" src="https://github.com/user-attachments/assets/50402889-ce97-4a21-aef5-f3ded5d605d1" />
