### PR TITLE
fix(api/gemini): add server-side model allowlist to prevent expensive model abuse

### DIFF
--- a/api/gemini.js
+++ b/api/gemini.js
@@ -16,9 +16,26 @@ module.exports = async (req, res) => {
     });
   }
 
+  // Server-side model allowlist. Accepting any caller-supplied model name lets
+  // a caller request expensive or experimental models (gemini-2.5-pro,
+  // gemini-1.5-pro-002) that cost significantly more per token. The server
+  // owner pays all charges, so only explicitly permitted models are allowed.
+  const ALLOWED_MODELS = new Set([
+    "gemini-2.5-flash",
+    "gemini-2.0-flash",
+    "gemini-1.5-flash",
+    "gemini-1.5-flash-8b",
+  ]);
+
   const { model, contents, systemPrompt } = req.body || {};
   if (!model || !Array.isArray(contents) || contents.length === 0) {
     return res.status(400).json({ error: "Invalid request body" });
+  }
+
+  if (!ALLOWED_MODELS.has(model)) {
+    return res.status(400).json({
+      error: `Model '${model}' is not permitted. Allowed models: ${[...ALLOWED_MODELS].join(", ")}`,
+    });
   }
 
   const payload = { contents };


### PR DESCRIPTION
## Description

Closes #5108

`api/gemini.js` accepted any caller-supplied `model` string and interpolated it directly into the Gemini API URL. Although `encodeURIComponent` prevented URL path traversal, it imposed no restriction on which models could be requested. A caller could request premium or experimental models (`gemini-2.5-pro`, `gemini-1.5-pro-002`) that cost significantly more per token than the intended flash models. The server owner bears all API charges.

**Root cause:** no model validation beyond checking that `model` is a non-empty string.

**Fix:** Added a server-side `ALLOWED_MODELS` Set containing only the explicitly permitted flash models. Any request specifying a model outside the allowlist is rejected with `400 Bad Request` before any call is made to the Gemini API.

Allowed models:
- `gemini-2.5-flash`
- `gemini-2.0-flash`
- `gemini-1.5-flash`
- `gemini-1.5-flash-8b`

## Related Issue

Closes #5108

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `api/gemini.js`: added `ALLOWED_MODELS` constant (a `Set`) and a rejection check before the existing request validation.

## Screenshots / Video (if applicable)

Not applicable. This is a server-side validation fix.

## Testing Done

1. Send `POST /api/gemini` with `{"model":"gemini-2.5-flash",...}`. Confirm the request proceeds normally.
2. Send with `{"model":"gemini-2.5-pro",...}`. Confirm `400` with model-not-permitted message.
3. Send with `{"model":"gemini-1.5-pro-002",...}`. Confirm `400`.
4. Send with an empty or missing `model`. Confirm the existing `400 Invalid request body` is returned.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] There are no merge conflicts with the base branch
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc