### PR TITLE
Fix homepage responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -189,27 +189,10 @@ header {
    NAVBAR & RESPONSIVE DRAWER ARCHITECTURE
    ============================================================ */
 .navbar {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    z-index: 999999;
-    background: rgba(11, 13, 15, 0.88);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
-    border-bottom: 1px solid var(--border);
-    padding: 0 3rem;
-    height: 60px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    transition: var(--t);
-}
-
-.navbar {
-    isolation: isolate;
+  isolation: isolate;
   position: fixed;
   top: 0;
+  left: 0;
   width: 100%;
   z-index: 100000;
   background: rgba(11, 13, 15, 0.88);
@@ -376,8 +359,30 @@ body.light-mode .navbar {
     height: auto;
   }
 
+  .navbar-brand {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .brand-copy {
+    overflow: hidden;
+  }
+
+  .brand-copy strong {
+    font-size: 0.75rem;
+    line-height: 1.2;
+    display: block;
+    white-space: normal;
+  }
+
+  .brand-kicker {
+    font-size: 0.55rem;
+  }
+
   .menu-toggle {
     display: block;
+    flex-shrink: 0;
+    margin-left: 0.5rem;
   }
 
   .menu-toggle i {
@@ -422,6 +427,12 @@ body.light-mode .navbar {
   .welcome-text {
     text-align: center;
     width: 100%;
+  }
+
+  .stats-strip {
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 1rem;
   }
 }
 


### PR DESCRIPTION
## Title: Fix: Homepage Navbar and Hero Section Responsiveness on Mobile (#3965)

### Description
This PR addresses layout issues on the main repository homepage (`index.html` & `style.css`) where the top navigation bar and hero section statistics were breaking or overflowing on smaller screens. 

**Changes Made:**
- **Navbar Layout Refactor:** Cleaned up duplicate `.navbar` CSS declarations. Updated the mobile `@media` queries to ensure the `.navbar-brand` and hamburger menu `.menu-toggle` share the same row without improperly wrapping. The logo text is allowed to gracefully scale down, preventing the toggle button from being pushed below the brand area.
- **Stats Strip Overflow:** Added `flex-wrap: wrap` and `justify-content: center` to `.stats-strip` on mobile view. This allows the project/star/fork counts to wrap cleanly to the next line instead of causing horizontal scroll clipping on narrow devices.

### Fixes
Fixes #3965 

### Checklist
- [x] Branch is up to date with `upstream/Main`.
- [x] No duplicate CSS rules.
- [x] Layout is verified on mobile view (Hamburger menu alignment & Stats wrapper).

### Screenshot

<img width="451" height="598" alt="image" src="https://github.com/user-attachments/assets/70332950-3a8d-4a70-9e32-63e7cc9b7811" />

