### PR TITLE
Fix: Add accessible labels to homepage filter controls (Issue #4255)

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,6 +195,7 @@
             class="search-input"
             placeholder="Search projects…"
             autocomplete="off"
+            aria-label="Search projects"
           />
           <button id="clearSearch" class="clear-btn" aria-label="Clear search" type="button">
             &times;
@@ -216,7 +217,7 @@
 
       <!-- Tech Stack Dropdown & Clear Filters -->
       <div style="margin: 20px 0 10px 0; display: flex; justify-content: flex-start; align-items: center; gap: 15px; width: 100%; flex-wrap: wrap;">
-        <select id="techStackFilter" style="width: 280px; padding: 12px 20px; border-radius: 30px; border: 1px solid #333; background: #1a1a1a; color: white; cursor: pointer; font-size: 14px;">
+        <select id="techStackFilter" style="width: 280px; padding: 12px 20px; border-radius: 30px; border: 1px solid #333; background: #1a1a1a; color: white; cursor: pointer; font-size: 14px;" aria-label="Filter by tech stack">
           <option value="all">Filter by Tech Stack (All)</option>
           <option value="HTML"> HTML</option>
           <option value="CSS"> CSS</option>
@@ -235,20 +236,6 @@
           <i class="fas fa-filter-circle-xmark"></i> Clear Filters
         </button>
       </div>
-
-<!-- Tech Stack Dropdown - Only technologies that exist in projects -->
-<div style="margin: 20px 0 10px 0; display: flex; justify-content: flex-start; width: 100%;">
-  <select id="techStackFilter" style="width: 280px; padding: 12px 20px; border-radius: 30px; border: 1px solid #333; background: #1a1a1a; color: white; cursor: pointer; font-size: 14px;">
-    <option value="all">Filter by Tech Stack (All)</option>
-    <option value="javascript">JavaScript</option>
-    <option value="css">CSS</option>
-    <option value="html">HTML</option>
-    <option value="react">React</option>
-    <option value="python">Python</option>
-    <option value="typescript">TypeScript</option>
-    <option value="tailwindcss">Tailwind CSS</option>
-  </select>
-</div>
 
     <!-- Project Grid -->
     <div class="project-grid" id="projectGrid"></div>


### PR DESCRIPTION
## Description

Fixes #4255

This PR improves homepage accessibility by adding proper ARIA labels to the project archive filter controls, ensuring better screen reader support and keyboard navigation usability.

## Changes Made

* Added `aria-label="Search projects"` to `#searchInput`
* Added `aria-label="Filter by tech stack"` to `#techStackFilter`
* Removed duplicate `id="techStackFilter"` element causing HTML validation issues

## Accessibility Improvements

* Screen readers can now correctly announce both controls
* Improved accessibility for keyboard and assistive technology users
* Removed duplicate IDs to maintain valid semantic HTML
* Better compliance with WCAG 2.1 accessibility guidelines

## Testing

* ✅ HTMLHint passes with 0 errors
* ✅ No UI/layout regressions
* ✅ Existing search and filtering functionality preserved
* ✅ Keyboard navigation verified

## Notes

* No breaking changes
* No unnecessary refactoring
* Accessibility-focused minimal fix only
