### PR TITLE
eat(memorygame): replace win modal emoji with modern animated trophy icon

### DIFF
--- a/public/MemoryGame/index.html
+++ b/public/MemoryGame/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Memory Match</title>
   <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;700;800&family=DM+Mono:wght@400;500&family=Orbitron:wght@700;900&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -67,7 +68,7 @@
   <!-- Win Modal -->
   <div class="modal-overlay" id="winModal">
     <div class="modal">
-      <span class="modal-emoji">🎉</span>
+      <span class="modal-emoji"><i class="fas fa-trophy fa-bounce" style="color: #fbbf24; font-size: 4rem; display: block; margin-bottom: 1rem;"></i></span>
       <h2 class="modal-title">You Won!</h2>
       <p class="modal-sub" id="modalSub">Amazing memory!</p>
       <div id="newBest" class="new-best" style="display:none">🏆 New Best Score!</div>


### PR DESCRIPTION
Closed #4019 

### Description
- Upgraded the victory markup grid inside `MemoryGame/index.html`.
- Substituted the default text emoji with a beautifully styled Font Awesome gold trophy (`fas fa-trophy fa-bounce`).
