### PR TITLE
fix: show description in renderRecentProjects() cards

### DIFF
--- a/index.js
+++ b/index.js
@@ -933,7 +933,7 @@ function renderRecentProjects() {
       tags,
       category,
       isBookmarked,
-      showDescription: false,
+      showDescription: true,
     });
 
     card.className = sourceOnly ? 'project-card source-only' : 'project-card';


### PR DESCRIPTION
## Summary

Closes #4210

`renderRecentProjects()` called `buildProjectCardHTML` with `showDescription: false`, which omitted the `.card-description` block entirely. The main grid (`renderGrid`) and the Bookmarks panel (`renderBookmarks`) both pass `showDescription: true`, so only the Recently Viewed panel was missing the description, making those cards visually shorter and inconsistent.

## Change

`index.js`: Changed `showDescription: false` to `showDescription: true` in the `buildProjectCardHTML` call inside `renderRecentProjects()`.

## Test plan

- [ ] View a project to add it to the Recently Viewed panel
- [ ] Confirm the Recently Viewed card shows a description below the project name
- [ ] Confirm the card layout matches the main grid and Bookmarks panel cards

Could you please add the appropriate GSSoC labels (`gssoc26`, `type:bug`, `level:beginner`) when you get a chance? Thank you!