### PR TITLE
Fix: Add password visibility toggle in Sign In and Sign Up forms (#4505)

### DIFF
--- a/public/Netflix_Cloning/Index.html
+++ b/public/Netflix_Cloning/Index.html
@@ -6,6 +6,30 @@
     <title>Netflix Clone</title>
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
+    <style>
+        .password-wrapper {
+            position: relative;
+            width: 100%;
+        }
+        .password-wrapper input {
+            width: 100%;
+            padding-right: 42px;
+            box-sizing: border-box;
+        }
+        .toggle-eye {
+            position: absolute;
+            right: 12px;
+            top: 50%;
+            transform: translateY(-50%);
+            cursor: pointer;
+            color: #aaa;
+            font-size: 16px;
+            user-select: none;
+        }
+        .toggle-eye:hover {
+            color: #fff;
+        }
+    </style>
 </head>
 <body>
 <a href="/" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 12px;border-radius:8px;background:white;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;box-shadow:0 8px 20px rgba(0, 0, 0);">? Back to Home</a>
@@ -67,7 +91,7 @@
     <section class="feature">
         <div class="text">
             <h2>Create profiles for kids</h2>
-            <p>Send children on adventures with their favourite characters in a space made just for them�free with your membership.</p>
+            <p>Send children on adventures with their favourite characters in a space made just for them—free with your membership.</p>
         </div>
         <img src="https://occ-0-2849-3646.1.nflxso.net/dnm/api/v6/19OhWN2dO19C9txTON9tvTFtefw/AAAABVr8nYuAg0xDpXDv0VI9HUoH7r2aGp4TKRCsKNQrMwxzTtr-NlwOHeS8bCI2oeZddmu3nMYr3j9MjYhHyjBASb1FaOGYZNYvPBCL.png?r=54d" alt="Kids">
     </section>
@@ -80,12 +104,12 @@
         <div class="faq-container">
             <button class="faq-question">What is Netflix?</button>
             <div class="faq-answer">
-                Netflix is a streaming service that offers a wide variety of award-winning TV shows, movies, anime, documentaries and more on thousands of internet-connected devices. You can watch as much as you want, when you want without a single ad � all for one low monthly price.
+                Netflix is a streaming service that offers a wide variety of award-winning TV shows, movies, anime, documentaries and more on thousands of internet-connected devices. You can watch as much as you want, when you want without a single ad — all for one low monthly price.
             </div>
 
             <button class="faq-question">How much does Netflix cost?</button>
             <div class="faq-answer">
-                Watch Netflix on your smartphone, tablet, Smart TV, laptop, or streaming device, all for one fixed monthly fee. Plans range from ?149 to ?649 a month. No extra costs, no contracts.
+                Watch Netflix on your smartphone, tablet, Smart TV, laptop, or streaming device, all for one fixed monthly fee. Plans range from ₹149 to ₹649 a month. No extra costs, no contracts.
             </div>
 
             <button class="faq-question">What can I watch on Netflix?</button>
@@ -162,9 +186,15 @@
                     <label for="signupEmail">Email Address</label>
                     <input type="email" id="signupEmail" placeholder="Enter your email" required>
                 </div>
+                <!-- ✅ FIX: Password visibility toggle added in Sign Up form -->
                 <div class="form-group">
                     <label for="signupPassword">Password</label>
-                    <input type="password" id="signupPassword" placeholder="Create a password" required>
+                    <div class="password-wrapper">
+                        <input type="password" id="signupPassword" placeholder="Create a password" required>
+                        <span class="toggle-eye" onclick="togglePassword('signupPassword', this)" title="Show/Hide Password">
+                            <i class="fas fa-eye"></i>
+                        </span>
+                    </div>
                 </div>
                 <button type="submit" class="btn-primary">Create Account</button>
             </form>
@@ -188,9 +218,15 @@
                     <label for="signinEmail">Email Address</label>
                     <input type="email" id="signinEmail" placeholder="Enter your email" required>
                 </div>
+                <!-- ✅ FIX: Password visibility toggle added in Sign In form -->
                 <div class="form-group">
                     <label for="signinPassword">Password</label>
-                    <input type="password" id="signinPassword" placeholder="Enter your password" required>
+                    <div class="password-wrapper">
+                        <input type="password" id="signinPassword" placeholder="Enter your password" required>
+                        <span class="toggle-eye" onclick="togglePassword('signinPassword', this)" title="Show/Hide Password">
+                            <i class="fas fa-eye"></i>
+                        </span>
+                    </div>
                 </div>
                 <button type="submit" class="btn-primary">Sign In</button>
             </form>
@@ -250,5 +286,21 @@
     </div>
 
     <script src="script.js"></script>
+    <script>
+        // ✅ FIX: Password visibility toggle function
+        function togglePassword(inputId, iconSpan) {
+            const input = document.getElementById(inputId);
+            const icon = iconSpan.querySelector('i');
+            if (input.type === 'password') {
+                input.type = 'text';
+                icon.classList.remove('fa-eye');
+                icon.classList.add('fa-eye-slash');
+            } else {
+                input.type = 'password';
+                icon.classList.remove('fa-eye-slash');
+                icon.classList.add('fa-eye');
+            }
+        }
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Related Issue
Fixes #4505

## Description
The password field in both Sign In and Sign Up modals had no show/hide 
toggle button, making it impossible for users to verify what they were 
typing. This led to login errors and poor user experience.

This PR adds a password visibility toggle (eye icon) to both forms using 
Font Awesome icons that were already included in the project.

## Type of PR
- [x] Bug fix

## Changes Made
- Wrapped password input fields in a `div.password-wrapper` in both 
  Sign In and Sign Up modals
- Added a clickable eye icon (`fa-eye` / `fa-eye-slash`) next to each 
  password field
- Added CSS in `<style>` tag for proper icon positioning
- Added `togglePassword()` JavaScript function at bottom of HTML file

## Screenshots/Videos
[Eye icon now visible next to password field — toggles between show/hide on click]

## Testing
- [x] Tested in Chrome
- [x] No console errors
- [x] Toggle works on both Sign In and Sign Up forms

## Checklist
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines
- [x] I have tested the changes thoroughly
- [x] My changes do not break any existing functionality
- [x] I have followed the code style guidelines of this project

## Additional Context
No external libraries were added. Font Awesome (already linked in the 
project) was used for the eye icon. Both Sign In and Sign Up forms are 
fixed as per the issue report.