### PR TITLE
chore: add .editorconfig file for consistent editor settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## What does this PR do?
This PR adds a standard `.editorconfig` file in the root directory to maintain consistent formatting across all IDEs and editors.

## Why is this change needed?
To ensure all contributors automatically follow uniform settings for line endings, indentation styles, and trailing spaces.

## What changes were made?
* Added `.editorconfig` with standard configuration settings.

## How to test
1. Verify the `.editorconfig` is present in the project root.
2. Verify editors supporting EditorConfig auto-apply the standard settings.

## Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes

Fixes #4491