### PR TITLE
fix: update tech stack dropdown to only show technologies with existing projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,25 +212,19 @@
         </div>
       </div>
 
-      <!-- Tech Stack Dropdown -->
-      <div style="margin: 20px 0 10px 0; display: flex; justify-content: flex-start; width: 100%;">
-        <select id="techStackFilter" style="width: 280px; padding: 12px 20px; border-radius: 30px; border: 1px solid #333; background: #1a1a1a; color: white; cursor: pointer; font-size: 14px;">
-          <option value="all">Filter by Tech Stack (All)</option>
-          <option value="HTML"> HTML</option>
-          <option value="CSS"> CSS</option>
-          <option value="JavaScript"> JavaScript</option>
-          <option value="React"> React</option>
-          <option value="Node.js"> Node.js</option>
-          <option value="Express"> Express</option>
-          <option value="MongoDB"> MongoDB</option>
-          <option value="Python"> Python</option>
-          <option value="Tailwind"> Tailwind</option>
-          <option value="Firebase"> Firebase</option>
-          <option value="Next.js"> Next.js</option>
-          <option value="TypeScript"> TypeScript</option>
-        </select>
-      </div>
-
+<!-- Tech Stack Dropdown - Only technologies that exist in projects -->
+<div style="margin: 20px 0 10px 0; display: flex; justify-content: flex-start; width: 100%;">
+  <select id="techStackFilter" style="width: 280px; padding: 12px 20px; border-radius: 30px; border: 1px solid #333; background: #1a1a1a; color: white; cursor: pointer; font-size: 14px;">
+    <option value="all">Filter by Tech Stack (All)</option>
+    <option value="javascript">JavaScript</option>
+    <option value="css">CSS</option>
+    <option value="html">HTML</option>
+    <option value="react">React</option>
+    <option value="python">Python</option>
+    <option value="typescript">TypeScript</option>
+    <option value="tailwindcss">Tailwind CSS</option>
+  </select>
+</div>
 
     <!-- Project Grid -->
     <div class="project-grid" id="projectGrid"></div>
@@ -343,7 +337,7 @@
   </button>
   <div class="toast" id="toast"></div>
   <script type="module" src="hero-terminal.js"></script>
-  <script src="index.js"></script>
+  <script src="index.js?v=3"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Fixes Issue #3837
The Tech Stack filter dropdown displays technologies like React, Node.js, Express, Python, etc., even though no projects are available for those categories.

## Changes Made
- Updated `index.html` tech stack dropdown
- Removed technologies with 0 projects (Node.js, Express, MongoDB, Firebase, Next.js)
- Kept only technologies that actually exist in projects:
  - JavaScript
  - CSS
  - HTML
  - React
  - Python
  - TypeScript
  - Tailwind CSS

## Before vs After

**Before (Issue #3837):** HTML, CSS, JavaScript, React, Node.js, Express, MongoDB, Python, Tailwind, Firebase, Next.js, TypeScript

**After:** JavaScript, CSS, HTML, React, Python, TypeScript, Tailwind CSS

## Testing
- Verified each technology in dropdown has at least one project
- No more "No projects match your search" for empty categories
- All filters work correctly

Fixes #3837