### PR TITLE
fix: add size constraints and validation to recent projects queue

### DIFF
--- a/index.js
+++ b/index.js
@@ -918,9 +918,14 @@ function trackRecentProject(project) {
   // Add to front
   recentProjects.unshift(projectObj);
 
-  // Keep only the 20 most recent entries (not filtered by time yet)
-  if (recentProjects.length > 20) {
-    recentProjects.pop();
+  // Clean up any elements with corrupted properties or invalid timestamps
+  recentProjects = recentProjects.filter(item => {
+    return item && typeof item === 'object' && item.day && !isNaN(new Date(item.timestamp).getTime());
+  });
+
+  // Keep only the 10 most recent entries (not filtered by time yet)
+  if (recentProjects.length > 10) {
+    recentProjects = recentProjects.slice(0, 10);
   }
 
   try {


### PR DESCRIPTION
Closes #4870 

# Summary
Enforces storage constraints on recently-viewed project items, limiting the queue to exactly 10 entries and validating all timestamps before parsing.

# Changes Made
- Modified `trackRecentProject` to cap the array at 10 items.
- Added strict date-parsing safeguards.

# Testing
- Confirmed list length is correctly limited and that invalid timestamps are safely pruned.

# Impact
Improves long-term storage stability and prevents performance degradation.