### PR TITLE
fix: pause timed mode automatically during tab inactivity

### DIFF
--- a/public/2048_game/script.js
+++ b/public/2048_game/script.js
@@ -21,56 +21,59 @@
    ========================================================= */
 
 const TILE_STYLES = {
-  2:    { fontSize: '36px' },
-  4:    { fontSize: '36px' },
-  8:    { fontSize: '36px' },
-  16:   { fontSize: '36px' },
-  32:   { fontSize: '36px' },
-  64:   { fontSize: '36px' },
-  128:  { fontSize: '28px' },
-  256:  { fontSize: '28px' },
-  512:  { fontSize: '28px' },
+  2: { fontSize: '36px' },
+  4: { fontSize: '36px' },
+  8: { fontSize: '36px' },
+  16: { fontSize: '36px' },
+  32: { fontSize: '36px' },
+  64: { fontSize: '36px' },
+  128: { fontSize: '28px' },
+  256: { fontSize: '28px' },
+  512: { fontSize: '28px' },
   1024: { fontSize: '22px' },
   2048: { fontSize: '22px' },
 };
 
-
 const PARTICLE_COLORS = ['#ff6b6b', '#ffd54f', '#69f0ae', '#4fc3f7', '#e040fb', '#ff9800'];
 
 const ACHIEVEMENTS = [
-  { id: 'first256',  label: 'Quarter Way',  desc: 'Reach 256',             check: (b) => maxTile(b) >= 256  },
-  { id: 'first512',  label: 'Halfway',      desc: 'Reach 512',             check: (b) => maxTile(b) >= 512  },
-  { id: 'first1024', label: 'So Close',     desc: 'Reach 1024',            check: (b) => maxTile(b) >= 1024 },
-  { id: 'first2048', label: 'Winner!',      desc: 'Reach 2048',            check: (b) => maxTile(b) >= 2048 },
-  { id: 'moves100',  label: 'Century',      desc: 'Play 100 moves',        check: () => moves >= 100        },
-  { id: 'score2000', label: 'High Scorer',  desc: 'Score over 2000',       check: () => score >= 2000       },
+  { id: 'first256', label: 'Quarter Way', desc: 'Reach 256', check: (b) => maxTile(b) >= 256 },
+  { id: 'first512', label: 'Halfway', desc: 'Reach 512', check: (b) => maxTile(b) >= 512 },
+  { id: 'first1024', label: 'So Close', desc: 'Reach 1024', check: (b) => maxTile(b) >= 1024 },
+  { id: 'first2048', label: 'Winner!', desc: 'Reach 2048', check: (b) => maxTile(b) >= 2048 },
+  { id: 'moves100', label: 'Century', desc: 'Play 100 moves', check: () => moves >= 100 },
+  { id: 'score2000', label: 'High Scorer', desc: 'Score over 2000', check: () => score >= 2000 },
 ];
 
 const COMBO_LABELS = {
-  3: '3× combo!', 4: '4× chain!', 5: 'On fire!',
-  6: 'Inferno!',  7: 'Unstoppable!', 8: 'LEGENDARY!',
+  3: '3× combo!',
+  4: '4× chain!',
+  5: 'On fire!',
+  6: 'Inferno!',
+  7: 'Unstoppable!',
+  8: 'LEGENDARY!',
 };
 
 /* =========================================================
    State
    ========================================================= */
 
-let N        = 4;       // grid size
-let TS       = 94;      // tile size in px
-let GAP      = 10;      // gap between tiles
-let PAD      = 12;      // board padding
+let N = 4; // grid size
+let TS = 94; // tile size in px
+let GAP = 10; // gap between tiles
+let PAD = 12; // board padding
 let paused = false;
-let board, score, best, prevBoard, prevScore; 
-let moves    = 0;
-let combo    = 0;
-let over     = false;
-let won      = false;
-let dark     = false;
-let soundOn  = true;
-let mode     = 'classic';
+let board, score, best, prevBoard, prevScore;
+let moves = 0;
+let combo = 0;
+let over = false;
+let won = false;
+let dark = false;
+let soundOn = true;
+let mode = 'classic';
 
 let timerInterval = null;
-let timeLeft      = 60;
+let timeLeft = 60;
 
 let confettiFrameId = null;
 let confettiParticles = [];
@@ -81,12 +84,17 @@ let stats = { best: 0, games: 0, wins: 0, bestTile: 2, earned: [] };
    Persistence
    ========================================================= */
 
-function loadStats () {
-  try { const s = localStorage.getItem('2048stats'); if (s) stats = JSON.parse(s); } catch (_) {}
+function loadStats() {
+  try {
+    const s = localStorage.getItem('2048stats');
+    if (s) stats = JSON.parse(s);
+  } catch (_) {}
 }
 
-function saveStats () {
-  try { localStorage.setItem('2048stats', JSON.stringify(stats)); } catch (_) {}
+function saveStats() {
+  try {
+    localStorage.setItem('2048stats', JSON.stringify(stats));
+  } catch (_) {}
 }
 
 function logGameScore(s) {
@@ -110,28 +118,27 @@ function togglePause() {
     document.getElementById('ov').style.display = 'none';
   }
 
-// REPLACE this entire function:
-function showOverlayPause() {
-  const ov = document.getElementById('ov');
-  ov.className = 'ov';
-  ov.innerHTML = `
+  // REPLACE this entire function:
+  function showOverlayPause() {
+    const ov = document.getElementById('ov');
+    ov.className = 'ov';
+    ov.innerHTML = `
     <div class="ov-title" style="color:#4fc3f7">⏸ Paused</div>
     <div class="ov-sub">Game is paused</div>
     <button class="btn" id="ov-resume-btn">▶ Resume</button>
   `;
-  ov.style.display = 'flex';
-  document.getElementById('ov-resume-btn').addEventListener('click', togglePause);
+    ov.style.display = 'flex';
+    document.getElementById('ov-resume-btn').addEventListener('click', togglePause);
+  }
 }
-}x
-
 
 function drawScoreGraph() {
   const history = stats.scoreHistory || [];
   const cv = document.getElementById('score-graph');
   if (!cv || history.length < 2) return;
   const ctx = cv.getContext('2d');
-  const W = cv.width = cv.offsetWidth || 260;
-  const H = cv.height = 80;
+  const W = (cv.width = cv.offsetWidth || 260);
+  const H = (cv.height = 80);
   ctx.clearRect(0, 0, W, H);
   const max = Math.max(...history, 1);
   const step = W / (history.length - 1);
@@ -155,46 +162,62 @@ function drawScoreGraph() {
   });
 }
 
-
-function loadBest () {
-  try { return parseInt(localStorage.getItem('2048best'), 10) || 0; } catch (_) { return 0; }
+function loadBest() {
+  try {
+    return parseInt(localStorage.getItem('2048best'), 10) || 0;
+  } catch (_) {
+    return 0;
+  }
 }
 
-function saveBest () {
-  try { localStorage.setItem('2048best', best); } catch (_) {}
+function saveBest() {
+  try {
+    localStorage.setItem('2048best', best);
+  } catch (_) {}
 }
 
-function saveGame () {
-  try { localStorage.setItem('2048state', JSON.stringify({ board, score, moves, mode })); } catch (_) {}
+function saveGame() {
+  try {
+    localStorage.setItem('2048state', JSON.stringify({ board, score, moves, mode }));
+  } catch (_) {}
 }
 
-function loadGame () {
+function loadGame() {
   try {
     const s = localStorage.getItem('2048state');
     if (!s) return false;
     const d = JSON.parse(s);
-    board = d.board; score = d.score; moves = d.moves || 0; mode = d.mode || 'classic';
+    board = d.board;
+    score = d.score;
+    moves = d.moves || 0;
+    mode = d.mode || 'classic';
     return true;
-  } catch (_) { return false; }
+  } catch (_) {
+    return false;
+  }
 }
 
-function clearSavedGame () {
-  try { localStorage.removeItem('2048state'); } catch (_) {}
+function clearSavedGame() {
+  try {
+    localStorage.removeItem('2048state');
+  } catch (_) {}
 }
 
 /* =========================================================
    Board helpers
    ========================================================= */
 
-function copyBoard (b) { return b.map(row => [...row]); }
+function copyBoard(b) {
+  return b.map((row) => [...row]);
+}
 
-function maxTile (b = board) {
+function maxTile(b = board) {
   let m = 0;
   for (let r = 0; r < N; r++) for (let c = 0; c < N; c++) m = Math.max(m, b[r][c]);
   return m;
 }
 
-function addTile (b = board) {
+function addTile(b = board) {
   const empty = [];
   for (let r = 0; r < N; r++) for (let c = 0; c < N; c++) if (!b[r][c]) empty.push([r, c]);
   if (!empty.length) return null;
@@ -203,8 +226,7 @@ function addTile (b = board) {
   return [r, c];
 }
 
-function tilePos (r, c) {
-
+function tilePos(r, c) {
   let scale = 1;
 
   if (window.innerWidth <= 415) scale = 0.88;
@@ -213,8 +235,8 @@ function tilePos (r, c) {
   const step = (TS + GAP) * scale;
 
   return {
-    top:  PAD * scale + r * step,
-    left: PAD * scale + c * step
+    top: PAD * scale + r * step,
+    left: PAD * scale + c * step,
   };
 }
 
@@ -222,8 +244,7 @@ function tilePos (r, c) {
    Board dimensions by mode
    ========================================================= */
 
-function applyGridDimensions () {
-
+function applyGridDimensions() {
   if (mode === 'zen') {
     N = 5;
   } else {
@@ -232,23 +253,24 @@ function applyGridDimensions () {
 
   const styles = getComputedStyle(document.documentElement);
 
-  TS  = parseInt(styles.getPropertyValue('--tile-size'));
+  TS = parseInt(styles.getPropertyValue('--tile-size'));
   GAP = parseInt(styles.getPropertyValue('--tile-gap'));
   PAD = parseInt(styles.getPropertyValue('--board-pad'));
 
   const bd = document.getElementById('bd');
 
   bd.style.gridTemplateColumns = `repeat(${N}, ${TS}px)`;
-  bd.style.gridTemplateRows    = `repeat(${N}, ${TS}px)`;
+  bd.style.gridTemplateRows = `repeat(${N}, ${TS}px)`;
 }
 
 /* =========================================================
    Slide logic (left-direction; board gets rotated as needed)
    ========================================================= */
 
-function slideRow (row) {
-  const arr = row.filter(x => x);
-  let pts = 0, didMerge = false;
+function slideRow(row) {
+  const arr = row.filter((x) => x);
+  let pts = 0,
+    didMerge = false;
   for (let i = 0; i < arr.length - 1; i++) {
     if (arr[i] === arr[i + 1] && !didMerge) {
       arr[i] *= 2;
@@ -263,7 +285,7 @@ function slideRow (row) {
   return { row: arr, pts };
 }
 
-function rotateBoard (b, turns) {
+function rotateBoard(b, turns) {
   let out = b;
   for (let t = 0; t < turns; t++) {
     const tmp = Array.from({ length: N }, () => Array(N).fill(0));
@@ -277,7 +299,7 @@ function rotateBoard (b, turns) {
    Core move
    ========================================================= */
 
-function doMove (dir) {
+function doMove(dir) {
   if (over) return;
 
   prevBoard = copyBoard(board);
@@ -292,19 +314,28 @@ function doMove (dir) {
   for (let r = 0; r < N; r++) {
     const res = slideRow([...tmp[r]]);
     if (res.row.some((v, i) => v !== tmp[r][i])) moved = true;
-    for (let c = 0; c < N; c++) if (res.row[c] > tmp[r][c] && res.row[c] > 0) mergePositions.push({ r, c, v: res.row[c] });
+    for (let c = 0; c < N; c++)
+      if (res.row[c] > tmp[r][c] && res.row[c] > 0) mergePositions.push({ r, c, v: res.row[c] });
     tmp[r] = res.row;
     pts += res.pts;
   }
 
-  if (!moved) { combo = 0; return; }
+  if (!moved) {
+    combo = 0;
+    return;
+  }
 
   board = rotateBoard(tmp, (4 - rotTurns[dir]) % 4);
   score += pts;
   moves++;
 
-  if (pts > 0) { combo++; playSound('merge'); }
-  else         { combo = 0; playSound('move'); }
+  if (pts > 0) {
+    combo++;
+    playSound('merge');
+  } else {
+    combo = 0;
+    playSound('move');
+  }
 
   if (score > best) {
     best = score;
@@ -331,34 +362,34 @@ function doMove (dir) {
     saveStats();
     clearSavedGame();
     if (mode === 'timed') clearInterval(timerInterval);
-    setTimeout(() => { showOverlay('win'); launchConfetti(); }, 300);
+    setTimeout(() => {
+      showOverlay('win');
+      launchConfetti();
+    }, 300);
     return;
   }
 
   if (isLost()) {
     over = true;
-    showToast(
-      reviveChance > 0
-      ? `Chance left: ${reviveChance}`
-      : 'No chances left'
-    );
+    showToast(reviveChance > 0 ? `Chance left: ${reviveChance}` : 'No chances left');
     if (mode === 'timed') clearInterval(timerInterval);
     stats.games++;
     stats.best = Math.max(stats.best, score);
     stats.bestTile = Math.max(stats.bestTile, mt);
-    logGameScore(score); 
+    logGameScore(score);
     saveStats();
     clearSavedGame();
     setTimeout(() => showOverlay('lose'), 350);
   }
 }
 
-function isLost () {
-  for (let r = 0; r < N; r++) for (let c = 0; c < N; c++) {
-    if (!board[r][c]) return false;
-    if (c < N - 1 && board[r][c] === board[r][c + 1]) return false;
-    if (r < N - 1 && board[r][c] === board[r + 1][c]) return false;
-  }
+function isLost() {
+  for (let r = 0; r < N; r++)
+    for (let c = 0; c < N; c++) {
+      if (!board[r][c]) return false;
+      if (c < N - 1 && board[r][c] === board[r][c + 1]) return false;
+      if (r < N - 1 && board[r][c] === board[r + 1][c]) return false;
+    }
   return true;
 }
 
@@ -366,26 +397,27 @@ function isLost () {
    Initialise / restart
    ========================================================= */
 
-function init (resume = false) {
+function init(resume = false) {
   applyGridDimensions();
 
   let didResume = false;
   if (resume) didResume = loadGame();
 
   if (!didResume) {
-    board    = Array.from({ length: N }, () => Array(N).fill(0));
-    score    = 0;
-    moves    = 0;
-    combo    = 0;
-    over     = false;
-    won      = false;
+    board = Array.from({ length: N }, () => Array(N).fill(0));
+    score = 0;
+    moves = 0;
+    combo = 0;
+    paused = false;
+    over = false;
+    won = false;
     prevBoard = null;
     prevScore = 0;
     addTile();
     addTile();
   } else {
-    over  = false;
-    won   = false;
+    over = false;
+    won = false;
     combo = 0;
     prevBoard = null;
   }
@@ -408,82 +440,90 @@ function init (resume = false) {
    Timer (timed mode)
    ========================================================= */
 
-function startTimer () {
+function startTimer() {
+  clearInterval(timerInterval);
+
   updateTimerBar();
+
   timerInterval = setInterval(() => {
+    if (paused || over) return;
+
     timeLeft--;
+
     updateTimerBar();
+
     if (timeLeft <= 0) {
       clearInterval(timerInterval);
+
       over = true;
+
       setTimeout(() => showOverlay('lose'), 200);
     }
   }, 1000);
 }
 
-function updateTimerBar () {
+function updateTimerBar() {
   const fill = document.getElementById('tfill');
-  fill.style.width = (timeLeft / 60 * 100) + '%';
+  fill.style.width = (timeLeft / 60) * 100 + '%';
   fill.className = 'timer-fill' + (timeLeft <= 15 ? ' danger' : '');
 }
-
-
 
 /* =========================================================
    Rendering
    ========================================================= */
-function renderBoard () {
+function renderBoard() {
   const bd = document.getElementById('bd');
   bd.innerHTML = '';
   const size = PAD * 2 + N * TS + (N - 1) * GAP;
   bd.style.width = size + 'px';
   bd.style.height = size + 'px';
   const tl = document.getElementById('tl');
-  tl.style.width  = size + 'px';
+  tl.style.width = size + 'px';
   tl.style.height = size + 'px';
 
   for (let i = 0; i < N * N; i++) {
     const cell = document.createElement('div');
     cell.className = 'cell';
-    cell.style.width  = TS + 'px';
+    cell.style.width = TS + 'px';
     cell.style.height = TS + 'px';
     bd.appendChild(cell);
   }
 }
 
-function renderTiles (newCell, pts, merges) {
+function renderTiles(newCell, pts, merges) {
   const tl = document.getElementById('tl');
   tl.innerHTML = '';
 
-  for (let r = 0; r < N; r++) for (let c = 0; c < N; c++) {
-    const v = board[r][c];
-    if (!v) continue;
+  for (let r = 0; r < N; r++)
+    for (let c = 0; c < N; c++) {
+      const v = board[r][c];
+      if (!v) continue;
 
-    const { top, left } = tilePos(r, c);
-    const isMerge  = merges && merges.some(m => m.r === r && m.c === c);
-    const isNew    = newCell && newCell[0] === r && newCell[1] === c;
-    const style    = TILE_STYLES[v] || { fontSize: '16px' };
-    const dataAttr = TILE_STYLES[v] ? String(v) : 'big';
+      const { top, left } = tilePos(r, c);
+      const isMerge = merges && merges.some((m) => m.r === r && m.c === c);
+      const isNew = newCell && newCell[0] === r && newCell[1] === c;
+      const style = TILE_STYLES[v] || { fontSize: '16px' };
+      const dataAttr = TILE_STYLES[v] ? String(v) : 'big';
 
-    const el = document.createElement('div');
-    el.className  = 'tile' + (isNew ? ' new' : isMerge ? ' merged' : '');
-    el.dataset.val = dataAttr;
-    el.style.top     = top  + 'px';
-    el.style.left    = left + 'px';
-    el.style.width   = TS   + 'px';
-    el.style.height  = TS   + 'px';
-    el.style.fontSize = style.fontSize;
-    el.textContent   = v;
-    tl.appendChild(el);
+      const el = document.createElement('div');
+      el.className = 'tile' + (isNew ? ' new' : isMerge ? ' merged' : '');
+      el.dataset.val = dataAttr;
+      el.style.top = top + 'px';
+      el.style.left = left + 'px';
+      el.style.width = TS + 'px';
+      el.style.height = TS + 'px';
+      el.style.fontSize = style.fontSize;
+      el.textContent = v;
+      tl.appendChild(el);
 
-    if (isMerge) spawnParticles(left + TS / 2, top + TS / 2, tl);
-  }
+      if (isMerge) spawnParticles(left + TS / 2, top + TS / 2, tl);
+    }
 
   if (pts > 0) {
     const fp = document.createElement('div');
     fp.className = 'score-float';
-    fp.style.top  = (PAD + 6) + 'px';
-    fp.style.left = (PAD + 4) + 'px';
+    fp.style.top = PAD + 6 + 'px';
+    fp.style.left = PAD + 4 + 'px';
     fp.textContent = '+' + pts.toLocaleString();
     tl.appendChild(fp);
     setTimeout(() => fp.remove(), 750);
@@ -497,21 +537,21 @@ function renderTiles (newCell, pts, merges) {
   }
 }
 
-function spawnParticles (cx, cy, parent) {
+function spawnParticles(cx, cy, parent) {
   const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   if (reduced) return;
 
   for (let i = 0; i < 8; i++) {
     const angle = Math.random() * Math.PI * 2;
-    const dist  = 28 + Math.random() * 28;
-    const px    = Math.cos(angle) * dist;
-    const py    = Math.sin(angle) * dist;
+    const dist = 28 + Math.random() * 28;
+    const px = Math.cos(angle) * dist;
+    const py = Math.sin(angle) * dist;
     const color = PARTICLE_COLORS[Math.floor(Math.random() * PARTICLE_COLORS.length)];
 
     const p = document.createElement('div');
     p.className = 'particle';
-    p.style.left       = (cx - 3.5) + 'px';
-    p.style.top        = (cy - 3.5) + 'px';
+    p.style.left = cx - 3.5 + 'px';
+    p.style.top = cy - 3.5 + 'px';
     p.style.background = color;
     p.style.setProperty('--px', px + 'px');
     p.style.setProperty('--py', py + 'px');
@@ -520,7 +560,7 @@ function spawnParticles (cx, cy, parent) {
   }
 }
 
-function updateUI () {
+function updateUI() {
   const sv = document.getElementById('sv');
   sv.textContent = score.toLocaleString();
   sv.classList.remove('bump');
@@ -530,11 +570,13 @@ function updateUI () {
   document.getElementById('bv').textContent = best.toLocaleString();
   document.getElementById('moves-val').textContent = moves;
 
-  let tileCount = 0, mt = 0;
-  for (let r = 0; r < N; r++) for (let c = 0; c < N; c++) {
-    if (board[r][c]) tileCount++;
-    mt = Math.max(mt, board[r][c]);
-  }
+  let tileCount = 0,
+    mt = 0;
+  for (let r = 0; r < N; r++)
+    for (let c = 0; c < N; c++) {
+      if (board[r][c]) tileCount++;
+      mt = Math.max(mt, board[r][c]);
+    }
   document.getElementById('tiles-val').textContent = tileCount;
   document.getElementById('btile-val').textContent = mt;
 }
@@ -543,7 +585,7 @@ function updateUI () {
    Overlays
    ========================================================= */
 
-function showOverlay (type) {
+function showOverlay(type) {
   const ov = document.getElementById('ov');
   ov.className = 'ov';
   ov.innerHTML = `
@@ -557,7 +599,7 @@ function showOverlay (type) {
     <button class="btn" id="ov-replay-btn">Play Again</button>
   `;
   ov.style.display = 'flex';
-// FIX: Clear out any previous listeners using a fresh replacement element reference
+  // FIX: Clear out any previous listeners using a fresh replacement element reference
   const replayBtn = document.getElementById('ov-replay-btn');
   replayBtn.onclick = () => init();
 
@@ -567,7 +609,7 @@ function showOverlay (type) {
     replayBtn2.onclick = watchReplay;
   }
 }
-function showToast (msg) {
+function showToast(msg) {
   const t = document.getElementById('toast');
   t.textContent = msg;
   t.classList.add('show');
@@ -578,8 +620,8 @@ function showToast (msg) {
    Achievements
    ========================================================= */
 
-function checkAchievements () {
-  ACHIEVEMENTS.forEach(a => {
+function checkAchievements() {
+  ACHIEVEMENTS.forEach((a) => {
     if (stats.earned.includes(a.id)) return;
     if (a.check(board)) {
       stats.earned.push(a.id);
@@ -589,8 +631,8 @@ function checkAchievements () {
   });
 }
 
-function triggerAchievement (label, desc) {
-  const el  = document.getElementById('ach');
+function triggerAchievement(label, desc) {
+  const el = document.getElementById('ach');
   document.getElementById('ach-msg').textContent = label + ' — ' + desc;
   el.classList.add('show');
   setTimeout(() => el.classList.remove('show'), 3200);
@@ -601,15 +643,15 @@ function triggerAchievement (label, desc) {
    Stats modal
    ========================================================= */
 
-function openStats () {
-  document.getElementById('st-best').textContent  = stats.best.toLocaleString();
+function openStats() {
+  document.getElementById('st-best').textContent = stats.best.toLocaleString();
   document.getElementById('st-games').textContent = stats.games;
-  document.getElementById('st-wins').textContent  = stats.wins;
-  document.getElementById('st-tile').textContent  = stats.bestTile;
+  document.getElementById('st-wins').textContent = stats.wins;
+  document.getElementById('st-tile').textContent = stats.bestTile;
 
   const badges = document.getElementById('ach-badges');
   badges.innerHTML = '';
-  ACHIEVEMENTS.forEach(a => {
+  ACHIEVEMENTS.forEach((a) => {
     const b = document.createElement('span');
     const earned = stats.earned.includes(a.id);
     b.className = 'ach-badge' + (earned ? ' earned' : '');
@@ -621,7 +663,7 @@ function openStats () {
   document.getElementById('stats-modal').classList.add('open');
 }
 
-function closeStats () {
+function closeStats() {
   document.getElementById('stats-modal').classList.remove('open');
 }
 
@@ -631,12 +673,12 @@ function closeStats () {
 
 let audioCtx = null;
 
-function getAudioCtx () {
+function getAudioCtx() {
   if (!audioCtx) audioCtx = new (window.AudioContext || window.webkitAudioContext)();
   return audioCtx;
 }
 
-function playSound (type) {
+function playSound(type) {
   if (!soundOn) return;
   try {
     const ctx = getAudioCtx();
@@ -650,22 +692,25 @@ function playSound (type) {
       osc.frequency.value = 220;
       gain.gain.setValueAtTime(0.07, ctx.currentTime);
       gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.08);
-      osc.start(); osc.stop(ctx.currentTime + 0.08);
-
+      osc.start();
+      osc.stop(ctx.currentTime + 0.08);
     } else if (type === 'merge') {
       osc.type = 'sine';
       osc.frequency.setValueAtTime(440, ctx.currentTime);
       osc.frequency.exponentialRampToValueAtTime(880, ctx.currentTime + 0.12);
       gain.gain.setValueAtTime(0.14, ctx.currentTime);
       gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.18);
-      osc.start(); osc.stop(ctx.currentTime + 0.18);
-
+      osc.start();
+      osc.stop(ctx.currentTime + 0.18);
     } else if (type === 'achieve') {
       osc.type = 'triangle';
-      [523, 659, 784].forEach((freq, i) => osc.frequency.setValueAtTime(freq, ctx.currentTime + i * 0.1));
+      [523, 659, 784].forEach((freq, i) =>
+        osc.frequency.setValueAtTime(freq, ctx.currentTime + i * 0.1)
+      );
       gain.gain.setValueAtTime(0.18, ctx.currentTime);
       gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.4);
-      osc.start(); osc.stop(ctx.currentTime + 0.4);
+      osc.start();
+      osc.stop(ctx.currentTime + 0.4);
     }
   } catch (_) {}
 }
@@ -674,13 +719,13 @@ function playSound (type) {
    Confetti
    ========================================================= */
 
-function launchConfetti () {
+function launchConfetti() {
   const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   if (reduced) return;
 
-  const cv  = document.getElementById('confetti-canvas');
+  const cv = document.getElementById('confetti-canvas');
   const ctx = cv.getContext('2d');
-  cv.width  = cv.offsetWidth  || 476;
+  cv.width = cv.offsetWidth || 476;
   cv.height = cv.offsetHeight || 520;
 
   confettiParticles = Array.from({ length: 90 }, () => ({
@@ -694,14 +739,19 @@ function launchConfetti () {
     vrot: (Math.random() - 0.5) * 8,
   }));
 
-  function frame () {
+  function frame() {
     ctx.clearRect(0, 0, cv.width, cv.height);
-    confettiParticles.forEach(p => {
-      p.x += p.vx; p.y += p.vy; p.rot += p.vrot;
-      if (p.y > cv.height) { p.y = -10; p.x = Math.random() * cv.width; }
+    confettiParticles.forEach((p) => {
+      p.x += p.vx;
+      p.y += p.vy;
+      p.rot += p.vrot;
+      if (p.y > cv.height) {
+        p.y = -10;
+        p.x = Math.random() * cv.width;
+      }
       ctx.save();
       ctx.translate(p.x, p.y);
-      ctx.rotate(p.rot * Math.PI / 180);
+      ctx.rotate((p.rot * Math.PI) / 180);
       ctx.fillStyle = p.color;
       ctx.fillRect(-p.r / 2, -p.r / 2, p.r, p.r);
       ctx.restore();
@@ -712,7 +762,7 @@ function launchConfetti () {
   setTimeout(stopConfetti, 5000);
 }
 
-function stopConfetti () {
+function stopConfetti() {
   if (confettiFrameId) cancelAnimationFrame(confettiFrameId);
   confettiFrameId = null;
   const cv = document.getElementById('confetti-canvas');
@@ -730,14 +780,17 @@ document.getElementById('nb').addEventListener('click', () => {
 });
 
 document.getElementById('ub').addEventListener('click', () => {
-  if (!prevBoard) { showToast('Nothing to undo'); return; }
+  if (!prevBoard) {
+    showToast('Nothing to undo');
+    return;
+  }
 
-  board     = prevBoard;
-  score     = prevScore;
+  board = prevBoard;
+  score = prevScore;
   prevBoard = null;
-  moves     = Math.max(0, moves - 1);
-  over      = false;
-  won       = false;
+  moves = Math.max(0, moves - 1);
+  over = false;
+  won = false;
 
   renderBoard();
   renderTiles();
@@ -765,9 +818,9 @@ document.getElementById('sdbtn').addEventListener('click', () => {
   showToast(soundOn ? 'Sound on' : 'Sound off');
 });
 
-document.querySelectorAll('.mode-btn').forEach(btn => {
+document.querySelectorAll('.mode-btn').forEach((btn) => {
   btn.addEventListener('click', () => {
-    document.querySelectorAll('.mode-btn').forEach(b => b.classList.remove('active'));
+    document.querySelectorAll('.mode-btn').forEach((b) => b.classList.remove('active'));
     btn.classList.add('active');
     mode = btn.dataset.mode;
     clearSavedGame();
@@ -777,28 +830,71 @@ document.querySelectorAll('.mode-btn').forEach(btn => {
 
 /* Keyboard */
 const KEY_MAP = {
-  ArrowLeft: 'left', ArrowRight: 'right', ArrowUp: 'up', ArrowDown: 'down',
-  a: 'left', d: 'right', w: 'up', s: 'down',
+  ArrowLeft: 'left',
+  ArrowRight: 'right',
+  ArrowUp: 'up',
+  ArrowDown: 'down',
+  a: 'left',
+  d: 'right',
+  w: 'up',
+  s: 'down',
 };
 
-document.addEventListener('keydown', e => {
- const dir = KEY_MAP[e.key];
-  if (dir) { e.preventDefault(); doMove(dir); }
+document.addEventListener('keydown', (e) => {
+  const dir = KEY_MAP[e.key];
+  if (dir) {
+    e.preventDefault();
+    doMove(dir);
+  }
 });
 
 /* Touch / swipe */
 let touchStart = { x: 0, y: 0 };
 
-document.getElementById('wr').addEventListener('touchstart', e => {
-  touchStart = { x: e.touches[0].clientX, y: e.touches[0].clientY };
-}, { passive: true });
+document.getElementById('wr').addEventListener(
+  'touchstart',
+  (e) => {
+    touchStart = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+  },
+  { passive: true }
+);
 
-document.getElementById('wr').addEventListener('touchend', e => {
-  const dx = e.changedTouches[0].clientX - touchStart.x;
-  const dy = e.changedTouches[0].clientY - touchStart.y;
-  if (Math.max(Math.abs(dx), Math.abs(dy)) < 28) return;
-  doMove(Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? 'right' : 'left') : (dy > 0 ? 'down' : 'up'));
-}, { passive: true });
+document.getElementById('wr').addEventListener(
+  'touchend',
+  (e) => {
+    const dx = e.changedTouches[0].clientX - touchStart.x;
+    const dy = e.changedTouches[0].clientY - touchStart.y;
+    if (Math.max(Math.abs(dx), Math.abs(dy)) < 28) return;
+    doMove(Math.abs(dx) > Math.abs(dy) ? (dx > 0 ? 'right' : 'left') : dy > 0 ? 'down' : 'up');
+  },
+  { passive: true }
+);
+
+/* =========================================================
+   Auto Pause On Tab Switch
+   ========================================================= */
+
+document.addEventListener('visibilitychange', () => {
+  if (mode !== 'timed' || over) return;
+
+  if (document.hidden) {
+    paused = true;
+    clearInterval(timerInterval);
+
+    document.getElementById('tfill').classList.add('paused');
+
+    showToast('Timer paused');
+  } else {
+    if (paused) {
+      paused = false;
+      startTimer();
+
+      document.getElementById('tfill').classList.remove('pgit aused');
+
+      showToast('Timer resumed');
+    }
+  }
+});
 
 /* =========================================================
    Boot

--- a/public/2048_game/style.css
+++ b/public/2048_game/style.css
@@ -10,7 +10,9 @@
 }
 
 /* ---------- Reset ---------- */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
@@ -39,22 +41,30 @@ body {
   transition: background 0.4s;
 }
 
-body.light { background: #12002a; }
-body.dark  { background: #060e1a; }
-
-#g {
-    font-family: var(--font);
-    padding: 20px 18px 24px;
-    max-width: 500px;
-    width: 100%;
-    border-radius: 22px;
-    position: relative;
-    overflow: hidden;
-    transition: background 0.4s;
+body.light {
+  background: #12002a;
+}
+body.dark {
+  background: #060e1a;
 }
 
-body.light #g { background: #1a0533; }
-body.dark  #g { background: #0a1628; }
+#g {
+  font-family: var(--font);
+  padding: 20px 18px 24px;
+  max-width: 500px;
+  width: 100%;
+  border-radius: 22px;
+  position: relative;
+  overflow: hidden;
+  transition: background 0.4s;
+}
+
+body.light #g {
+  background: #1a0533;
+}
+body.dark #g {
+  background: #0a1628;
+}
 
 /* ---------- Animated background blobs ---------- */
 .blobs {
@@ -74,21 +84,81 @@ body.dark  #g { background: #0a1628; }
 }
 
 @keyframes drift {
-  0%   { transform: translate(0, 0) scale(1); }
-  100% { transform: translate(20px, 14px) scale(1.09); }
+  0% {
+    transform: translate(0, 0) scale(1);
+  }
+  100% {
+    transform: translate(20px, 14px) scale(1.09);
+  }
 }
 
 /* Light theme blobs */
-body.light .b1 { width:280px; height:280px; background:#e040fb; top:-80px;  left:-70px;  animation-delay: 0s;  }
-body.light .b2 { width:220px; height:220px; background:#ff6b6b; bottom:-60px; right:-50px; animation-delay:-3s;  }
-body.light .b3 { width:190px; height:190px; background:#4fc3f7; top:35%;    right:-60px; animation-delay:-5s;  }
-body.light .b4 { width:160px; height:160px; background:#69f0ae; bottom:15%; left:-40px;  animation-delay:-2s;  }
+body.light .b1 {
+  width: 280px;
+  height: 280px;
+  background: #e040fb;
+  top: -80px;
+  left: -70px;
+  animation-delay: 0s;
+}
+body.light .b2 {
+  width: 220px;
+  height: 220px;
+  background: #ff6b6b;
+  bottom: -60px;
+  right: -50px;
+  animation-delay: -3s;
+}
+body.light .b3 {
+  width: 190px;
+  height: 190px;
+  background: #4fc3f7;
+  top: 35%;
+  right: -60px;
+  animation-delay: -5s;
+}
+body.light .b4 {
+  width: 160px;
+  height: 160px;
+  background: #69f0ae;
+  bottom: 15%;
+  left: -40px;
+  animation-delay: -2s;
+}
 
 /* Dark theme blobs */
-body.dark .b1 { width:280px; height:280px; background:#00bcd4; top:-80px;  left:-70px;  animation-delay: 0s;  }
-body.dark .b2 { width:220px; height:220px; background:#7c4dff; bottom:-60px; right:-50px; animation-delay:-3s;  }
-body.dark .b3 { width:190px; height:190px; background:#00e676; top:35%;    right:-60px; animation-delay:-5s;  }
-body.dark .b4 { width:160px; height:160px; background:#ff6e40; bottom:15%; left:-40px;  animation-delay:-2s;  }
+body.dark .b1 {
+  width: 280px;
+  height: 280px;
+  background: #00bcd4;
+  top: -80px;
+  left: -70px;
+  animation-delay: 0s;
+}
+body.dark .b2 {
+  width: 220px;
+  height: 220px;
+  background: #7c4dff;
+  bottom: -60px;
+  right: -50px;
+  animation-delay: -3s;
+}
+body.dark .b3 {
+  width: 190px;
+  height: 190px;
+  background: #00e676;
+  top: 35%;
+  right: -60px;
+  animation-delay: -5s;
+}
+body.dark .b4 {
+  width: 160px;
+  height: 160px;
+  background: #ff6e40;
+  bottom: 15%;
+  left: -40px;
+  animation-delay: -2s;
+}
 
 /* ---------- Confetti canvas ---------- */
 #confetti-canvas {
@@ -102,7 +172,10 @@ body.dark .b4 { width:160px; height:160px; background:#ff6e40; bottom:15%; left:
 }
 
 /* ---------- Inner content ---------- */
-#inner { position: relative; z-index: 1; }
+#inner {
+  position: relative;
+  z-index: 1;
+}
 
 /* ---------- Header ---------- */
 .hdr {
@@ -131,7 +204,10 @@ body.dark .logo {
 }
 
 /* ---------- Score boxes ---------- */
-.score-row { display: flex; gap: 7px; }
+.score-row {
+  display: flex;
+  gap: 7px;
+}
 
 .sc {
   border-radius: var(--radius-card);
@@ -157,10 +233,14 @@ body.dark .logo {
   color: #fff;
 }
 
-.sc-val.bump { animation: sbump 0.2s ease; }
+.sc-val.bump {
+  animation: sbump 0.2s ease;
+}
 
 @keyframes sbump {
-  50% { transform: scale(1.28); }
+  50% {
+    transform: scale(1.28);
+  }
 }
 
 .gold-flash {
@@ -176,7 +256,10 @@ body.dark .logo {
   margin-bottom: 8px;
 }
 
-.btns { display: flex; gap: 7px; }
+.btns {
+  display: flex;
+  gap: 7px;
+}
 
 .btn {
   font-family: var(--font);
@@ -189,15 +272,26 @@ body.dark .logo {
   color: #fff;
   background: rgba(255, 255, 255, 0.15);
   letter-spacing: 0.2px;
-  transition: transform 0.12s, background 0.15s;
+  transition:
+    transform 0.12s,
+    background 0.15s;
 }
 
 .btn:hover {
-    background: rgba(255, 255, 255, 0.25);}
-.btn:active { transform: scale(0.93); }
-.btn.sm     { padding: 6px 12px; font-size: 12px; }
+  background: rgba(255, 255, 255, 0.25);
+}
+.btn:active {
+  transform: scale(0.93);
+}
+.btn.sm {
+  padding: 6px 12px;
+  font-size: 12px;
+}
 
-.top-icons { display: flex; gap: 7px; }
+.top-icons {
+  display: flex;
+  gap: 7px;
+}
 
 .icon-btn {
   background: rgba(255, 255, 255, 0.12);
@@ -214,7 +308,9 @@ body.dark .logo {
   color: #fff;
 }
 
-.icon-btn:hover { transform: rotate(30deg) scale(1.1); }
+.icon-btn:hover {
+  transform: rotate(30deg) scale(1.1);
+}
 
 /* ---------- Mode buttons ---------- */
 .mode-row {
@@ -257,7 +353,9 @@ body.dark .logo {
   height: 100%;
   border-radius: 2px;
   background: linear-gradient(90deg, #69f0ae, #00bcd4);
-  transition: width 0.1s linear, background 0.4s;
+  transition:
+    width 0.1s linear,
+    background 0.4s;
 }
 
 .timer-fill.danger {
@@ -280,7 +378,9 @@ body.dark .logo {
   letter-spacing: 0.3px;
 }
 
-.meta-item span { color: rgba(255, 255, 255, 0.85); }
+.meta-item span {
+  color: rgba(255, 255, 255, 0.85);
+}
 
 /* ---------- Combo streak ---------- */
 .streak {
@@ -296,7 +396,9 @@ body.dark .logo {
   text-shadow: 0 0 14px rgba(255, 213, 79, 0.9);
 }
 
-.streak.show { opacity: 1; }
+.streak.show {
+  opacity: 1;
+}
 
 /* ---------- Board ---------- */
 .wrap {
@@ -334,8 +436,12 @@ body.dark .board {
   border-radius: var(--radius-tile);
 }
 
-body.light .cell { background: rgba(255, 255, 255, 0.06); }
-body.dark  .cell { background: rgba(255, 255, 255, 0.04); }
+body.light .cell {
+  background: rgba(255, 255, 255, 0.06);
+}
+body.dark .cell {
+  background: rgba(255, 255, 255, 0.04);
+}
 
 /* ---------- Tiles layer ---------- */
 .tiles-layer {
@@ -347,45 +453,111 @@ body.dark  .cell { background: rgba(255, 255, 255, 0.04); }
 }
 
 .tile {
-    position: absolute;
-    border-radius: var(--radius-tile);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-family: var(--font);
-    font-weight: 900;
-    border: 1.5px solid rgba(255, 255, 255, 0.22);
-  transition: top var(--anim-tile), left var(--anim-tile);
-    user-select: none;
+  position: absolute;
+  border-radius: var(--radius-tile);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font);
+  font-weight: 900;
+  border: 1.5px solid rgba(255, 255, 255, 0.22);
+  transition:
+    top var(--anim-tile),
+    left var(--anim-tile);
+  user-select: none;
 }
 
-.tile.new    { animation: tpop   0.20s cubic-bezier(0.34, 1.56, 0.64, 1); }
-.tile.merged { animation: tmerge 0.22s cubic-bezier(0.34, 1.56, 0.64, 1); }
+.tile.new {
+  animation: tpop 0.2s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+.tile.merged {
+  animation: tmerge 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
 
 @keyframes tpop {
-  0%   { transform: scale(0) rotate(-8deg); opacity: 0; }
-  65%  { transform: scale(1.12); }
-  100% { transform: scale(1); opacity: 1; }
+  0% {
+    transform: scale(0) rotate(-8deg);
+    opacity: 0;
+  }
+  65% {
+    transform: scale(1.12);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 @keyframes tmerge {
-  45%  { transform: scale(1.22); }
-  100% { transform: scale(1); }
+  45% {
+    transform: scale(1.22);
+  }
+  100% {
+    transform: scale(1);
+  }
 }
 
 /* ---------- Tile colours ---------- */
-.tile[data-val="2"]    { background: linear-gradient(135deg,#f8f9fa,#e9ecef); color:#495057; font-size:36px; }
-.tile[data-val="4"]    { background: linear-gradient(135deg,#fff3e0,#ffe0b2); color:#e65100; font-size:36px; }
-.tile[data-val="8"]    { background: linear-gradient(135deg,#ff9800,#f44336); color:#fff;    font-size:36px; }
-.tile[data-val="16"]   { background: linear-gradient(135deg,#f44336,#e91e63); color:#fff;    font-size:36px; }
-.tile[data-val="32"]   { background: linear-gradient(135deg,#e91e63,#9c27b0); color:#fff;    font-size:36px; }
-.tile[data-val="64"]   { background: linear-gradient(135deg,#9c27b0,#673ab7); color:#fff;    font-size:36px; }
-.tile[data-val="128"]  { background: linear-gradient(135deg,#3f51b5,#2196f3); color:#fff;    font-size:28px; }
-.tile[data-val="256"]  { background: linear-gradient(135deg,#2196f3,#00bcd4); color:#fff;    font-size:28px; }
-.tile[data-val="512"]  { background: linear-gradient(135deg,#00bcd4,#4caf50); color:#fff;    font-size:28px; }
-.tile[data-val="1024"] { background: linear-gradient(135deg,#4caf50,#cddc39); color:#fff;    font-size:22px; }
-.tile[data-val="2048"] { background: linear-gradient(135deg,#ffd700,#ff9800,#ff5722); color:#fff; font-size:22px; }
-.tile[data-val="big"]  { background: linear-gradient(135deg,#212121,#424242); color:#fff;    font-size:16px; }
+.tile[data-val='2'] {
+  background: linear-gradient(135deg, #f8f9fa, #e9ecef);
+  color: #495057;
+  font-size: 36px;
+}
+.tile[data-val='4'] {
+  background: linear-gradient(135deg, #fff3e0, #ffe0b2);
+  color: #e65100;
+  font-size: 36px;
+}
+.tile[data-val='8'] {
+  background: linear-gradient(135deg, #ff9800, #f44336);
+  color: #fff;
+  font-size: 36px;
+}
+.tile[data-val='16'] {
+  background: linear-gradient(135deg, #f44336, #e91e63);
+  color: #fff;
+  font-size: 36px;
+}
+.tile[data-val='32'] {
+  background: linear-gradient(135deg, #e91e63, #9c27b0);
+  color: #fff;
+  font-size: 36px;
+}
+.tile[data-val='64'] {
+  background: linear-gradient(135deg, #9c27b0, #673ab7);
+  color: #fff;
+  font-size: 36px;
+}
+.tile[data-val='128'] {
+  background: linear-gradient(135deg, #3f51b5, #2196f3);
+  color: #fff;
+  font-size: 28px;
+}
+.tile[data-val='256'] {
+  background: linear-gradient(135deg, #2196f3, #00bcd4);
+  color: #fff;
+  font-size: 28px;
+}
+.tile[data-val='512'] {
+  background: linear-gradient(135deg, #00bcd4, #4caf50);
+  color: #fff;
+  font-size: 28px;
+}
+.tile[data-val='1024'] {
+  background: linear-gradient(135deg, #4caf50, #cddc39);
+  color: #fff;
+  font-size: 22px;
+}
+.tile[data-val='2048'] {
+  background: linear-gradient(135deg, #ffd700, #ff9800, #ff5722);
+  color: #fff;
+  font-size: 22px;
+}
+.tile[data-val='big'] {
+  background: linear-gradient(135deg, #212121, #424242);
+  color: #fff;
+  font-size: 16px;
+}
 
 /* ---------- Merge particles ---------- */
 .particle {
@@ -399,8 +571,14 @@ body.dark  .cell { background: rgba(255, 255, 255, 0.04); }
 }
 
 @keyframes particle-fly {
-  0%   { opacity: 1; transform: translate(0, 0) scale(1); }
-  100% { opacity: 0; transform: translate(var(--px), var(--py)) scale(0); }
+  0% {
+    opacity: 1;
+    transform: translate(0, 0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(var(--px), var(--py)) scale(0);
+  }
 }
 
 /* ---------- Score float ---------- */
@@ -417,8 +595,14 @@ body.dark  .cell { background: rgba(255, 255, 255, 0.04); }
 }
 
 @keyframes floatup {
-  0%   { opacity: 1; transform: translateY(0); }
-  100% { opacity: 0; transform: translateY(-52px); }
+  0% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-52px);
+  }
 }
 
 /* ---------- Game over / win overlay ---------- */
@@ -435,10 +619,21 @@ body.dark  .cell { background: rgba(255, 255, 255, 0.04); }
   animation: fdin 0.35s ease;
 }
 
-body.light .ov { background: rgba(10, 0, 30, 0.85); }
-body.dark  .ov { background: rgba(0, 10, 25, 0.88); }
+body.light .ov {
+  background: rgba(10, 0, 30, 0.85);
+}
+body.dark .ov {
+  background: rgba(0, 10, 25, 0.88);
+}
 
-@keyframes fdin { from { opacity: 0; } to { opacity: 1; } }
+@keyframes fdin {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
 
 .ov-title {
   font-size: 36px;
@@ -446,8 +641,14 @@ body.dark  .ov { background: rgba(0, 10, 25, 0.88); }
   letter-spacing: -1px;
 }
 
-.ov-title.win  { color: #ffd54f; text-shadow: 0 0 22px rgba(255, 213, 79, 0.8); }
-.ov-title.lose { color: #ff6b6b; text-shadow: 0 0 22px rgba(255, 107, 107, 0.7); }
+.ov-title.win {
+  color: #ffd54f;
+  text-shadow: 0 0 22px rgba(255, 213, 79, 0.8);
+}
+.ov-title.lose {
+  color: #ff6b6b;
+  text-shadow: 0 0 22px rgba(255, 107, 107, 0.7);
+}
 
 .ov-sub {
   font-size: 14px;
@@ -456,7 +657,11 @@ body.dark  .ov { background: rgba(0, 10, 25, 0.88); }
   margin-top: -6px;
 }
 
-.ov-stats { display: flex; gap: 10px; margin: 4px 0; }
+.ov-stats {
+  display: flex;
+  gap: 10px;
+  margin: 4px 0;
+}
 
 .ov-stat {
   background: rgba(255, 255, 255, 0.1);
@@ -474,9 +679,18 @@ body.dark  .ov { background: rgba(0, 10, 25, 0.88); }
   letter-spacing: 1px;
 }
 
-.ov-stat-val { font-size: 18px; font-weight: 900; color: #fff; }
+.ov-stat-val {
+  font-size: 18px;
+  font-weight: 900;
+  color: #fff;
+}
 
-.ov .btn { font-size: 14px; padding: 10px 26px; border-radius: 12px; margin-top: 2px; }
+.ov .btn {
+  font-size: 14px;
+  padding: 10px 26px;
+  border-radius: 12px;
+  margin-top: 2px;
+}
 
 /* ---------- Achievement pop-up ---------- */
 .achievement {
@@ -492,14 +706,19 @@ body.dark  .ov { background: rgba(0, 10, 25, 0.88); }
   z-index: 50;
   opacity: 0;
   transform: translateY(-10px);
-  transition: opacity 0.3s, transform 0.3s;
+  transition:
+    opacity 0.3s,
+    transform 0.3s;
   border: 1px solid rgba(255, 255, 255, 0.3);
   max-width: 185px;
   text-align: center;
   pointer-events: none;
 }
 
-.achievement.show { opacity: 1; transform: translateY(0); }
+.achievement.show {
+  opacity: 1;
+  transform: translateY(0);
+}
 
 .ach-title {
   font-size: 10px;
@@ -522,14 +741,26 @@ body.dark  .ov { background: rgba(0, 10, 25, 0.88); }
   font-size: 13px;
   font-weight: 800;
   opacity: 0;
-  transition: opacity 0.25s, bottom 0.25s;
+  transition:
+    opacity 0.25s,
+    bottom 0.25s;
   pointer-events: none;
   white-space: nowrap;
   z-index: 30;
   border: 1px solid rgba(255, 255, 255, 0.22);
 }
 
-.toast.show { opacity: 1; bottom: -42px; }
+.toast.show {
+  opacity: 1;
+  bottom: -42px;
+}
+
+/* ---------- Timer paused state ---------- */
+
+.timer-fill.paused {
+  opacity: 0.5;
+  filter: grayscale(0.4);
+}
 
 /* ---------- Stats modal ---------- */
 .stats-modal {
@@ -543,10 +774,16 @@ body.dark  .ov { background: rgba(0, 10, 25, 0.88); }
   animation: fdin 0.3s ease;
 }
 
-body.light .stats-modal { background: rgba(10, 0, 30, 0.92); }
-body.dark  .stats-modal { background: rgba(0, 10, 25, 0.94); }
+body.light .stats-modal {
+  background: rgba(10, 0, 30, 0.92);
+}
+body.dark .stats-modal {
+  background: rgba(0, 10, 25, 0.94);
+}
 
-.stats-modal.open { display: flex; }
+.stats-modal.open {
+  display: flex;
+}
 
 .stats-inner {
   width: 88%;
@@ -594,7 +831,9 @@ body.dark  .stats-modal { background: rgba(0, 10, 25, 0.94); }
   margin-top: 2px;
 }
 
-.ach-list { margin-bottom: 14px; }
+.ach-list {
+  margin-bottom: 14px;
+}
 
 .ach-list-title {
   font-size: 12px;
@@ -642,26 +881,31 @@ body.dark  .stats-modal { background: rgba(0, 10, 25, 0.94); }
 
 /* ---------- Reduced motion ---------- */
 @media (prefers-reduced-motion: reduce) {
-  .tile, .tile.new, .tile.merged,
-  .particle, .score-float, .blob,
-  .streak, .achievement { animation: none !important; transition: none !important; }
+  .tile,
+  .tile.new,
+  .tile.merged,
+  .particle,
+  .score-float,
+  .blob,
+  .streak,
+  .achievement {
+    animation: none !important;
+    transition: none !important;
+  }
 }
 
 /* ---------- Responsive ---------- */
 /* ---------- Responsive ---------- */
-@media (max-width: 480px){
-
+@media (max-width: 480px) {
   html,
-  body{
+  body {
     margin: 0;
     padding: 0;
     overflow-x: hidden;
     width: 100%;
   }
 
-  
-
-  #g{
+  #g {
     width: 100%;
     max-width: 100vw;
     padding: 10px 6px 16px;
@@ -671,86 +915,86 @@ body.dark  .stats-modal { background: rgba(0, 10, 25, 0.94); }
 
   /* HEADER */
 
-  .hdr{
+  .hdr {
     margin-bottom: 10px;
     align-items: center;
   }
 
-  .logo{
+  .logo {
     font-size: 34px;
   }
 
-  .score-row{
+  .score-row {
     gap: 4px;
   }
 
-  .sc{
+  .sc {
     min-width: 54px;
     padding: 4px 7px;
   }
 
-  .sc-lbl{
+  .sc-lbl {
     font-size: 9px;
   }
 
-  .sc-val{
+  .sc-val {
     font-size: 15px;
   }
 
-  .ctrl{
+  .ctrl {
     flex-direction: column;
     gap: 8px;
     margin-bottom: 10px;
   }
 
   .btns,
-  .top-icons{
+  .top-icons {
     justify-content: center;
     flex-wrap: wrap;
   }
 
-  .btn{
+  .btn {
     padding: 7px 12px;
     font-size: 12px;
   }
 
-  .icon-btn{
+  .icon-btn {
     width: 32px;
     height: 32px;
     font-size: 15px;
   }
 
-  .mode-row{
+  .mode-row {
     flex-wrap: wrap;
     gap: 5px;
   }
 
-  .mode-btn{
+  .mode-btn {
     padding: 5px 10px;
     font-size: 11px;
   }
 
-  .meta-row{
+  .meta-row {
     justify-content: center;
     flex-wrap: wrap;
     gap: 6px;
     margin-bottom: 8px;
   }
 
-  .meta-item{
+  .meta-item {
     font-size: 11px;
   }
 
   /* BOARD */
 
-  .wrap{
+  .wrap {
     width: 100%;
     display: flex;
     justify-content: center;
     overflow: hidden;
   }
 
-  .board{
+  .board {
     position: relative;
     margin: 0 auto;
     overflow: hidden;
@@ -759,182 +1003,178 @@ body.dark  .stats-modal { background: rgba(0, 10, 25, 0.94); }
     padding: var(--board-pad);
   }
 
-  .cell{
+  .cell {
     width: var(--tile-size);
     height: var(--tile-size);
   }
 
-  .tile{
+  .tile {
     width: var(--tile-size) !important;
     height: var(--tile-size) !important;
   }
 
-  .tiles-layer{
+  .tiles-layer {
     position: absolute;
     inset: 0;
   }
 
   /* TILE FONT SIZES */
 
-  .tile[data-val="2"],
-  .tile[data-val="4"],
-  .tile[data-val="8"],
-  .tile[data-val="16"],
-  .tile[data-val="32"],
-  .tile[data-val="64"]{
+  .tile[data-val='2'],
+  .tile[data-val='4'],
+  .tile[data-val='8'],
+  .tile[data-val='16'],
+  .tile[data-val='32'],
+  .tile[data-val='64'] {
     font-size: 20px;
   }
 
-  .tile[data-val="128"],
-  .tile[data-val="256"],
-  .tile[data-val="512"]{
+  .tile[data-val='128'],
+  .tile[data-val='256'],
+  .tile[data-val='512'] {
     font-size: 16px;
   }
 
-  .tile[data-val="1024"],
-.tile[data-val="2048"] {  font-size: 16px; }
-@media (max-width: 768px) {
-
-}
-
-@media (max-width: 445px){
-
-  :root{
-    --tile-size: 62px;
-    --tile-gap: 7px;
-    --board-pad: 6px;
+  .tile[data-val='1024'],
+  .tile[data-val='2048'] {
+    font-size: 16px;
+  }
+  @media (max-width: 768px) {
   }
 
-  .tile[data-val="2"],
-  .tile[data-val="4"],
-  .tile[data-val="8"],
-  .tile[data-val="16"],
-  .tile[data-val="32"],
-  .tile[data-val="64"]{
-    font-size: 22px;
+  @media (max-width: 445px) {
+    :root {
+      --tile-size: 62px;
+      --tile-gap: 7px;
+      --board-pad: 6px;
+    }
+
+    .tile[data-val='2'],
+    .tile[data-val='4'],
+    .tile[data-val='8'],
+    .tile[data-val='16'],
+    .tile[data-val='32'],
+    .tile[data-val='64'] {
+      font-size: 22px;
+    }
+
+    .tile[data-val='128'],
+    .tile[data-val='256'],
+    .tile[data-val='512'] {
+      font-size: 18px;
+    }
+
+    .tile[data-val='1024'],
+    .tile[data-val='2048'] {
+      font-size: 14px;
+    }
+
+    .tile {
+      width: calc(var(--tile-size) + 14px) !important;
+      height: calc(var(--tile-size) + 14px) !important;
+    }
   }
 
-  .tile[data-val="128"],
-  .tile[data-val="256"],
-  .tile[data-val="512"]{
-    font-size: 18px;
+  @media (max-width: 418px) {
+    :root {
+      --tile-size: 58px;
+      --tile-gap: 5.5px;
+      --board-pad: 4px;
+    }
+
+    .tile {
+      width: calc(var(--tile-size) + 10px) !important;
+      height: calc(var(--tile-size) + 10px) !important;
+    }
   }
 
-  .tile[data-val="1024"],
-  .tile[data-val="2048"]{
-    font-size: 14px;
+  @media (max-width: 415px) {
+    :root {
+      --tile-size: 64px; /* slightly bigger like you asked */
+      --tile-gap: 4px; /* enough breathing room */
+      --board-pad: 4px;
+    }
+
+    /* keep board stable — DO NOT distort */
+    .board {
+      gap: var(--tile-gap);
+      padding: var(--board-pad);
+      box-sizing: border-box;
+    }
+
+    .cell {
+      width: var(--tile-size);
+      height: var(--tile-size);
+    }
+
+    /* IMPORTANT: no calc, no scaling tricks */
+    .tile {
+      width: var(--tile-size) !important;
+      height: var(--tile-size) !important;
+    }
+
+    /* FIX: ensure tiles don’t sit on border */
+    .tiles-layer {
+      inset: var(--board-pad);
+    }
   }
 
-  .tile{
-  width: calc(var(--tile-size) + 14px) !important;
-  height: calc(var(--tile-size) + 14px) !important;
-}
+  @media (max-width: 406px) {
+    :root {
+      --tile-size: 62px; /* keep tiles BIG (your request) */
+      --tile-gap: 2px; /* minimal gap */
+      --board-pad: 2px; /* minimal padding */
+    }
 
-}
+    /* 🔥 HARD COMPRESS BOARD CONTAINER */
+    .wrap {
+      transform: scale(0.92);
+      transform-origin: center;
+    }
 
-@media (max-width: 418px){
+    .board {
+      gap: var(--tile-gap);
+      padding: var(--board-pad);
+      box-sizing: border-box;
+    }
 
-  :root{
-    --tile-size: 58px;
-    --tile-gap: 5.5px;
-    --board-pad: 4px;
+    /* ensure alignment stays inside board */
+    .cell {
+      width: var(--tile-size);
+      height: var(--tile-size);
+    }
+
+    .tile {
+      width: var(--tile-size) !important;
+      height: var(--tile-size) !important;
+    }
+
+    .tiles-layer {
+      inset: var(--board-pad);
+    }
+
+    .blobs {
+      inset: 0;
+      overflow: hidden;
+    }
+
+    .blob {
+      opacity: 0.08; /* reduce distraction */
+    }
+
+    /* OPTIONAL: push blobs behind everything safely */
+    .blobs {
+      z-index: 0;
+    }
+
+    #inner {
+      position: relative;
+      z-index: 2;
+    }
+
+    .wrap {
+      position: relative;
+      z-index: 3;
+    }
   }
-
-  .tile{
-    width: calc(var(--tile-size) + 10px) !important;
-    height: calc(var(--tile-size) + 10px) !important;
-  }
-
-}
-
-@media (max-width: 415px){
-
-  :root{
-    --tile-size: 64px;   /* slightly bigger like you asked */
-    --tile-gap: 4px;     /* enough breathing room */
-    --board-pad: 4px;
-  }
-
-  /* keep board stable — DO NOT distort */
-  .board{
-    gap: var(--tile-gap);
-    padding: var(--board-pad);
-    box-sizing: border-box;
-  }
-
-  .cell{
-    width: var(--tile-size);
-    height: var(--tile-size);
-  }
-
-  /* IMPORTANT: no calc, no scaling tricks */
-  .tile{
-    width: var(--tile-size) !important;
-    height: var(--tile-size) !important;
-  }
-
-  /* FIX: ensure tiles don’t sit on border */
-  .tiles-layer{
-    inset: var(--board-pad);
-  }
-}
-
-@media (max-width: 406px){
-
-  :root{
-    --tile-size: 62px;   /* keep tiles BIG (your request) */
-    --tile-gap: 2px;     /* minimal gap */
-    --board-pad: 2px;    /* minimal padding */
-  }
-
-  /* 🔥 HARD COMPRESS BOARD CONTAINER */
-  .wrap{
-    transform: scale(0.92);
-    transform-origin: center;
-  }
-
-  .board{
-    gap: var(--tile-gap);
-    padding: var(--board-pad);
-    box-sizing: border-box;
-  }
-
-  /* ensure alignment stays inside board */
-  .cell{
-    width: var(--tile-size);
-    height: var(--tile-size);
-  }
-
-  .tile{
-    width: var(--tile-size) !important;
-    height: var(--tile-size) !important;
-  }
-
-  .tiles-layer{
-    inset: var(--board-pad);
-  }
-
-  .blobs{
-  inset: 0;
-  overflow: hidden;
-}
-
-.blob{
-  opacity: 0.08;   /* reduce distraction */
-}
-
-/* OPTIONAL: push blobs behind everything safely */
-.blobs{
-  z-index: 0;
-}
-
-#inner{
-  position: relative;
-  z-index: 2;
-}
-
-.wrap{
-  position: relative;
-  z-index: 3;
-}
 }


### PR DESCRIPTION
## Description

### Overview
This PR fixes the issue where the countdown timer in Timed Mode continued running even when the browser tab became inactive.

This caused unfair game losses when users switched tabs or minimized the browser.

### Changes Made
- Added automatic timer pause using the Visibility API
- Added automatic timer resume when user returns
- Prevented multiple timer intervals from running simultaneously
- Reset pause state properly on new game initialization
- Added paused visual state for timer bar
- Added pause/resume toast notifications

### Before Fix
- Timer continued decreasing in inactive tabs
- Users could lose the game unfairly
- Multiple timer intervals could stack on resume

### After Fix
- Timer pauses automatically when tab becomes inactive
- Timer resumes correctly when user returns
- Countdown remains accurate and fair
- Better user experience during tab switching

### Testing Done
- Tested tab switching
- Tested minimizing browser
- Tested multiple tab changes
- Verified timer resumes correctly
- Verified no duplicate intervals occur
- Verified timed mode still ends properly at 0 seconds

Fixes #3123