### PR TITLE
default api is directly taken from vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env.local for local development
+GEMINI_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ out/
 .env.production.local
 .env.build
 
+# Local AI ChatBot default Gemini API key
+/public/AI ChatBot/default-config.js
+
 # IDE and editor files
 .vscode/
 .idea/

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -15,7 +15,13 @@
    - Output Directory: **`.`** (current directory)
    - Install Command: **Leave empty**
 
-3. **Redeploy:**
+3. **Add a Gemini API secret:**
+   - Go to your Vercel project dashboard
+   - Open **Settings → Environment Variables**
+   - Add `GEMINI_API_KEY` with your Gemini API key
+   - Deploy to the **Production** environment (or add the same variable for Preview)
+
+4. **Redeploy:**
    - Go to your Vercel dashboard
    - Click "Redeploy" on the latest deployment
    - Or trigger a new deployment by pushing to GitHub

--- a/api/gemini.js
+++ b/api/gemini.js
@@ -1,0 +1,54 @@
+const dotenv = require("dotenv");
+dotenv.config();
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+
+module.exports = async (req, res) => {
+  if (req.method !== "POST") {
+    res.setHeader("Allow", "POST");
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  if (!GEMINI_API_KEY) {
+    return res.status(500).json({
+      error:
+        "Gemini API key is not configured on the server. Set GEMINI_API_KEY in your hosting environment.",
+    });
+  }
+
+  const { model, contents, systemPrompt } = req.body || {};
+  if (!model || !Array.isArray(contents) || contents.length === 0) {
+    return res.status(400).json({ error: "Invalid request body" });
+  }
+
+  const payload = { contents };
+  if (systemPrompt) {
+    payload.systemInstruction = { parts: [{ text: systemPrompt }] };
+  }
+
+  try {
+    const apiUrl = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(
+      model,
+    )}:generateContent?key=${encodeURIComponent(GEMINI_API_KEY)}`;
+
+    const response = await fetch(apiUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await response.json().catch(() => null);
+    if (!response.ok) {
+      const message = data?.error?.message || `Gemini API error (${response.status})`;
+      return res.status(response.status).json({ error: message, details: data });
+    }
+
+    return res.status(200).json(data);
+  } catch (error) {
+    return res.status(500).json({
+      error: error.message || "Unexpected server error",
+    });
+  }
+};

--- a/public/AI ChatBot/Readme.md
+++ b/public/AI ChatBot/Readme.md
@@ -25,6 +25,28 @@ A sleek, privacy-first AI chatbot powered by Google Gemini with dark mode, multi
 2. Place them in the **same folder**
 3. **Double-click `index.html`** to open in your browser
 
+### Optional: Use a local default Gemini API key
+
+If you want to keep a Gemini key locally without committing it to git, create `public/AI ChatBot/default-config.js` with:
+
+```js
+window.DEFAULT_GEMINI_API_KEY = "YOUR_GEMINI_KEY_HERE";
+```
+
+That file is already gitignored by the project.
+
+### Hosted default key on deployment
+
+If you deploy to Vercel, set the environment variable `GEMINI_API_KEY` in your Vercel project settings. The hosted app will automatically use that key as a default via `/api/gemini` when no local Gemini key is configured.
+
+For local development with the proxy, create a `.env.local` file with:
+
+```bash
+GEMINI_API_KEY=your_real_gemini_key_here
+```
+
+If you have a local key stored in the browser or in `default-config.js`, those will be used first instead.
+
 ### Step 4: Enter Your Keys
 
 1. The onboarding wizard will guide you through 4 steps

--- a/public/AI ChatBot/chatbot.html
+++ b/public/AI ChatBot/chatbot.html
@@ -12,6 +12,7 @@
       rel="stylesheet"
     />
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="default-config.js" defer></script>
   </head>
   <body>
     <!-- ONBOARDING OVERLAY (first visit) -->

--- a/public/AI ChatBot/script.js
+++ b/public/AI ChatBot/script.js
@@ -17,8 +17,13 @@ const MODEL_NAMES = {
   "gemini-2.0-flash": "Gemini 2.0 Flash",
 };
 
+// Optional local default config file.
+// Create public/AI ChatBot/default-config.js and set window.DEFAULT_GEMINI_API_KEY.
+const DEFAULT_GEMINI_API_KEY = window.DEFAULT_GEMINI_API_KEY?.trim() || "";
+const GEMINI_PROXY_ENDPOINT = "/api/gemini";
+
 /* STATE */
-let apiKey = localStorage.getItem(STORAGE.API_KEY) || "";
+let apiKey = localStorage.getItem(STORAGE.API_KEY) || DEFAULT_GEMINI_API_KEY || "";
 let hfKey = localStorage.getItem(STORAGE.HF_KEY) || "";
 let sessions = loadSessions();
 let activeSessionId = null;
@@ -789,10 +794,6 @@ function togglePinnedView() {
 
 /* VOICE INPUT */
 function toggleVoice() {
-  if (!apiKey) {
-    openSettings();
-    return;
-  } // add this guard
   if (isListening) stopListening();
   else startListening();
 }
@@ -1098,11 +1099,6 @@ function handleSend() {
     return;
   }
 
-  if (!apiKey) {
-    openSettings();
-    return;
-  }
-
   // 🧠 LAZY SESSION CREATION
   let session = getCurrentSession();
 
@@ -1150,18 +1146,33 @@ async function getAIResponse() {
   if (sysProm) body.systemInstruction = { parts: [{ text: sysProm }] };
 
   try {
-    const res = await fetch(`${API_URL}?key=${apiKey}`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(body),
-    });
+    const useProxy = !apiKey;
+    const fetchOptions = useProxy
+      ? {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            model,
+            contents: chatHistory,
+            systemPrompt: sysProm,
+          }),
+        }
+      : {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(body),
+        };
+
+    const requestUrl = useProxy ? GEMINI_PROXY_ENDPOINT : `${API_URL}?key=${apiKey}`;
+    const res = await fetch(requestUrl, fetchOptions);
 
     removeTyping(typingRow);
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
+      const message = err.error?.message || err.error || `HTTP ${res.status}`;
       throw new Error(
-        err.error?.message || `HTTP ${res.status} — Check your API key.`,
+        message || "Unable to connect to Gemini. Check your hosted proxy or API key.",
       );
     }
 


### PR DESCRIPTION
## closes #4142 




## Description
Earlier user has to give their api key to use the chatbot,
Now while deploy, we can give a Gemini API key in vercel an it will automatically pick it up 
from there and use it as a default api key 

## Type of PR
BUG FIX









## Checklist
- [ ✅] I have performed a self-review of my code.
- [ ✅] I have read and followed the Contribution Guidelines.
- [ ]✅ I have tested the changes thoroughly before submitting this pull request.
- [ ✅] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [ ✅] I have commented my code, particularly in hard-to-understand areas.
- [✅ ] I have followed the code style guidelines of this project.
- [✅ ] I have checked for any existing open issues that my pull request may address.
- [ ✅] I have ensured that my changes do not break any existing functionality.

- [ ✅] I have read the resources for guidance listed below.
- [ ✅] I have followed security best practices in my code changes.
