### PR TITLE
fix: add missing color-neutral CSS class in expense tracker

### DIFF
--- a/public/expense_Tracker/style.css
+++ b/public/expense_Tracker/style.css
@@ -331,6 +331,7 @@ button { font-family: inherit; font-weight: 500; border-radius: 8px; cursor: poi
 .text-green { color: var(--green-success); }
 .text-red { color: var(--red-error); }
 .text-blue { color: var(--blue-info); }
+.color-neutral { color: var(--text-main); }
 
 @media (min-width: 576px) {
     .dashboard-stats { grid-template-columns: repeat(4, 1fr); gap: 16px; }


### PR DESCRIPTION
Fixes #3812 

**Problem**
The index.html uses class="stat-number color-neutral" on 
the account balance element but color-neutral was never 
defined in style.css. This caused:
- No styling applied to balance on initial page load
- Balance text color undefined until first calculation
- Inconsistent styling before any transactions added

**Fix**
Added the missing .color-neutral CSS class in style.css:
.color-neutral { color: var(--text-main); }

This ensures the balance displays with correct neutral 
color on initial page load before any transactions.

**Testing**
- Balance shows correct neutral color on page load ✅
- Balance turns green when positive ✅
- Balance turns red when negative ✅
- Works in both light and dark mode ✅