### PR TITLE
fix: remove leftover debug console logs in Weather Forcasting

### DIFF
--- a/public/Weather Forcasting/script.js
+++ b/public/Weather Forcasting/script.js
@@ -237,7 +237,6 @@ function buildWeatherSummary(data) {
 
 // FIX: Safe UI update for main weather card
 function updateWeatherCard(cityLabel, summary) {
-  console.log("UPDATING UI:", cityLabel, summary); // DEBUG
 
   if (!summary) {
     console.error("Summary is undefined");
@@ -456,15 +455,11 @@ function bindSearchForm() {
 
   if (!searchForm || !cityInput) return;
 
-  console.log("Search system initialized"); // DEBUG
-
   // FIX: form submit (button click also triggers this)
   searchForm.addEventListener("submit", (event) => {
     event.preventDefault(); // stop page refresh
 
     const city = cityInput.value.trim();
-
-    console.log("SEARCH CLICKED:", city); // DEBUG
 
     if (!city) return;
 


### PR DESCRIPTION
﻿## What changed
* Removed three console.log debug statements from public/Weather Forcasting/script.js.

## Why
The frontend code had several hardcoded console.log statements with // DEBUG comments that pollute the browser console. Removing these improves the application's production readiness and prevents unnecessary console spam when searching for weather.

## How to test
Run the relevant test suite:
`ash id="t1x9ab"
npm run lint
`
Expected result:
* The linter should successfully execute without reporting errors.

## Screenshots (if UI change)
N/A (Logic change only)

## Related issue
Closes #5136

---
## Pre-Submission Checklist
* [x] Branch named following GSSoC convention: ix/remove-weather-debug-logs
* [x] Changes committed with meaningful commit message
* [x] Changes pushed to remote fork
* [x] Relevant tests executed successfully
* [x] Code follows project contribution guidelines
