### PR TITLE
fix(accessibility): resolve invalid aria-hidden on navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
 
     <!-- ── NAVBAR ──────────────────────────────────────────── -->
   <header>
-      <nav class="navbar" id="navbar" aria-hidden="Main Navigation">
+      <nav class="navbar" id="navbar" aria-label="Main Navigation">
         <a class="navbar-brand" href="index.html" style="text-decoration:none;">
           <span class="brand-mark" aria-label="100 Days logo">100</span>
             <span class="brand-copy">


### PR DESCRIPTION
## Related Issue

Closes #3830 

## Description

This pull request resolves an accessibility bug in the main navigation bar.

### Problem
In [index.html](file:///c:/gssoc-contributions/100_days_100_web_project/index.html#L47), the main `<nav>` element was configured with `aria-hidden="Main Navigation"`. Because `aria-hidden` only accepts boolean values (`"true"` or `"false"`), browser accessibility APIs treat non-boolean strings as truthy. This accidentally hid the entire navigation landmark and its interactive children from screen readers and other assistive technologies.

### Fix
Replaced the invalid `aria-hidden` attribute with the semantically correct `aria-label="Main Navigation"` to properly name the navigation landmark, allowing screen readers to discover and announce the navigation links correctly.
