### PR TITLE
fix: added missing tags and difficulty for Day 167 project to prevent page rendering crash

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,7 +235,7 @@ const PROJECT_DATA = [
   [ 'Day 164' , 'Code Visualizer Playground' , './public/code-visualizer-playground/index.html' , 'tool javascript html css' , 'advanced' ],
   [ 'Day 165' , 'Amazon Clone' , './public/AmazonClone/index.html' , 'Amazon Clone HTML CSS JavaScript' , 'beginner' ],
   [ "Day 166" , "Boredom Buster" , "./public/BoredomBuster/index.html" , "html css javascript" , 'advanced' ],
-  ["Day 167", "scam-sms-detector", "/public/scam-sms-detector/index.html"],
+  ["Day 167", "scam-sms-detector", "./public/scam-sms-detector/index.html", "html css javascript tool", "intermediate"],
    [ "Day 168" , "Color Sort Puzzle game" , "./public/colorsort/index.html" , "html css javascript" , 'advanced' ]
 ];
 const PROJECTS = PROJECT_DATA;


### PR DESCRIPTION
### Linked Issue
Closes #3909

### Description of Changes
- Added tags `html css javascript tool` and difficulty `intermediate` to Day 167 in the `PROJECT_DATA` array.
- Adjusted the absolute path `/public/...` to `./public/...` to match the relative path style of all other projects.

### Verification
- Navigated to the final page of the project grid and verified that Day 167 displays beautifully with its badges without causing any console warnings or rendering crashes!