### PR TITLE
fix(zen-timer): Fix timer drift using real clock timestamps #3926

### DIFF
--- a/public/ZEN_TIMER/script.js
+++ b/public/ZEN_TIMER/script.js
@@ -25,6 +25,10 @@ let currentMode = 'work';
 let sessionsToday = 0;
 let lastSessionDate = null;
 
+// Track real clock time to prevent timer drift on inactive tabs
+let timerStartTime = null;   // Date.now() when timer last started/resumed
+let timerStartLeft = null;   // timeLeft value when timer last started/resumed
+
 const timeDisplay = document.getElementById('timeDisplay');
 const startBtn = document.getElementById('startBtn');
 const resetBtn = document.getElementById('resetBtn');
@@ -175,20 +179,33 @@ function startTimer() {
         pauseTimer();
         return;
     }
-    
+
     isRunning = true;
     startBtn.textContent = 'Pause';
     startBtn.style.background = '#e67e22';
-    
+
+    // Record the real clock time and remaining seconds at start/resume
+    timerStartTime = Date.now();
+    timerStartLeft = timeLeft;
+
+    // Check twice per second for better accuracy
     timer = setInterval(() => {
-        timeLeft--;
+        // Calculate real elapsed seconds using actual clock — not tick count
+        const elapsed = Math.floor((Date.now() - timerStartTime) / 1000);
+        timeLeft = timerStartLeft - elapsed;
+
+        // Clamp to 0 so it never goes negative
+        if (timeLeft <= 0) {
+            timeLeft = 0;
+            updateDisplay();
+            updateProgress();
+            completeSession();
+            return;
+        }
+
         updateDisplay();
         updateProgress();
-        
-        if (timeLeft <= 0) {
-            completeSession();
-        }
-    }, 1000);
+    }, 500);
 }
 
 function pauseTimer() {
@@ -250,7 +267,21 @@ function setMode(mode) {
 }
 
 startBtn.addEventListener('click', startTimer);
-resetBtn.addEventListener('click', resetTimer);
+resetBtn.addEventListener('click', resetTimer); 
+// Sync timer when user returns to tab after it was hidden
+// This recalculates timeLeft based on real elapsed time
+document.addEventListener('visibilitychange', () => {
+    if (!document.hidden && isRunning) {
+        const elapsed = Math.floor((Date.now() - timerStartTime) / 1000);
+        timeLeft = timerStartLeft - elapsed;
+        if (timeLeft <= 0) {
+            timeLeft = 0;
+            completeSession();
+        }
+        updateDisplay();
+        updateProgress();
+    }
+});
 
 document.querySelectorAll('.mode-btn').forEach(btn => {
     btn.addEventListener('click', () => {


### PR DESCRIPTION
## Related Issue
Closes #3926

## Description
Fixes timer drift caused by `setInterval` being throttled on inactive browser tabs.

The original implementation decremented `timeLeft` by 1 on each interval tick,
assuming ticks fire exactly every 1000ms. Browsers throttle background tabs so
ticks slow down — causing the timer to fall behind real clock time.

**Root Cause:**
Old code decremented timeLeft by 1 per tick — assuming exactly 1 second per tick.
Browsers don't guarantee this, especially on inactive tabs.

**Fix Applied:**
Record Date.now() when timer starts. Calculate real elapsed seconds on every tick.
timeLeft is now always = timerStartLeft minus real elapsed seconds.
Also added visibilitychange listener to sync display instantly when user returns to tab.

**Changes in script.js:**
- Added timerStartTime and timerStartLeft variables
- Rewrote startTimer() to use real clock math instead of tick counting
- Set interval to 500ms for snappier display updates
- Added visibilitychange listener for instant sync on tab switch

## Type of PR
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other

## Screenshots / Videos
Not applicable — this is a timing logic fix. 
Test by starting timer, switching tabs for 10 seconds, returning — time stays accurate.

## Checklist
- [X] I have performed a self-review of my code.
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have followed the code style guidelines of this project.
- [X] I have checked for any existing open issues that my pull request may address.
- [X] I have ensured that my changes do not break any existing functionality.
- [X] Each contributor is allowed to create a maximum of 4 issues per day.
- [X] I have read the resources for guidance listed below.
- [X] I have followed security best practices in my code changes.

## Additional Context
Requested labels: `level:intermediate` `type:bug` `type:performance` `type:refactor`

---
*GSSoC 2026 | Mallya Moni | github.com/mallya-m*