### PR TITLE
fix: remove unsafe eval() usage in Vanilla JavaScript Calculator

### DIFF
--- a/public/Vanilla-JavaScript-Calculator-master/script.js
+++ b/public/Vanilla-JavaScript-Calculator-master/script.js
@@ -80,7 +80,14 @@ class Calculator {
     if (this.expression === '' || this.expression === 'Error') return;
     try {
       const formatted = this.formatExpression(this.expression);
-      let result = eval(formatted);
+      
+      // Security: Validate the expression contains only math characters before execution
+      if (/[^0-9+\-*/().^\se]/.test(formatted)) {
+        throw new Error("Invalid characters in expression");
+      }
+      
+      // Safely evaluate without giving access to local scope
+      let result = new Function('return ' + formatted)();
       if (!isFinite(result) || isNaN(result)) {
         this.setError();
         return;


### PR DESCRIPTION
﻿## What changed
* Replaced the dangerous eval() execution in public/Vanilla-JavaScript-Calculator-master/script.js with a safer 
ew Function('return ' + formatted)() evaluator.
* Added a strict RegEx validation check (/[^0-9+\-*/().^\se]/) before execution to throw an error if any non-mathematical characters are present in the expression.

## Why
Using eval() is a critical security vulnerability and anti-pattern (CWE-94). If a malicious payload was ever introduced into the expression chain, it could execute arbitrary code. By validating the string first and using an isolated Function constructor, we eliminate the security risk while maintaining the calculator's full mathematical functionality.

## How to test
Run the relevant test suite:
`ash id="t1x9ab"
npm run lint
`
Expected result:
* The linter should pass with no errors. The calculator should work exactly as it did before.

## Screenshots (if UI change)
N/A 

## Related issue
Closes #5138

---
## Pre-Submission Checklist
* [x] Branch named following GSSoC convention
* [x] Changes committed with meaningful commit message
* [x] Changes pushed to remote fork
* [x] Relevant tests executed successfully
* [x] Code follows project contribution guidelines
