### PR TITLE
[Bug]game over fix

### DIFF
--- a/public/snake_game/script.js
+++ b/public/snake_game/script.js
@@ -191,9 +191,9 @@ function startGame() {
   document.getElementById('gameOverOverlay').classList.add('hidden');
   cancelAnimationFrame(animFrame); // stop idle animation
 
-  isGameOver = false; // FIX 3: clear the flag so inputs can be taken again
+  isGameOver = false; // FIX 1: clear the flag so inputs can be taken again
  
-  // FIX 4: re-attach the listener as the player has restarted the game
+  // FIX 3: re-attach the listener as the player has restarted the game
   document.removeEventListener('keydown', handleKeyDown);
   document.addEventListener('keydown', handleKeyDown);
 
@@ -206,14 +206,14 @@ function startGame() {
 
 function endGame() {
 
-  // FIX 5: Changes finalScore early
+  // FIX 2: Changes finalScore early
   finalScore = score;
 
   running = false;
-  isGameOver = true; // FIX 6: raises the dead flag
+  isGameOver = true; // FIX 1: raises the dead flag
   clearInterval(gameLoop);
 
-  // FIX 7: remove the listener when game ends so no more inputs are taken after death
+  // FIX 3: remove the listener when game ends so no more inputs are taken after death
   document.removeEventListener('keydown', handleKeyDown);
 
   
@@ -225,7 +225,7 @@ function endGame() {
       clearInterval(flash);
       draw();
       document.getElementById('finalScore').textContent =
-        `SCORE: ${finalScore}  |  BEST: ${highScore}`; // FIX 8: Chooses between finalScore and highScore (Not score, which could have changed at death)
+        `SCORE: ${finalScore}  |  BEST: ${highScore}`; // FIX 2: Chooses between finalScore and highScore (Not score, which could have changed at death)
       document.getElementById('gameOverOverlay').classList.remove('hidden');
     }
   }, 80);
@@ -246,9 +246,9 @@ const KEY_MAP = {
   A: { x: -1, y:  0 },
   D: { x:  1, y:  0 },
 };
-function handleKeyDown(e) { // FIX 9: Named the function so it can be added/removed cleanly
+function handleKeyDown(e) { // FIX 3: Named the function so it can be added/removed cleanly
 
-  // FIX 10: If the game is over, dont take any key input
+  // FIX 1: If the game is over, dont take any key input
   if (isGameOver) return;
 
   
@@ -278,15 +278,16 @@ function handleKeyDown(e) { // FIX 9: Named the function so it can be added/remo
       restartLoop();
     }
   }
-});
+};
 
 // Attach the named listener on start screen
 document.addEventListener('keydown', handleKeyDown);
 
-// FIX 11: Play Again button is the only restart path
+// FIX 4: Play Again button is the only restart path
 document.getElementById('startBtn').addEventListener('click', startGame);
 document.getElementById('restartBtn').addEventListener('click', startGame);
 
+//NOTE: the mousedown "click anywhere to start" listener has been intentionally removed.
 // document.addEventListener('mousedown', e => {
 //   if (!running && e.target.id !== 'startBtn' && e.target.id !== 'restartBtn') {
 //     startGame();

--- a/public/snake_game/script.js
+++ b/public/snake_game/script.js
@@ -11,6 +11,8 @@ canvas.height = ROWS * CELL;
 let snake, dir, nextDir, food, score, level, speed, gameLoop, running, paused;
 
 let highScore = 0;
+let isGameOver = false; // FIX 1: new flag — single source of truth for dead state
+let finalScore = 0;     // FIX 2: captures score the instant collision occurs 
 
 function initGame() {
   
@@ -188,6 +190,14 @@ function startGame() {
   document.getElementById('startOverlay').classList.add('hidden');
   document.getElementById('gameOverOverlay').classList.add('hidden');
   cancelAnimationFrame(animFrame); // stop idle animation
+
+  isGameOver = false; // FIX 3: clear the flag so inputs can be taken again
+ 
+  // FIX 4: re-attach the listener as the player has restarted the game
+  document.removeEventListener('keydown', handleKeyDown);
+  document.addEventListener('keydown', handleKeyDown);
+
+  
   initGame();
   running = true;
   draw();
@@ -195,8 +205,16 @@ function startGame() {
 }
 
 function endGame() {
+
+  // FIX 5: Changes finalScore early
+  finalScore = score;
+
   running = false;
+  isGameOver = true; // FIX 6: raises the dead flag
   clearInterval(gameLoop);
+
+  // FIX 7: remove the listener when game ends so no more inputs are taken after death
+  document.removeEventListener('keydown', handleKeyDown);
 
   
   let flashes = 0;
@@ -207,7 +225,7 @@ function endGame() {
       clearInterval(flash);
       draw();
       document.getElementById('finalScore').textContent =
-        `SCORE: ${score}  |  BEST: ${highScore}`;
+        `SCORE: ${finalScore}  |  BEST: ${highScore}`; // FIX 8: Chooses between finalScore and highScore (Not score, which could have changed at death)
       document.getElementById('gameOverOverlay').classList.remove('hidden');
     }
   }, 80);
@@ -228,8 +246,11 @@ const KEY_MAP = {
   A: { x: -1, y:  0 },
   D: { x:  1, y:  0 },
 };
+function handleKeyDown(e) { // FIX 9: Named the function so it can be added/removed cleanly
 
-document.addEventListener('keydown', e => {
+  // FIX 10: If the game is over, dont take any key input
+  if (isGameOver) return;
+
   
   if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
     e.preventDefault();
@@ -259,15 +280,18 @@ document.addEventListener('keydown', e => {
   }
 });
 
+// Attach the named listener on start screen
+document.addEventListener('keydown', handleKeyDown);
 
+// FIX 11: Play Again button is the only restart path
 document.getElementById('startBtn').addEventListener('click', startGame);
 document.getElementById('restartBtn').addEventListener('click', startGame);
 
-document.addEventListener('mousedown', e => {
-  if (!running && e.target.id !== 'startBtn' && e.target.id !== 'restartBtn') {
-    startGame();
-  }
-});
+// document.addEventListener('mousedown', e => {
+//   if (!running && e.target.id !== 'startBtn' && e.target.id !== 'restartBtn') {
+//     startGame();
+//   }
+// });
 
 let animFrame;
 


### PR DESCRIPTION
## Description

Fixes #4061

Fixes a race condition where sending a directional input fast enough after the snake dies would cause the game to continue running beneath the Game Over overlay. In this broken state, the score displayed on the Game Over screen would incorrectly show 0 instead of the player's actual score at the time of death. The only previous recovery was to lose the game a second time.

Four targeted changes were made:

- Added an `isGameOver` boolean flag that is raised the instant a collision is detected, and a single guard at the top of the key handler (`if (isGameOver) return;`) that swallows all input while the game is in a dead state

- Introduced a `finalScore` variable that captures the score at the moment of collision, before any reset logic can run, and passes that value to the Game Over overlay

- Converted the anonymous `keydown` listener to a named `handleKeyDown` function so it can be explicitly removed on death (`removeEventListener`) and re-attached only when the player chooses to restart — belt-and-suspenders on top of the flag

- Removed the `mousedown` "click anywhere to restart" shortcut, which was a secondary path that could trigger `startGame()` during the flash animation window before the overlay was visible

## Type of Change

- [ ] New project

- [x] Bug fix

- [ ] Feature enhancement

- [ ] Documentation update

## Testing

- [ ] Tested in Chrome

- [x] Tested in Firefox

- [ ] Tested on mobile

- [x] No console errors

## Checklist

- [x] Code follows style guidelines

- [x] Self-review completed

- [ ] Documentation updated

- [x] No merge conflicts