### PR TITLE
Fix incorrect palindrome output generation

### DIFF
--- a/public/Palindrome_Generator/script.js
+++ b/public/Palindrome_Generator/script.js
@@ -39,8 +39,9 @@ document.addEventListener('DOMContentLoaded', () => {
         return str;
     };
 
-   const reversedValue = val.toLowerCase().split('').reverse().join('');
-   const palindromeResult = val.toLowerCase() + reversedValue;
+    const str = val.toLowerCase();
+    const palindromeResult = str + str.split('').reverse().join('');
+    
     // Update UI
     resultBox.className = "result-container mt-4 text-center success-bg";
     resultText.innerText = `Result: ${palindromeResult}`;

--- a/public/Palindrome_Generator/script.js
+++ b/public/Palindrome_Generator/script.js
@@ -39,8 +39,8 @@ document.addEventListener('DOMContentLoaded', () => {
         return str;
     };
 
-    const palindromeResult = makeShortestPalindrome(val.toLowerCase());
-
+   const reversedValue = val.toLowerCase().split('').reverse().join('');
+   const palindromeResult = val.toLowerCase() + reversedValue;
     // Update UI
     resultBox.className = "result-container mt-4 text-center success-bg";
     resultText.innerText = `Result: ${palindromeResult}`;


### PR DESCRIPTION
## Related Issue

Fixes #4920

## Description

This pull request fixes the incorrect palindrome generation logic in the Palindrome Generator project.

Previously, the application generated the shortest possible palindrome by appending only the required characters. However, the expected behavior is to append the complete reverse of the input string.

### Changes Made

* Updated palindrome generation logic.
* Implemented full reverse string concatenation.
* Verified output using multiple test cases.

### Test Cases

* hello → helloolleh
* abc → abccba
* 123 → 123321
* madam → madammadam

## Type of PR

* [x] Bug fix
* [ ] Feature enhancement
* [ ] Documentation update
* [ ] Security enhancement
* [ ] Other (specify): _______________

## Screenshots / Videos (if applicable)

Attached screenshots demonstrating the corrected palindrome output.

## Checklist

* [x] I have performed a self-review of my code.
* [x] I have read and followed the Contribution Guidelines.
* [x] I have tested the changes thoroughly before submitting this pull request.
* [x] I have provided relevant issue numbers, screenshots, and videos after making the changes.
* [x] I have followed the code style guidelines of this project.
* [x] I have ensured that my changes do not break any existing functionality.

## Additional Context

The palindrome generator now correctly appends the complete reverse of the input string, matching the expected output specified in Issue #4920.
