### PR TITLE
fix: remove duplicate initTheme function in BMI Calculator

### DIFF
--- a/public/BMI_Calculator/script.js
+++ b/public/BMI_Calculator/script.js
@@ -23,31 +23,6 @@
         localStorage.setItem(STORAGE_KEY, isDark ? "dark" : "light");
     });
 
-  const themeBtn = document.getElementById("theme-toggle");
-  const STORAGE_KEY = "bmi-theme";
-
-  // Resolve initial theme: saved preference → OS preference → light
-  function getPreferred() {
-    const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved) return saved;
-    return window.matchMedia("(prefers-color-scheme: dark)").matches
-      ? "dark"
-      : "light";
-  }
-
-  function applyTheme(theme) {
-    document.body.classList.toggle("dark", theme === "dark");
-  }
-
-  // Apply on first load (runs synchronously before paint)
-  applyTheme(getPreferred());
-
-  // Toggle on click
-  themeBtn.addEventListener("click", () => {
-    const isDark = document.body.classList.toggle("dark");
-    localStorage.setItem(STORAGE_KEY, isDark ? "dark" : "light");
-  });
-
 })();
 
 const heightUnitEl = document.getElementById("height-unit");


### PR DESCRIPTION
Fixes #3684 

**Problem**
The initTheme IIFE in script.js had its entire body written 
twice inside the same function. This caused:
- SyntaxError due to duplicate const declarations 
  (themeBtn and STORAGE_KEY declared twice)
- Theme toggle completely broken on page load
- localStorage persistence not working

**Fix**
Removed the duplicate block keeping only one clean 
initTheme IIFE with proper indentation.

**Testing**
- Theme toggle works on click ✅
- Dark mode persists on page refresh ✅
- No console errors on load ✅