### PR TITLE
Add 12h/24h format toggle with persistent preferences

### DIFF
--- a/public/digital_clock/digitalclock.css
+++ b/public/digital_clock/digitalclock.css
@@ -237,6 +237,26 @@ body {
   user-select: none;
 }
 
+.format-toggle {
+  background: var(--accent-light);
+  color: var(--accent);
+  padding: 10px 18px;
+  border-radius: 100px;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  border: 1px solid var(--accent-border);
+  cursor: pointer;
+  user-select: none;
+  transition: all 0.2s ease;
+  margin-bottom: 15px;
+}
+
+.format-toggle:hover {
+  transform: translateY(-1px);
+}
+
 .clock-top-row {
   display: flex;
   justify-content: space-between;

--- a/public/digital_clock/digitalclock.html
+++ b/public/digital_clock/digitalclock.html
@@ -46,6 +46,8 @@
         <span id="ampm" class="ampm" aria-label="AM or PM">PM</span>
       </section>
 
+      <button id="format-toggle" class="format-toggle">24H</button>
+
       <footer class="bottom-info">
         <div class="info-tag">
           <span class="info-tag-dot" aria-hidden="true"></span>

--- a/public/digital_clock/digitalclock.js
+++ b/public/digital_clock/digitalclock.js
@@ -11,6 +11,7 @@ let ringInterval = null;
 let audioCtx = null;
 let triggeredAlarms = new Set();
 let currentTimeTheme = "";
+let is24HourFormat = localStorage.getItem("is24HourFormat") === "true"; 
 
 // DOM Selectors
 const hoursEl = document.getElementById("hours");
@@ -29,6 +30,7 @@ const popupAlarmLabel = document.getElementById("popup-alarm-label");
 const alarmSound = document.getElementById("alarm-sound");
 const historyHeader = document.getElementById("history-header");
 const historyChevron = document.getElementById("history-chevron");
+const formatToggleBtn = document.getElementById("format-toggle");
 
 // World Clock Modal DOM
 const worldModal = document.getElementById("world-clock-modal");
@@ -81,9 +83,12 @@ document.addEventListener("DOMContentLoaded", () => {
   // Then apply manual accent color
   setAccentColor(activeAccent);
 
+  formatToggleBtn.textContent = is24HourFormat ? "12H" : "24H";
+
   populateTimezoneDropdown();
   renderAlarmsList();
   renderWorldClocks();
+  tickWorldClocks();
   renderHistoryLogs();
   updateAlarmSummary();
 
@@ -95,6 +100,16 @@ document.addEventListener("DOMContentLoaded", () => {
     tickWorldClocks();
     applyTimeBasedTheme();
   }, 1000);
+    formatToggleBtn.addEventListener("click", () => {
+    is24HourFormat = !is24HourFormat;
+
+    formatToggleBtn.textContent = is24HourFormat ? "12H" : "24H";
+
+    localStorage.setItem("is24HourFormat", is24HourFormat);
+
+    updateClock();
+    tickWorldClocks();
+});
 });
 
 // ================= ACCENT COLOR =================
@@ -125,12 +140,12 @@ function updateClock() {
   const s = now.getSeconds();
 
   const ampm = h >= 12 ? "PM" : "AM";
-  let hh = h % 12 || 12;
+  let hh = is24HourFormat ? h : (h % 12 || 12);
 
   hoursEl.textContent = String(hh).padStart(2, "0");
   minutesEl.textContent = String(m).padStart(2, "0");
   secondsEl.textContent = String(s).padStart(2, "0");
-  ampmEl.textContent = ampm;
+  ampmEl.textContent = is24HourFormat ? "" : ampm;
 
   const days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
   dayNameEl.textContent = days[now.getDay()];
@@ -452,7 +467,7 @@ function tickWorldClocks() {
       hour: "2-digit",
       minute: "2-digit",
       second: "2-digit",
-      hour12: true
+      hour12: !is24HourFormat
     });
   });
 }


### PR DESCRIPTION
## Related Issue

Closes #2844 

## Description

This PR adds support for switching between 12-hour and 24-hour time formats in the Digital Clock application.

### Changes Made

* Added a 12h/24h format toggle button
* Persisted the selected format using localStorage
* Applied the selected format consistently across all world clocks
* Fixed initial world clock rendering to prevent placeholder values from appearing on page load
* Added styling for the format toggle to match the existing UI design

### Testing

* Verified 12-hour format displays correctly
* Verified 24-hour format displays correctly
* Verified format preference persists after page refresh
* Verified world clocks update according to the selected format
* Verified clocks render correctly on initial page load

### Screenshots

12-hour format
<img width="1897" height="972" alt="image" src="https://github.com/user-attachments/assets/a7734670-5e2f-4b3c-9d53-3d74b8b78c8e" />

24-hour format
<img width="1890" height="965" alt="image" src="https://github.com/user-attachments/assets/731bda80-b804-4bad-8e5c-c5bdda903c65" />

