### PR TITLE
fix: remove duplicate function body in bmiToPercent in BMI Calculator

### DIFF
--- a/public/BMI_Calculator/script.js
+++ b/public/BMI_Calculator/script.js
@@ -123,12 +123,7 @@ function bmiToPercent(bmi) {
     const MIN = 10, MAX = 45;
     const clamped = Math.min(Math.max(bmi, MIN), MAX);
     return ((clamped - MIN) / (MAX - MIN)) * 100;
-
-  const MIN = 10,
-    MAX = 45;
-  const clamped = Math.min(Math.max(bmi, MIN), MAX);
-  return ((clamped - MIN) / (MAX - MIN)) * 100;
-
+    
 }
 
 // ─── Chart.js setup ───


### PR DESCRIPTION
Fixes #3691 

**Problem**
The bmiToPercent function in script.js had its entire body 
written twice inside the same function. This caused:
- SyntaxError due to duplicate const declarations
  (MIN, MAX and clamped declared twice)
- BMI range pointer not moving correctly on the range bar
- Incorrect percentage calculation for BMI visualization

**Fix**
Removed the duplicate block keeping only one clean 
bmiToPercent function with proper indentation.

**Testing**
- BMI range pointer moves correctly ✅
- Percentage calculation works correctly ✅
- No console errors on load ✅