### PR TITLE
fix: remove duplicate DOMContentLoaded event listener in expense tracker

### DIFF
--- a/public/expense_Tracker/expense.js
+++ b/public/expense_Tracker/expense.js
@@ -27,12 +27,6 @@ const errorLogs = {
     description: document.getElementById('descriptionError'),
     category: document.getElementById('categoryError')
 };
-document.addEventListener('DOMContentLoaded', () => {
-    initializeThemeEngine();
-    setDefaultDateToToday();
-    setupUserInteractionEvents();
-    calculateAndRefreshSummary();
-});
 
 document.addEventListener('DOMContentLoaded', () => {
     initializeThemeEngine();


### PR DESCRIPTION
Fixes #3806 

**Problem**
The expense.js file had DOMContentLoaded event listener 
registered twice. This caused:
- initializeThemeEngine() called twice on page load
- setDefaultDateToToday() called twice
- setupUserInteractionEvents() called twice causing 
  duplicate event listeners on all buttons and inputs
- calculateAndRefreshSummary() called twice unnecessarily

**Fix**
Removed the first duplicate DOMContentLoaded block. 
The second block is kept as it has proper null checks:
- if (document.getElementById('date')) before setDefaultDateToToday()
- if (document.getElementById('transactionsBody')) before renderHistoryTable()

**Testing**
- Page loads correctly ✅
- Theme toggle works ✅
- Form submission works ✅
- No duplicate event listeners ✅