### PR TITLE
fix: remove duplicate body fat gauge elements with same IDs in BMI Ca…

### DIFF
--- a/public/BMI_Calculator/index.html
+++ b/public/BMI_Calculator/index.html
@@ -189,18 +189,6 @@
             <div class="metric-label">Est. body fat</div>
             <span class="bf-badge" id="bf-badge"></span>
           </div>
-          <div class="bf-body">
-            <div class="bf-gauge-wrap">
-              <svg class="bf-gauge" viewBox="0 0 120 120">
-                <circle class="bf-track" cx="60" cy="60" r="52" stroke-width="7" fill="none" />
-                <circle class="bf-fill" id="bf-arc" cx="60" cy="60" r="52" stroke-width="7" fill="none"
-                  stroke-dasharray="326.73" stroke-dashoffset="326.73" stroke-linecap="round" />
-                <text class="bf-pct-text" x="60" y="56" text-anchor="middle" dominant-baseline="central"
-                  id="bf-pct">—</text>
-                <text class="bf-pct-unit" x="60" y="74" text-anchor="middle" dominant-baseline="central">% body
-                  fat</text>
-              </svg>
-            </div>
             <div class="bf-body">
               <div class="bf-gauge-wrap">
                 <svg class="bf-gauge" viewBox="0 0 120 120">


### PR DESCRIPTION
Fixes #3698 

**Problem**
The body fat gauge SVG in index.html was rendered twice 
with the same IDs (bf-arc and bf-pct). This caused:
- JavaScript only updates the first element with that ID
- Second gauge element is dead markup
- Body fat gauge animation not working correctly
- Duplicate DOM elements causing confusion

**Fix**
Removed the duplicate shorter gauge block keeping only 
the complete gauge with bf-info section intact.

**Testing**
- Body fat gauge renders correctly ✅
- Gauge animation works on calculate ✅
- No duplicate IDs in DOM ✅