### PR TITLE
fix(filters): replace innerHTML with DOM methods in updateTechFilterDisplay to prevent XSS

### DIFF
--- a/index.js
+++ b/index.js
@@ -406,19 +406,29 @@ function updateTechFilterDisplay() {
 
   container.style.display = "flex";
 
-  // Render filter tags with remove buttons
-  tagsContainer.innerHTML = techStackFilters
-    .map(
-      (tech) => `
-    <span class="tech-filter-tag">
-      ${tech}
-      <button onclick="removeTechFilter('${tech}')" aria-label="Remove ${tech} filter">
-        <i class="fas fa-times"></i>
-      </button>
-    </span>
-  `,
-    )
-    .join("");
+  // Render filter tags using DOM methods to prevent XSS.
+  // Assigning techStackFilters values directly to innerHTML would allow a
+  // filter value containing HTML special characters or a quote-breaking
+  // sequence to inject markup or break out of the onclick attribute string.
+  tagsContainer.textContent = "";
+  techStackFilters.forEach((tech) => {
+    const span = document.createElement("span");
+    span.className = "tech-filter-tag";
+
+    const label = document.createTextNode(tech);
+    span.appendChild(label);
+
+    const btn = document.createElement("button");
+    btn.setAttribute("aria-label", `Remove ${tech} filter`);
+    btn.addEventListener("click", () => removeTechFilter(tech));
+
+    const icon = document.createElement("i");
+    icon.className = "fas fa-times";
+    btn.appendChild(icon);
+
+    span.appendChild(btn);
+    tagsContainer.appendChild(span);
+  });
 }
 
 /**


### PR DESCRIPTION
## Description

`updateTechFilterDisplay` built active filter chip markup by embedding raw `techStackFilters` values directly into `innerHTML` and into an inline `onclick` attribute string. A filter value containing HTML special characters or a quote-breaking sequence could inject markup into the DOM or break out of the `onclick` attribute and execute code. `techStackFilters` is populated from keyboard input in the tech search field, making this a reflected XSS vector.

## Root Cause

```js
tagsContainer.innerHTML = techStackFilters.map(tech => `
  <span class="tech-filter-tag">
    ${tech}
    <button onclick="removeTechFilter('${tech}')" ...>
  </span>
`).join('');
```

A value like `<img src=x onerror=alert(1)>` or `'); alert(1); ('` is injected verbatim.

## Related Issue

Closes #5107
Closes #5617

## Type of Change

- [x] Bug fix

## Changes Made

- `index.js`:
  - Replaced the `innerHTML` assignment in `updateTechFilterDisplay` with DOM element creation using `document.createElement`, `document.createTextNode`, and `addEventListener`.
  - Tag values are set via `createTextNode` so they are always treated as text, never as HTML.
  - The remove button uses `addEventListener('click', ...)` instead of an inline `onclick` attribute, so the tech value is passed as a closed-over reference and never interpolated into an attribute string.

## Testing Done

1. Add a normal tech filter (e.g., `javascript`): chip renders and remove button works as before.
2. Add a filter containing `<script>alert(1)</script>`: value renders as literal text, no script execution.
3. Add a filter containing `'); alert(1); ('`: value renders safely, no attribute breakout.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue