### PR TITLE
Fix Undo System Allowing Game Revival After Game Over in 2048

### DIFF
--- a/public/2048_game/index.html
+++ b/public/2048_game/index.html
@@ -86,7 +86,14 @@
   <div class="tiles-layer" id="tl" aria-hidden="true"></div>
 
   <!-- Game-over / win overlay -->
-  <div id="ov" style="display:none" role="dialog" aria-modal="true" aria-label="Game result"></div>
+  <div
+  id="ov"
+  class="ov"
+  style="display:none"
+  role="dialog"
+  aria-modal="true"
+  aria-label="Game result">
+</div>
 
   <!-- Achievement pop-up -->
   <div class="achievement" id="ach" role="alert">

--- a/public/2048_game/script.js
+++ b/public/2048_game/script.js
@@ -603,6 +603,7 @@ function showOverlay(type) {
     <button class="btn" id="ov-replay-btn">Play Again</button>
   `;
   ov.style.display = 'flex';
+  ov.style.zIndex = '9999';
   // FIX: Clear out any previous listeners using a fresh replacement element reference
   const replayBtn = document.getElementById('ov-replay-btn');
   replayBtn.onclick = () => init();

--- a/public/2048_game/script.js
+++ b/public/2048_game/script.js
@@ -68,6 +68,7 @@ let moves = 0;
 let combo = 0;
 let over = false;
 let won = false;
+let undoLocked = false;
 let dark = false;
 let soundOn = true;
 let mode = 'classic';
@@ -371,7 +372,9 @@ function doMove(dir) {
 
   if (isLost()) {
     over = true;
-    showToast(reviveChance > 0 ? `Chance left: ${reviveChance}` : 'No chances left');
+    undoLocked = true;
+
+    showToast('Game Over');
     if (mode === 'timed') clearInterval(timerInterval);
     stats.games++;
     stats.best = Math.max(stats.best, score);
@@ -411,6 +414,7 @@ function init(resume = false) {
     paused = false;
     over = false;
     won = false;
+    undoLocked = false;
     prevBoard = null;
     prevScore = 0;
     addTile();
@@ -780,22 +784,25 @@ document.getElementById('nb').addEventListener('click', () => {
 });
 
 document.getElementById('ub').addEventListener('click', () => {
+  if (undoLocked) {
+    showToast('Undo unavailable after game over');
+    return;
+  }
+
   if (!prevBoard) {
     showToast('Nothing to undo');
     return;
   }
 
-  board = prevBoard;
+  board = copyBoard(prevBoard);
   score = prevScore;
   prevBoard = null;
+
   moves = Math.max(0, moves - 1);
-  over = false;
-  won = false;
 
   renderBoard();
   renderTiles();
   updateUI();
-  document.getElementById('ov').style.display = 'none';
 
   showToast('Undone!');
 });

--- a/public/2048_game/style.css
+++ b/public/2048_game/style.css
@@ -405,6 +405,7 @@ body.dark .logo {
   position: relative;
   width: fit-content;
   margin: 0 auto;
+  overflow: visible;
 }
 
 .board {
@@ -448,8 +449,7 @@ body.dark .cell {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  position: absolute;
-  inset: 0;
+  z-index: 5;
 }
 
 .tile {
@@ -615,8 +615,11 @@ body.dark .cell {
   align-items: center;
   justify-content: center;
   gap: 11px;
-  z-index: 15;
+
+  z-index: 9999; /* FIX */
   animation: fdin 0.35s ease;
+
+  backdrop-filter: blur(6px);
 }
 
 body.light .ov {
@@ -731,28 +734,30 @@ body.dark .ov {
 /* ---------- Toast ---------- */
 .toast {
   position: absolute;
-  bottom: -50px;
+  bottom: 20px;
   left: 50%;
   transform: translateX(-50%);
-  background: rgba(255, 255, 255, 0.18);
+
+  background: rgba(0, 0, 0, 0.85);
   color: #fff;
-  padding: 7px 18px;
+
+  padding: 10px 18px;
   border-radius: 20px;
+
   font-size: 13px;
   font-weight: 800;
+
   opacity: 0;
-  transition:
-    opacity 0.25s,
-    bottom 0.25s;
+  transition: opacity 0.25s ease;
+
   pointer-events: none;
   white-space: nowrap;
-  z-index: 30;
-  border: 1px solid rgba(255, 255, 255, 0.22);
+
+  z-index: 10000;
 }
 
 .toast.show {
   opacity: 1;
-  bottom: -42px;
 }
 
 /* ---------- Timer paused state ---------- */


### PR DESCRIPTION
##  Description

### Issue

The Undo feature in the 2048 game allowed players to bypass the game-over state. After losing, pressing the **Undo** button restored the previous board and reset the game state, enabling continued gameplay despite the game having already ended.

### Root Cause

The Undo handler restored the previous board and score while also resetting:

```javascript
over = false;
won = false;
```

This unintentionally revived the game after a legitimate game-over condition.

### Changes Made

- Added an `undoLocked` state variable.
- Locked Undo functionality once a game-over state is reached.
- Reset the lock when a new game starts.
- Added user feedback when Undo is attempted after game over.
- Preserved normal Undo behavior during active gameplay.

### Before

- Lose the game.
- Click **Undo**.
- Previous board is restored.
- Game-over state is cleared.
- User can continue playing.

### After

- Lose the game.
- Click **Undo**.
- Undo is blocked.
- Game-over state remains intact.
- User must start a new game.

### Benefits

- Prevents unintended game revival.  
- Maintains consistent gameplay rules.  
- Preserves existing Undo functionality during active games.  
- Improves game state integrity.

## Screenshots
<img width="1919" height="978" alt="image" src="https://github.com/user-attachments/assets/183c43a2-a2f7-4581-8f4b-d8f36deb4f49" />
<img width="1919" height="969" alt="image" src="https://github.com/user-attachments/assets/055d52a0-18ee-43d4-8e6f-5fef4e078b77" />
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/f6e2b277-c4ae-4d48-a6c8-258e1915cc8c" />
<img width="1919" height="983" alt="image" src="https://github.com/user-attachments/assets/dff49575-de47-41a5-afb5-d97342595c4d" />


##  Testing

### Test Case 1: Normal Undo

1. Start a game.
2. Make a move.
3. Click Undo.

**Expected:** Previous board and score are restored.



### Test Case 2: Undo Without Previous Move

1. Start a new game.
2. Click Undo immediately.

**Expected:** "Nothing to undo" message appears.



### Test Case 3: Game Over Protection

1. Play until no valid moves remain.
2. Trigger Game Over.
3. Click Undo.

**Expected:** "Undo unavailable after game over" message appears and game remains over.


### Test Case 4: New Game Reset

1. Reach Game Over.
2. Start a new game.
3. Make a move.
4. Click Undo.

**Expected:** Undo works normally.



### Test Case 5: Score Restoration

1. Make a move that increases score.
2. Click Undo.

**Expected:** Score returns to its previous value.


##  Related Issue

Fixes #3124