### PR TITLE
perf: debounce search and tech stack filter inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1433,24 +1433,20 @@ function initTechStackSearch() {
 
   if (!input) return;
 
-  let debounceTimer;
+  // Use the shared debounce utility instead of a manual inline timer
+  input.addEventListener('input', debounce((e) => {
+    const value = e.target.value.trim().toLowerCase();
 
-  input.addEventListener('input', (e) => {
-    clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(() => {
-      const value = e.target.value.trim().toLowerCase();
-
-      if (value) {
-        const techs = value.split(/[,\s]+/).filter(t => t.length > 0);
-        techStackFilters = [...new Set(techs)];
-        updateTechFilterDisplay();
-        currentPage = 1;
-        renderGrid();
-      } else {
-        clearAllTechFilters();
-      }
-    }, 300);
-  });
+    if (value) {
+      const techs = value.split(/[,\s]+/).filter(t => t.length > 0);
+      techStackFilters = [...new Set(techs)];
+      updateTechFilterDisplay();
+      currentPage = 1;
+      renderGrid();
+    } else {
+      clearAllTechFilters();
+    }
+  }, 300));
 
   if (clearBtn) {
     clearBtn.addEventListener('click', () => {
@@ -2021,11 +2017,12 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.querySelector('input[type="text"]') ||
     document.querySelector('.search-input');
   if (searchInput) {
-    searchInput.addEventListener('input', () => {
+    // Debounced so rapid typing doesn't trigger a renderGrid() on every keystroke
+    searchInput.addEventListener('input', debounce(() => {
       const { category } = getQueryParams();
       updateURL(searchInput.value, category);
       applyFilters(searchInput.value, category);
-    });
+    }, 200));
   }
   const categoryFilter = document.getElementById('category');
   if (categoryFilter) {


### PR DESCRIPTION
## Summary

Implemented debounce optimization for search and tech stack filtering to reduce unnecessary re-renders during rapid typing.

## Changes Made

* Reused the existing shared `debounce()` utility
* Applied debounce to the main search input listener
* Replaced manual timeout logic in tech stack search with the reusable debounce utility
* Applied debounce to persistent search state updates

## Result

* Reduced unnecessary `renderGrid()` calls
* Improved responsiveness while typing
* Preserved existing filtering and pagination behavior

## Screenshots

<img width="1919" height="908" alt="image" src="https://github.com/user-attachments/assets/b25ce494-7cd0-4a34-956a-de6beccd204c" />

Search filtering after debounce optimization

Fixes #4320
