### PR TITLE
fix: dropdown option visibility in Chromium browsers

### DIFF
--- a/contributors/contributor.css
+++ b/contributors/contributor.css
@@ -608,6 +608,13 @@ body {
   padding-right: 3rem;
 }
 
+/* Dropdown Options Styling */
+
+.contributors-controls option {
+  background-color: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
 /* Empty State */
 
 .empty-state {


### PR DESCRIPTION
## Related Issue

Fixes #4125

---

## Description

Fixed the visibility issue in the contributors sorting dropdown for Chrome and Brave browsers. Added custom background and text color styling for the `<option>` elements to ensure the dropdown options remain visible without requiring hover interaction.

---

## Type of PR

* [x] Bug fix
* [ ] Feature enhancement
* [ ] Documentation update
* [ ] Security enhancement
* [ ] Other (specify): _______________

---

## Screenshots / Videos (if applicable)

Attached in the related issue.

---

## Checklist

* [x] I have performed a self-review of my code.
* [x] I have read and followed the Contribution Guidelines.
* [x] I have tested the changes thoroughly before submitting this pull request.
* [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have followed the code style guidelines of this project.
* [x] I have checked for any existing open issues that my pull request may address.
* [x] I have ensured that my changes do not break any existing functionality.
* [x] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
* [x] I have read the resources for guidance listed below.
* [x] I have followed security best practices in my code changes.

---

## Additional Context

The issue was reproducible in Chromium-based browsers such as Chrome and Brave, where dropdown option text became visible only on hover due to insufficient contrast between the option background and text color.
