### PR TITLE
fix: remove duplicate body styles in expense tracker stylesheet

### DIFF
--- a/public/expense_Tracker/style.css
+++ b/public/expense_Tracker/style.css
@@ -85,19 +85,6 @@ body {
     opacity: 0.12; /* Slightly brighter in dark mode for contrast */
 }
 
-body {
-    background-color: var(--page-bg);
-    color: var(--text-main);
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    min-height: 100vh;
-    padding: 24px;
-    display: flex;
-    flex-direction: column;
-    align-items: center; /* Forces frame to hold true center alignment instantly on paint */
-    justify-content: flex-start;
-    transition: background-color 0.2s, color 0.2s;
-}
-
 .app-container {
     width: 100%;
     max-width: 1440px; /* Expanded from 1200px to sit beautifully on wider viewports */


### PR DESCRIPTION
Fixes #3814 

**Problem**
The style.css file had the body selector defined twice.
The second block overrode some properties from the first:
- Missing position: relative
- Missing background-image gradient
- Missing background-attachment: fixed
- Missing background-blend-mode: overlay
- Added justify-content: flex-start (conflicting)

This caused the background gradient and aura effect 
to not render correctly.

**Fix**
Removed the duplicate body block keeping only the first 
complete one which has all required properties including
background gradient and position settings.

**Testing**
- Background gradient renders correctly ✅
- Aura effect works correctly ✅
- No duplicate body styles ✅
- Works in both light and dark mode ✅