### PR TITLE
fix: prevent pagination from scrolling to top when user is already in project grid

### DIFF
--- a/index.js
+++ b/index.js
@@ -754,6 +754,10 @@ function scrollToProjectSection() {
   const header = document.querySelector('.projects-header');
   if (!header) return;
 
+  // Only scroll if the projects section is fully below the viewport.
+  // If the user is already within or past the project grid, don't move them.
+  if (header.getBoundingClientRect().top < window.innerHeight) return;
+
   const navbar = document.querySelector('.navbar');
   // Subtract height of fixed navbar with a 50px buffer to prevent overlaying the search bar
   const offset = navbar ? navbar.offsetHeight - 50 : 30;


### PR DESCRIPTION
## Related Issue
Closes #4346

## Description
Pagination buttons (previous, next, page numbers) were calling 
`scrollToProjectSection()` on every click unconditionally, scrolling 
the user back to the top of the project grid every time they changed 
pages. This forced them to scroll back down repeatedly just to use 
pagination — poor UX.

**Fix:** Added a one-line guard in `scrollToProjectSection()` in `index.js` 
that checks if the projects header is already visible or scrolled past. 
If so, the function returns early without scrolling. Scroll only triggers 
when the user is completely above the project section.

**File changed:** `index.js` — `scrollToProjectSection()` function

## Type of PR
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other (specify): _______________

## Screenshots / Videos (if applicable)
Tested locally — clicking next/prev page while scrolled into the project 
grid no longer jumps back to the top. Scroll-to-section still works 
correctly when the user hasn't reached the projects section yet.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have followed the code style guidelines of this project.
- [x] I have checked for any existing open issues that my pull request may address.
- [x] I have ensured that my changes do not break any existing functionality.
- [x] Each contributor is allowed to create a maximum of 4 issues per day. This helps us manage and address issues efficiently.
- [x] I have read the resources for guidance listed below.
- [x] I have followed security best practices in my code changes.

## Additional Context
Only `index.js` was modified. No styles, project files, or data files were changed.