### PR TITLE
fix(api/gemini): cap contents array size to prevent token quota exhaustion per request

### DIFF
--- a/api/gemini.js
+++ b/api/gemini.js
@@ -38,6 +38,18 @@ module.exports = async (req, res) => {
     });
   }
 
+  // Bound the total serialised size of the contents array before forwarding.
+  // Without this check a single request containing a multi-megabyte payload
+  // can exhaust the token quota in one call. The limit of 32 KB is generous
+  // for normal chat turns and well within the UI's typical message sizes.
+  const MAX_CONTENTS_BYTES = 32 * 1024; // 32 KB
+  const contentsJson = JSON.stringify(contents);
+  if (contentsJson.length > MAX_CONTENTS_BYTES) {
+    return res.status(400).json({
+      error: `Request payload too large. The contents array must not exceed ${MAX_CONTENTS_BYTES} bytes when serialised.`,
+    });
+  }
+
   const payload = { contents };
   if (systemPrompt) {
     payload.systemInstruction = { parts: [{ text: systemPrompt }] };


### PR DESCRIPTION
## Description

Closes #5110

`api/gemini.js` validated that `contents` was a non-empty array but placed no bound on the total payload size. A single POST request with a contents array containing very long text parts (e.g. a 200 KB document) would forward the entire payload to the Gemini API, consuming a large fraction of the monthly token quota in one call at zero cost to the caller.

**Root cause:** structural validation (non-empty array) without size validation.

**Fix:** After the structural validation, serialize `contents` to JSON and reject the request with `400 Bad Request` if the byte length exceeds 32 KB. 32 KB is generous for normal conversational turns and well within what the AI ChatBot UI sends in practice, while blocking runaway single-request attacks that exhaust the quota.

## Related Issue

Closes #5110

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `api/gemini.js`: added `MAX_CONTENTS_BYTES = 32 * 1024` constant and a size check using `JSON.stringify(contents).length` between the structural validation and the payload assembly.

## Screenshots / Video (if applicable)

Not applicable. This is a server-side input validation fix.

## Testing Done

1. Send `POST /api/gemini` with a small, normal `contents` array (under 32 KB). Confirm the request proceeds normally.
2. Send with a `contents` array whose serialised JSON exceeds 32 KB (e.g. a text part containing 40 000 characters). Confirm `400 Request payload too large`.
3. Verify the error message includes the byte limit.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] There are no merge conflicts with the base branch
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc