### PR TITLE
chore: add .gitattributes file to manage line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Auto normalize line endings
+* text=auto eol=lf
+
+# Custom overrides
+*.html text diff=html
+*.css text
+*.js text
+*.json text


### PR DESCRIPTION
## What does this PR do?
This PR adds a `.gitattributes` file in the root directory to manage line endings.

## Why is this change needed?
To enforce LF line normalization and avoid visual git noise or unnecessary CRLF modification diffs from cross-platform contributors.

## What changes were made?
* Added `.gitattributes` to normalize line endings.

## How to test
1. Clone the project and verify line endings are auto-normalized to LF.

## Checklist
* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes

Fixes #4492