### PR TITLE
fix: resolve blank homepage issue caused by canvas layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -2347,6 +2347,12 @@ body.light-mode .brand-mark {
     width: 100% !important;
     max-width: 300px !important;
   }
+  input, button, .btn {
+    width: 100% !important;
+    max-width: 300px !important;
+  }
+}
+
 /* ============================================================
    CANVAS FIX — particle canvas was pushing hero content down
    by occupying block layout space equal to window.innerHeight.


### PR DESCRIPTION
## Summary

Fixed the blank homepage issue caused by layout behavior from the particle canvas and CSS structure.

## Changes Made

* Corrected layout behavior affecting the homepage render
* Fixed CSS/media-query structure causing excessive blank space
* Ensured the hero section displays properly on page load

## Issue Fixed

Previously, users encountered a large blank section before the homepage content appeared. The issue was caused by layout interference from the background canvas layer.

## Testing

* Verified locally on desktop view
* Confirmed homepage now renders correctly without extra blank space
* Checked overall layout stability after the fix
<img width="1470" height="956" alt="Screenshot 2026-05-27 at 1 37 00 PM" src="https://github.com/user-attachments/assets/fe8c9f00-0669-4415-bd79-c6bc53c881b2" />
