### PR TITLE
fix: improve hero stats strip readability in light mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -2343,6 +2343,25 @@ body.light-mode .noise-layer {
   mix-blend-mode: multiply;
   opacity: 0.15;
 }
+
+body.light-mode .stats-strip {
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.02),
+    0 18px 60px rgba(37, 99, 235, 0.08);
+}
+
+body.light-mode .stats-strip .stat-item,
+body.light-mode .stats-strip .stat-item strong,
+body.light-mode .stats-strip span {
+  color: #0f172a;
+}
+
+body.light-mode .stats-strip .stat-divider {
+  color: rgba(15, 23, 42, 0.3);
+}
+
 @media (max-width: 768px) {
   .projects-header {
     align-items: stretch;
@@ -2350,9 +2369,10 @@ body.light-mode .noise-layer {
 
   body.light-mode .stats-strip {
     background: rgba(255, 255, 255, 0.85);
+    border: 1px solid rgba(15, 23, 42, 0.08);
     box-shadow:
-      0 0 0 1px rgba(0, 0, 0, 0.05),
-      0 18px 60px rgba(0, 0, 0, 0.02);
+      0 0 0 1px rgba(15, 23, 42, 0.02),
+      0 18px 60px rgba(37, 99, 235, 0.08);
   }
 
   body.light-mode .brand-mark {


### PR DESCRIPTION
## Summary
- Fixes homepage hero stats strip readability issue in light mode.
- Added `body.light-mode` overrides for `.stats-strip` background, border, and shadow to improve contrast.
- Added light-mode text color overrides for stats strip text and divider elements.

## Changes Made
- Updated `style.css` only.
- Added light-mode styles for:
  - `body.light-mode .stats-strip`
  - `body.light-mode .stats-strip .stat-item`
  - `body.light-mode .stats-strip .stat-item strong`
  - `body.light-mode .stats-strip span`
  - `body.light-mode .stats-strip .stat-divider`
- Aligned mobile light-mode `.stats-strip` override with the same border/shadow contrast pattern.

## Why
In light mode, stats strip text/blending had low contrast against the strip/background, making values harder to read.  
This change ensures consistent, accessible contrast while keeping dark mode behavior unchanged.

## Test Plan
- [ ] Open homepage in dark mode and confirm stats strip appearance is unchanged.
- [ ] Toggle to light mode and confirm stats strip background is light and text is clearly readable.
- [ ] Verify stat divider color is visible but subtle in light mode.
- [ ] Check responsive/mobile view (`max-width: 768px`) for matching light-mode styling.
- [ ] Confirm no HTML/JS behavior changes (CSS-only update).

## Issue
Closes #4717