### PR TITLE
Bug Fix: Stats Bar Does Not Update Properly When Switching to Light Mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -2347,7 +2347,7 @@ body.light-mode .noise-layer {
   .projects-header {
     align-items: stretch;
   }
-
+}
   body.light-mode .stats-strip {
     background: rgba(255, 255, 255, 0.85);
     box-shadow:
@@ -2359,7 +2359,7 @@ body.light-mode .noise-layer {
     background: linear-gradient(180deg, rgba(59, 130, 246, 0.15), rgba(255, 255, 255, 0.9));
     border: 1px solid rgba(0, 0, 0, 0.08);
   }
-}
+
 
 @media (prefers-reduced-motion: reduce) {
   html {


### PR DESCRIPTION
## Fix Theme Switching Issue in Stats Bar
Fixes #<4714>




## Description

This pull request resolves the theme switching inconsistency in the stats bar section of the landing page.

The stats bar previously retained a dark background in light mode, which caused poor contrast and an inconsistent visual appearance. With this update, the component now adapts properly to both light and dark themes, improving readability and overall UI consistency.


## Type of PR

- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other (specify): _______________


check in issue by entering [X] in boxes

## Screenshots / Videos (if applicable)

[Attach any relevant screenshots or videos demonstrating the changes]

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have read and followed the Contribution Guidelines.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.

## Additional Context
##Before
<img width="1906" height="922" alt="Screenshot 2026-05-28 122038" src="https://github.com/user-attachments/assets/6b37be9e-aadc-4453-ba7e-7525bced805e" />
##After
<img width="1909" height="924" alt="image" src="https://github.com/user-attachments/assets/a6d257fe-76d9-493a-889b-5526bab187b7" />



