### PR TITLE
fix: add future date validation in expense tracker form

### DIFF
--- a/public/expense_Tracker/expense.js
+++ b/public/expense_Tracker/expense.js
@@ -137,7 +137,16 @@ function checkFormErrors() {
     if (dateInput && !dateInput.value) {
         if (errorLogs.date) errorLogs.date.textContent = 'Please select a date.';
         isValid = false;
+    }else if (dateInput && dateInput.value) {
+    const selectedDate = new Date(dateInput.value);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (selectedDate > today) {
+        if (errorLogs.date) errorLogs.date.textContent = 'Future dates are not allowed.';
+        isValid = false;
+        }
     }
+
     if (descriptionInput && !descriptionInput.value.trim()) {
         if (errorLogs.description) errorLogs.description.textContent = 'Please type a short description.';
         isValid = false;


### PR DESCRIPTION
Fixes #3809 

**Problem**
The date input had dateInput.max = today set in HTML 
but there was no validation in checkFormErrors() to 
reject future dates if someone types one manually.
This allowed future dated transactions to be saved.

**Fix**
Added future date validation in checkFormErrors():
- Gets selected date from input
- Compares with today's date (time set to 00:00:00)
- Shows error message if selected date is in future
- Prevents form submission with future dates

**Testing**
- Select today's date → form submits correctly ✅
- Select past date → form submits correctly ✅
- Type future date manually → shows error message ✅
- Empty date → shows please select a date error ✅