### PR TITLE
feat: add difficulty filtering to showcase grid #3687

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,6 +181,12 @@
             <option value="latest">Latest Day</option>
             <option value="difficulty">Difficulty</option>
           </select>
+          <select id="difficultyFilter" aria-label="Filter projects by difficulty">
+            <option value="all">Difficulty (All)</option>
+            <option value="beginner">Beginner</option>
+            <option value="intermediate">Intermediate</option>
+            <option value="advanced">Advanced</option>
+          </select>
         </div>
       </div>
 

--- a/index.js
+++ b/index.js
@@ -478,13 +478,14 @@ let activeFilter = 'all';
 let searchQuery = '';
 let sortOption = 'default';
 let techStackFilter = 'all';
+let difficultyFilter = 'all';
 
 function renderGrid() {
   const grid = document.getElementById('projectGrid');
   const noResults = document.getElementById('noResults');
   if (!grid) return;
 
-  const filtered = PROJECTS.filter(([day, name, url, tags]) => {
+  const filtered = PROJECTS.filter(([day, name, url, tags, difficulty = '']) => {
     // Category filter
     const category = getCategoryFromTags(tags, name);
     const targetCategory = FILTER_CATEGORY_MAP[activeFilter] || 'all';
@@ -505,7 +506,13 @@ function renderGrid() {
       matchesTech = tagStr.includes(techStackFilter.toLowerCase());
     }
 
-    return matchesFilter && matchesSearch && matchesTech;
+    // Difficulty filter
+    let matchesDifficulty = true;
+    if (difficultyFilter && difficultyFilter !== 'all') {
+      matchesDifficulty = (difficulty || '').toLowerCase() === difficultyFilter.toLowerCase();
+    }
+
+    return matchesFilter && matchesSearch && matchesTech && matchesDifficulty;
   });
 
   // Apply sorting
@@ -988,6 +995,16 @@ function initSearch() {
   if (techStack) {
     techStack.addEventListener('change', () => {
       techStackFilter = techStack.value;
+      currentPage = 1;
+      renderGrid();
+    });
+  }
+
+  // Difficulty dropdown filter listener
+  const diffFilterElement = document.getElementById('difficultyFilter');
+  if (diffFilterElement) {
+    diffFilterElement.addEventListener('change', () => {
+      difficultyFilter = diffFilterElement.value;
       currentPage = 1;
       renderGrid();
     });

--- a/style.css
+++ b/style.css
@@ -681,7 +681,8 @@ body.light-mode .navbar {
   max-width: 650px;
 }
 
-#sortProjects {
+#sortProjects,
+#difficultyFilter {
   min-width: 140px;
   height: 42px;
   padding: 0 12px;
@@ -694,7 +695,8 @@ body.light-mode .navbar {
   flex-shrink: 0;
 }
 
-#sortProjects option {
+#sortProjects option,
+#difficultyFilter option {
  background: var(--bg-elevated);
 color: var(--text-primary);
 }
@@ -1695,6 +1697,11 @@ color: var(--text-primary);
 }
 
 @media (max-width: 768px) {
+  .search-bar {
+    flex-wrap: wrap;
+    max-width: 100%;
+  }
+
   .navbar {
     padding: 0 1.5rem;
   }


### PR DESCRIPTION
## Description
Currently, users can sort the showcase grid projects by difficulty using the sort dropdown, but they cannot directly filter them. This pull request introduces an interactive **Difficulty Filter** dropdown to the showcase search controls. 

With this enhancement, users can select a specific level (`Beginner`, `Intermediate`, or `Advanced`) to dynamically filter and view only those projects that match their skill level, greatly improving the user experience and grid discoverability.

---

## Related Issues
Closes #3687

---

## Proposed Changes

### 1. `index.html`
- Added the `<select id="difficultyFilter">` dropdown inside the `.search-bar` container, positioned right next to the sorting dropdown, containing options for:
  - `Difficulty (All)` (Default)
  - `Beginner`
  - `Intermediate`
  - `Advanced`

### 2. `index.js`
- Declared a global `difficultyFilter` state variable initialized to `'all'`.
- Updated the `.filter()` list calculation in `renderGrid()` to unpack the 5th element (`difficulty`) of each project and verify it matches the selected dropdown option (ignoring case).
- Registered a change event listener for `#difficultyFilter` inside `initSearch()` to update the active filter state, reset pagination `currentPage` back to `1`, and trigger a clean grid re-render.

### 3. `style.css`
- Extended existing selector rules to apply the exact same premium glassmorphism styling, colors, and margins of `#sortProjects` to `#difficultyFilter`.
- Improved mobile responsive design inside the `768px` media query by adding `flex-wrap: wrap` to the `.search-bar` container, ensuring the two dropdowns and search input stack beautifully on smaller screens without visual overflow.

---

## How Has This Been Tested?
- **Syntax and Compliance**: Ran the HTMLHint linter (`npm run lint`), which succeeded with `no errors found`.
- **Logic & Filter Correctness**: Verified that selecting a specific difficulty option updates the project grid to show only projects with the matching difficulty classification (case-insensitive) and accurately recalculates grid pagination.
