### PR TITLE
fix: rename misleading "Export Executive Brief" button to "Print Profile Summary"

### DIFF
--- a/public/github_profile_finder/index.html
+++ b/public/github_profile_finder/index.html
@@ -74,8 +74,8 @@
               <span>View GitHub Profile</span>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"></path><polyline points="15 3 21 3 21 9"></polyline><line x1="10" y1="14" x2="21" y2="3"></line></svg>
             </a>
-            <button id="exportPdfBtn" class="external-profile-btn" type="button" style="background: transparent; border-style: dashed; width: 100%;">
-              <span>Export Executive Brief</span>
+            <button id="printProfileBtn" class="external-profile-btn" type="button" style="background: transparent; border-style: dashed; width: 100%;" aria-label="Print Profile Summary">
+              <span>Print Profile Summary</span>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
             </button>
           </div>

--- a/public/github_profile_finder/script.js
+++ b/public/github_profile_finder/script.js
@@ -9,7 +9,7 @@ const UI = {
   themeToggle: document.getElementById("themeToggle"),
   themeIcon: document.getElementById("themeIcon"),
   offlineIndicator: document.getElementById("offlineIndicator"),
-  exportPdfBtn: document.getElementById("exportPdfBtn")
+  printProfileBtn: document.getElementById("printProfileBtn")
 };
 
 const Nodes = {
@@ -561,8 +561,8 @@ document.querySelectorAll(".workspace-tabs-nav .tab-nav-item").forEach(tabBtn =>
   });
 });
 
-if (UI.exportPdfBtn) {
-  UI.exportPdfBtn.addEventListener("click", () => {
+if (UI.printProfileBtn) {
+  UI.printProfileBtn.addEventListener("click", () => {
     window.print();
   });
 }


### PR DESCRIPTION
## Description

This PR fixes a UI/UX inconsistency in the GitHub Profile Finder project.

Currently, the button is labeled **"Export Executive Brief"**, but its functionality only triggers the browser's print dialog through `window.print()`. This can be confusing because users may expect a downloadable PDF report or an exported executive summary.

### Changes Made

* Renamed the button text from **"Export Executive Brief"** to **"Print Profile Summary"**
* Updated related element identifiers in JavaScript for better readability and consistency
* Improved clarity by making the button label accurately reflect its actual behavior

### Why This Change?

The current implementation does not export or generate any report. Renaming the button removes ambiguity and improves the overall user experience without changing existing functionality.

### Issue Fixed

Fixes #5028 
