### PR TITLE
Fix: Resolve empty img src attributes causing HTMLHint validation errors

### DIFF
--- a/public/AI Image Classifier/index.html
+++ b/public/AI Image Classifier/index.html
@@ -27,7 +27,7 @@
                 </p>
             </div>
             <div class="upload-area">
-                <img id="preview" src="" alt="Preview">
+                <img id="preview" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Preview">
                 <div class="upload-content" id="uploadContent">
                     <div class="upload-icon">
                         📸

--- a/public/AstronomyDashboard/astro.html
+++ b/public/AstronomyDashboard/astro.html
@@ -73,7 +73,7 @@
 
         <section class="apod-card feature-card">
             <div class="apod-image" id="apodImage" role="img" aria-label="NASA astronomy picture of the day">
-                <img id="apodImg" src="" alt="NASA astronomy picture of the day" referrerpolicy="no-referrer"
+                <img id="apodImg" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="NASA astronomy picture of the day" referrerpolicy="no-referrer"
                     decoding="async">
             </div>
             <div class="apod-copy">

--- a/public/Github-Profile-Battle/index.html
+++ b/public/Github-Profile-Battle/index.html
@@ -153,14 +153,14 @@
                 <div class="heatmaps-container">
                     <div class="heatmap-card glass-card">
                         <div class="heatmap-header">
-                            <img id="heatmapAvatar1" src="" alt="" class="heatmap-avatar">
+                            <img id="heatmapAvatar1" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="" class="heatmap-avatar">
                             <span id="heatmapName1" class="heatmap-name"></span>
                         </div>
                         <div id="heatmap1" class="heatmap-grid"></div>
                     </div>
                     <div class="heatmap-card glass-card">
                         <div class="heatmap-header">
-                            <img id="heatmapAvatar2" src="" alt="" class="heatmap-avatar">
+                            <img id="heatmapAvatar2" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="" class="heatmap-avatar">
                             <span id="heatmapName2" class="heatmap-name"></span>
                         </div>
                         <div id="heatmap2" class="heatmap-grid"></div>

--- a/public/ImageCompressor/index.html
+++ b/public/ImageCompressor/index.html
@@ -133,9 +133,9 @@
 
                 <!-- Comparison Slider Component -->
                 <div class="image-compare-container" id="compareContainer">
-                    <img src="" alt="Compressed" id="compareCompressed" class="compare-img">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Compressed" id="compareCompressed" class="compare-img">
                     <div class="compare-overlay" id="compareOverlay">
-                        <img src="" alt="Original" id="compareOriginal" class="compare-img">
+                        <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Original" id="compareOriginal" class="compare-img">
                     </div>
                     <div class="compare-slider-handle" id="compareHandle">
                         <div class="handle-line"></div>

--- a/public/Music App/index.html
+++ b/public/Music App/index.html
@@ -49,7 +49,7 @@
                     <h2 id="heroTitle">Select a track</h2>
                     <p id="heroMeta">Choose any song from the library to start listening.</p>
                 </div>
-                <img id="heroCover" class="hero-cover" src="" alt="" />
+                <img id="heroCover" class="hero-cover" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="" />
             </section>
 
             <section class="library-section" aria-label="Song library">
@@ -68,7 +68,7 @@
 
         <footer class="player-bar" aria-label="Music player">
             <div class="track-summary">
-                <img id="playerCover" src="" alt="" />
+                <img id="playerCover" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="" />
                 <div>
                     <strong id="playerTitle">Nothing playing</strong>
                     <span id="playerArtist">Pick a track to begin</span>

--- a/public/Streak-Visualizer/index.html
+++ b/public/Streak-Visualizer/index.html
@@ -31,7 +31,7 @@
             
             <div id="card1" class="user-card">
                 <div class="profile-card">
-                    <img src="" alt="Avatar" id="avatar1" class="avatar">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Avatar" id="avatar1" class="avatar">
                     <div class="profile-info">
                         <h2 id="name1">User 1</h2>
                         <p class="rank-text">Solved: <span id="solved1" class="highlight-green">0</span> <span id="solvedCrown1" class="hidden">👑</span></p>
@@ -51,7 +51,7 @@
 
             <div id="card2" class="user-card hidden">
                 <div class="profile-card">
-                    <img src="" alt="Avatar" id="avatar2" class="avatar">
+                    <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Avatar" id="avatar2" class="avatar">
                     <div class="profile-info">
                         <h2 id="name2">User 2</h2>
                         <p class="rank-text">Solved: <span id="solved2" class="highlight-green">0</span> <span id="solvedCrown2" class="hidden">👑</span></p>

--- a/public/geo-guesser/index.html
+++ b/public/geo-guesser/index.html
@@ -107,7 +107,7 @@
 
           <div class="hint-content" id="hintContent">
             <div class="hint-image">
-              <img id="hintImage" src="" alt="Location hint" />
+              <img id="hintImage" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Location hint" />
             </div>
             <div class="hint-text">
               <h3 id="hintTitle">Mystery Location</h3>

--- a/public/github_profile_finder/index.html
+++ b/public/github_profile_finder/index.html
@@ -59,7 +59,7 @@
         
         <div class="profile-essence">
           <div class="avatar-wrapper">
-            <img id="avatar" class="dashboard-avatar" src="" alt="GitHub avatar representation" />
+            <img id="avatar" class="dashboard-avatar" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="GitHub avatar representation" />
           </div>
           
           <div class="identity-block">

--- a/public/indianflag/flag.html
+++ b/public/indianflag/flag.html
@@ -48,7 +48,7 @@
 
       <div class="quote-container">
         <div class="image-wrapper">
-          <img id="patriot-image" src="" alt="Patriot Image" />
+          <img id="patriot-image" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Patriot Image" />
         </div>
 
         <div class="quote">


### PR DESCRIPTION
I noticed that some projects had empty src="" in image tags, which was causing HTMLHint validation errors in CI.

I’ve fixed it by replacing the empty src with a small valid placeholder image so the lint checks don’t fail anymore and the images don’t break in the browser.

Changes:
Fixed empty src in multiple project files
Replaced them with a 1x1 transparent image (data URI)
No change in functionality, just fixing validation issues
Files updated:
AI Image Classifier
Astronomy Dashboard
GitHub Profile Battle
Image Compressor
Music App
Streak Visualizer
Geo Guesser
GitHub Profile Finder
Indian Flag project

fixes issue #5325 