### PR TITLE
fix(cards): correct indentation of project and description variables in buildProjectCardHTML

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,11 +208,8 @@ function buildProjectCardHTML({
         .split(/\s+/)
         .filter((t) => t && t !== SOURCE_ONLY_TAG);
   const tagsHTML = tagsArray.map((t) => `<span class="tag">${t}</span>`).join('');
-  const project =
-PROJECTS.find(p => p[1] === name);
-
-const description =
-getProjectDescription(project);
+  const project = PROJECTS.find((p) => p[1] === name);
+  const description = getProjectDescription(project);
   const sourceOnlyBadge = sourceOnly
     ? '<span class="source-only-badge" title="Requires local server setup">Source only</span>'
     : '';


### PR DESCRIPTION
## Description

Closes #4207

The `const project` and `const description` declarations inside `buildProjectCardHTML` were split across two lines with the second line at column 0:

```js
// Before — misleading indentation
const project =
PROJECTS.find(p => p[1] === name);

const description =
getProjectDescription(project);
```

Both assignments are valid inside the function (a `const` declaration after `=` cannot trigger ASI), but the zero-indentation of the continuation lines made them visually appear to be at module scope. This obscured the scope of `description` when reading `renderBookmarks` and made the null guard in `getProjectDescription` harder to verify.

**Fix:** Collapse each into a single properly-indented line:

```js
const project = PROJECTS.find((p) => p[1] === name);
const description = getProjectDescription(project);
```

The logic is unchanged. The null guard (`project && project[5]`) in `getProjectDescription` continues to handle the case where `PROJECTS.find` returns `undefined`.

## Related Issue

Closes #4207

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- `index.js`: collapsed two multi-line variable declarations in `buildProjectCardHTML` into single properly-indented lines.

## Screenshots / Video (if applicable)

Not applicable. This is a code clarity fix with no runtime behavior change.

## Testing Done

1. Open the app and bookmark several projects.
2. Open the Bookmarks panel. Confirm all bookmarked cards render with their correct names, descriptions, and tags.
3. Verify no console errors appear related to `description` being undefined.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] There are no merge conflicts with the base branch
- [x] I have not used any AI-generated content in this PR

## GSSoC Label Request

Could you please add the appropriate GSSoC 2026 label to this PR? It helps with tracking and scoring under GSSoC '26. Thank you!

program: gssoc