### PR TITLE
Fix silent repository fetch failures in GitHub Profile Battle

### DIFF
--- a/public/Github-Profile-Battle/script.js
+++ b/public/Github-Profile-Battle/script.js
@@ -140,7 +140,11 @@ async function fetchRepos(username) {
     const perPage = 100;
     while (true) {
         const res = await fetch(`${API_BASE}/users/${username}/repos?per_page=${perPage}&page=${page}&sort=updated`);
-        if (!res.ok) break;
+        if (!res.ok) {
+    throw new Error(
+        `Failed to fetch repositories for ${username} (HTTP ${res.status})`
+    );
+}
         const repos = await res.json();
         if (repos.length === 0) break;
         allRepos = allRepos.concat(repos);


### PR DESCRIPTION
## Summary

While testing the GitHub Profile Battle app, I noticed that repository fetch failures were being silently ignored. The code would stop fetching repositories when a request failed, which made it difficult to understand whether the issue was caused by a network problem, GitHub API rate limits, or another API error.

This PR updates the repository fetch logic to surface a clear error instead of failing silently.

## What Changed

* Added explicit error handling in `fetchRepos()`
* Included the HTTP status code in the error message
* Prevented repository API failures from being silently ignored
* Improved debugging and user feedback when repository requests fail

## Testing

* Tested with valid GitHub usernames and confirmed the battle works correctly
* Tested with invalid usernames and verified the appropriate error message is displayed
* Simulated offline/network failure conditions and confirmed repository fetch failures are now surfaced instead of being silently ignored

Fixes #5206 
