### PR TITLE
fix: resolve virtual piano 404 error

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -979,7 +979,7 @@
 "projectDesc":"Playable piano simulation responding to keyboard or click inputs.",
 "techStack":["css","javascript"],
 "difficulty":"intermediate",
-"projectPath":"./public/Virtual Piano/index.html"
+"projectPath":"./public/Virtual_Piano/index.html"
 },
 
 {


### PR DESCRIPTION
## Related Issue
Closes #4149 

## Description
Fixed the 404 error for the Virtual Piano project. The project was listed on the website but the link was broken due to a path mismatch the folder name in `projects.json` had a space (`Virtual Piano`) instead of an underscore (`Virtual_Piano`). Updated the path to match the actual folder name on disk.

## Type of PR
- [X] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other (specify): _______________

## Screenshots / Videos (if applicable)
<img width="1919" height="861" alt="image" src="https://github.com/user-attachments/assets/a7582e5a-44c6-4875-843d-22f4633564d9" />


## Checklist
- [X] I have performed a self-review of my code.
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have followed the code style guidelines of this project.
- [X] I have checked for any existing open issues that my pull request may address.
- [X] I have ensured that my changes do not break any existing functionality.
- [X] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
- [X] I have read the resources for guidance listed below.
- [X] I have followed security best practices in my code changes.

## Additional Context
The Virtual Piano project files exist in the repository under `public/Virtual_Piano/` but the path in `projects.json` referenced `./public/Virtual Piano/index.html` (with a space), causing a 404 on all browsers. This is a one-line fix that restores the project for all users.
