### PR TITLE
fix: add activate handler to service-worker.js to evict stale caches

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -15,6 +15,21 @@ self.addEventListener('install', (event) => {
   );
 });
 
+// Delete any caches whose name does not match the current CACHE_NAME.
+// Without this handler, old caches accumulate across deployments and
+// returning users continue to receive stale assets indefinitely.
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames
+          .filter((name) => name !== CACHE_NAME)
+          .map((name) => caches.delete(name))
+      );
+    })
+  );
+});
+
 self.addEventListener('fetch', (event) => {
   event.respondWith(
     caches.match(event.request).then((response) => {


### PR DESCRIPTION
## Summary

Closes #4209

The service worker had `install` and `fetch` handlers but no `activate` handler. When `CACHE_NAME` is bumped to deploy a new version, the old cache is never cleaned up. Returning users continue to receive stale HTML, CSS, and JS assets from the previous cached version until they manually clear site data.

## Change

`service-worker.js`: Added an `activate` event handler that iterates all existing cache keys and deletes any whose name does not match the current `CACHE_NAME`. This is the standard pattern for cache versioning in service workers.

```js
self.addEventListener('activate', (event) => {
  event.waitUntil(
    caches.keys().then((cacheNames) => {
      return Promise.all(
        cacheNames
          .filter((name) => name !== CACHE_NAME)
          .map((name) => caches.delete(name))
      );
    })
  );
});
```

## Test plan

- [ ] After bumping `CACHE_NAME` to `v2`, the old `v1` cache is deleted on the first `activate` event for the new worker
- [ ] Current `CACHE_NAME` cache is preserved (not deleted)
- [ ] `fetch` handler continues to serve cached assets normally

Could you please add the appropriate GSSoC labels (`gssoc26`, `type:bug`, `level:beginner`) when you get a chance? Thank you!