### PR TITLE
Fix: Show confirmation dialog when closing modal with unsaved data (#4504)

### DIFF
--- a/public/Netflix_Cloning/script.js
+++ b/public/Netflix_Cloning/script.js
@@ -108,6 +108,14 @@ function logoutUser() {
     localStorage.removeItem('currentUser');
 }
 
+// ============= HELPER: Check if form has data ============= 
+function hasFormData(formId) {
+    const form = document.getElementById(formId);
+    if (!form) return false;
+    const inputs = form.querySelectorAll('input');
+    return Array.from(inputs).some(input => input.value.trim() !== '');
+}
+
 // ============= MODAL FUNCTIONS ============= 
 function openSignupModal() {
     document.getElementById('signupModal').classList.add('active');
@@ -137,16 +145,31 @@ function switchToSignIn() {
     openSigninModal();
 }
 
-// Close modals when clicking outside
+// ✅ FIX: Close modals when clicking outside — with confirmation if form has data
 window.addEventListener('click', (event) => {
     const signupModal = document.getElementById('signupModal');
     const signinModal = document.getElementById('signinModal');
-    
+
     if (event.target === signupModal) {
-        closeSignupModal();
+        if (hasFormData('signupForm')) {
+            const confirmClose = confirm('Are you sure you want to leave? Your entered data will be lost.');
+            if (confirmClose) {
+                closeSignupModal();
+            }
+        } else {
+            closeSignupModal();
+        }
     }
+
     if (event.target === signinModal) {
-        closeSigninModal();
+        if (hasFormData('signinForm')) {
+            const confirmClose = confirm('Are you sure you want to leave? Your entered data will be lost.');
+            if (confirmClose) {
+                closeSigninModal();
+            }
+        } else {
+            closeSigninModal();
+        }
     }
 });
 


### PR DESCRIPTION
Fixes #4504

## Related Issue
Fixes #4504

## Description
In the Netflix Clone (Day 51), clicking outside the Sign In or Sign Up modal would immediately close it without any warning, causing all entered data to be lost. This was a poor user experience especially when a user had already typed their credentials.

This PR adds a confirmation dialog before closing the modal if the user has entered any data in the form fields.

## Type of PR
- [x] Bug fix

## Changes Made
- Added `hasFormData()` helper function to check if form fields have data.
- Modified the outside-click event listener to show a confirmation dialog when form has unsaved data.
- If form is empty, modal closes normally without any dialog.
- Works for both Sign In and Sign Up modals.

## Screenshots/Videos
- Before: Modal closed immediately on outside click, data was lost

<img width="893" height="683" alt="Screenshot 2026-05-27 125609" src="https://github.com/user-attachments/assets/c155c3a0-789e-4480-bc9a-e90fe7a5c291" />

- After: Confirmation dialog appears — "Are you sure you want to leave? 
  Your entered data will be lost." — user can choose to stay or leave

## Checklist
- [x] I have performed a self-review of my code
- [x] I have read and followed the Contribution Guidelines
- [x] I have tested the changes thoroughly
- [x] My changes do not break any existing functionality
- [x] I have followed the code style guidelines of this project

## Additional Context
Only `script.js` was modified. No new libraries or dependencies added.