### PR TITLE
fix: use whole-word token matching in matchesTechStack()

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,8 +278,9 @@ function normalizeTech(tech) {
 }
 
 /**
- * Check if project matches the active tech stack filters
- * EFFICIENT APPROACH: Direct string matching without complex transformations
+ * Check if project matches the active tech stack filters.
+ * Each filter must match a complete tag token, not a substring of another tag.
+ * Example: searching "java" must not return projects tagged "javascript".
  * @param {string|array} projectTags - Project tags (space-separated string or array)
  * @returns {boolean} True if project matches all active filters
  */
@@ -290,12 +291,17 @@ function matchesTechStack(projectTags) {
   // Handle empty or missing tags
   if (!projectTags) return false;
 
-  // Convert to single lowercase string for efficient matching
-  const tagsLower = (typeof projectTags === 'string' ? projectTags : projectTags.join(' ')).toLowerCase();
+  // Normalize to a set of individual lowercase tokens for whole-word matching.
+  // Using a Set avoids repeated linear scans for each filter.
+  const tagSet = new Set(
+    (Array.isArray(projectTags) ? projectTags : String(projectTags).split(/\s+/))
+      .map((t) => t.toLowerCase().trim())
+      .filter(Boolean)
+  );
 
-  // EFFICIENT: Check if ALL filters exist in tags (AND logic)
-  // Uses simple includes() - O(n*m) where n=filters, m=tag length
-  return techStackFilters.every(filter => tagsLower.includes(filter));
+  // Every active filter must match an exact token in the tag set (AND logic).
+  // This prevents "java" from matching "javascript", "css" from matching "canvas", etc.
+  return techStackFilters.every((filter) => tagSet.has(filter.toLowerCase()));
 }
 
 


### PR DESCRIPTION
## Summary

Closes #4211

`matchesTechStack()` used `String.prototype.includes()` against the entire joined tag string, performing a raw substring match. This caused false positives:

| Search term | Unintended matches |
|---|---|
| `java` | All JavaScript projects (tag contains "java" as a substring) |
| `css` | Canvas projects (tag contains "cs") |
| `c` | Every project with any tag |

## Fix

`index.js`: Changed `matchesTechStack()` to:
1. Split the project's tag array (or space-separated string) into individual lowercase tokens
2. Store the tokens in a `Set` for O(1) lookup
3. Check each active filter with `tagSet.has(filter)` (exact token match, not substring)

```js
const tagSet = new Set(
  (Array.isArray(projectTags) ? projectTags : String(projectTags).split(/\s+/))
    .map((t) => t.toLowerCase().trim())
    .filter(Boolean)
);
return techStackFilters.every((filter) => tagSet.has(filter.toLowerCase()));
```

This ensures "java" only matches projects explicitly tagged "java", not "javascript".

## Test plan

- [ ] Searching "javascript" returns JavaScript projects but not Java-only projects
- [ ] Searching "java" does NOT return JavaScript projects  
- [ ] Searching "css" does NOT return Canvas projects
- [ ] Existing tech stack chips (api, game, tool, etc.) still filter correctly
- [ ] Multiple active filters use AND logic (project must have all filtered tags)

Could you please add the appropriate GSSoC labels (`gssoc26`, `type:bug`, `level:beginner`) when you get a chance? Thank you!