### PR TITLE
fix: remove duplicate BMI reference table without row IDs in BMI Calc…

### DIFF
--- a/public/BMI_Calculator/index.html
+++ b/public/BMI_Calculator/index.html
@@ -281,49 +281,6 @@
           <p class="card-title">Reference chart</p>
         </div>
 
-
-        <table class="bmi-table">
-          <thead>
-            <tr>
-              <th>BMI</th>
-              <th>Category</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>&lt; 18.5</td>
-              <td>Underweight</td>
-              <td><span class="dot dot-blue"></span></td>
-            </tr>
-            <tr>
-              <td>18.5 – 24.9</td>
-              <td>Normal weight</td>
-              <td><span class="dot dot-green"></span></td>
-            </tr>
-            <tr>
-              <td>25.0 – 29.9</td>
-              <td>Overweight</td>
-              <td><span class="dot dot-amber"></span></td>
-            </tr>
-            <tr>
-              <td>30.0 – 34.9</td>
-              <td>Obese (Class I)</td>
-              <td><span class="dot dot-red1"></span></td>
-            </tr>
-            <tr>
-              <td>35.0 – 39.9</td>
-              <td>Obese (Class II)</td>
-              <td><span class="dot dot-red2"></span></td>
-            </tr>
-            <tr>
-              <td>≥ 40.0</td>
-              <td>Obese (Class III)</td>
-              <td><span class="dot dot-red3"></span></td>
-            </tr>
-          </tbody>
-        </table>
-
           <table class="bmi-table">
             <thead>
               <tr>


### PR DESCRIPTION
Fixes #3709 

**Problem**
The index.html had two BMI reference tables rendered.
The first table had no row IDs so the active-row highlight
never worked on it. The second table had correct row IDs
(underweight-row, normal-row etc.) for JavaScript to target.
Having two tables caused:
- Duplicate reference table visible on page
- active-row highlight not working on first table
- Confusing UI with repeated information

**Fix**
Removed the first duplicate table without row IDs keeping 
only the correct second table with proper row IDs.

**Testing**
- Single reference table renders correctly ✅
- active-row highlight works on calculate ✅
- No duplicate tables in DOM ✅