### PR TITLE
fix(links): handle absolute-path entries in getSourceUrl to fix broken Code buttons

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,6 +190,13 @@ function getSourceUrl(url, day) {
     const folderPath = trimmed.substring(2, trimmed.lastIndexOf("/"));
     return `https://github.com/${window.REPO_OWNER}/${window.REPO_NAME}/tree/Main/${folderPath}`;
   }
+  // Handle absolute paths such as /public/project/index.html.
+  // These fall through the ./ branch and previously returned the bare repo root,
+  // making the Code button link to the repository root instead of the project folder.
+  if (trimmed.startsWith("/")) {
+    const folderPath = trimmed.substring(1, trimmed.lastIndexOf("/"));
+    return `https://github.com/${window.REPO_OWNER}/${window.REPO_NAME}/tree/Main/${folderPath}`;
+  }
   return `https://github.com/${window.REPO_OWNER}/${window.REPO_NAME}/tree/Main`;
 }
 


### PR DESCRIPTION
## Description

`getSourceUrl` derived the GitHub source folder link from a project's path field. Paths starting with `./` were handled correctly. Paths starting with `/` (absolute paths such as `/public/project/index.html`) fell through to the final `return` statement, which pointed to the bare repository root. This made the Code button on those cards link to the repo root instead of the actual project source folder.

## Root Cause

```js
if (trimmed.startsWith('./')) {
  const folderPath = trimmed.substring(2, trimmed.lastIndexOf('/'));
  return `...tree/Main/${folderPath}`;
}
return `...tree/Main`; // fallback — wrong for absolute paths
```

No branch handled paths starting with `/`.

## Related Issue

Closes #4208

## Type of Change

- [x] Bug fix

## Changes Made

- `index.js`:
  - Added an explicit branch for paths starting with `/` in `getSourceUrl`. Strips the leading slash and builds the tree URL using the same `folderPath` logic as the `./` branch.

## Testing Done

1. Project with `./public/project/index.html`: Code button links to correct folder as before.
2. Project with `/public/project/index.html`: Code button now links to correct folder instead of repo root.
3. Projects with `http` or GitHub tree URLs: unchanged.

## Checklist

- [x] My code follows the style and formatting of this project
- [x] I have tested my changes locally and they work as expected
- [x] There are no merge conflicts with the base branch
- [x] This PR is linked to the correct issue