### PR TITLE
fix: validate dice count input range

### DIFF
--- a/public/Dice-Roller/main.html
+++ b/public/Dice-Roller/main.html
@@ -470,12 +470,22 @@
     });
 
     // ── Dice count ──
-    document.getElementById('diceCount').addEventListener('change', e => {
-        state.diceCount = Math.max(1, Math.min(10, parseInt(e.target.value) || 1));
-        state.rolls = [];
-        renderDice();
-    });
+document.getElementById('diceCount').addEventListener('change', e => {
+    let value = parseInt(e.target.value);
 
+    if (isNaN(value)) {
+        value = state.diceCount;
+    }
+
+    if (value < 1) value = 1;
+    if (value > 10) value = 10;
+
+    state.diceCount = value;
+    e.target.value = value;
+
+    state.rolls = [];
+    renderDice();
+});
     // ── Colour picker ──
     document.querySelectorAll('.color-option').forEach(opt => {
         opt.addEventListener('click', () => {


### PR DESCRIPTION
## Description

This pull request fixes the Dice Roller input validation issue by ensuring that the dice count always remains within the supported range of 1–10.

### What was fixed
- Added validation for invalid, empty, and non-numeric inputs.
- Prevented users from entering values below 1.
- Prevented users from entering values above 10.
- Automatically clamps out-of-range values to the nearest valid limit.
- Keeps the displayed input value synchronized with the internal application state.
- Prevents inconsistent behavior between the UI and dice rendering logic.

### Benefits
- Improves application reliability.
- Enhances user experience with safer input handling.
- Eliminates edge cases that could cause unexpected behavior.
- Ensures consistent dice rendering and statistics tracking.

### Testing
- Tested values below the minimum range (0, -1).
- Tested values above the maximum range (11, 20).
- Tested empty input.
- Tested valid values between 1 and 10.

Fixes #5215