### PR TITLE
Add PDF export functionality to periodic table

### DIFF
--- a/public/Periodic Table/index.html
+++ b/public/Periodic Table/index.html
@@ -62,9 +62,12 @@
             </option>
 
         </select>
+        <button id="exportPdfBtn">
+    Export PDF
+</button>
 
     </div>
-
+<div id="pdfExportArea">
 
     <!-- Legend -->
     <div class="legend"></div>
@@ -164,6 +167,7 @@ Select a trend property
     </div>
 
 
+</div>
 </div>
 
 
@@ -392,6 +396,8 @@ Trails
 
 
 <script src="script.js?v=2024"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </body>
 </html>

--- a/public/Periodic Table/script.js
+++ b/public/Periodic Table/script.js
@@ -706,7 +706,7 @@ el.symbol.toLowerCase();
 
 lanContainer.appendChild(lanLabel);
 lanContainer.appendChild(lanRow);
-document.querySelector(".main-container").appendChild(lanContainer);
+document.getElementById("pdfExportArea").appendChild(lanContainer);
 
 
 //--------------Add Actinides------------------
@@ -753,7 +753,9 @@ el.symbol.toLowerCase();
 
 actContainer.appendChild(actLabel);
 actContainer.appendChild(actRow);
-document.querySelector(".periodic-table-wrapper").appendChild(actContainer);
+document
+.getElementById("pdfExportArea")
+.appendChild(actContainer);
 
 
 // Filter categories from Dropdown List
@@ -1424,3 +1426,240 @@ document
 trendFilter.value="none";
 
 });
+const exportBtn =
+document.getElementById(
+"exportPdfBtn"
+);
+
+exportBtn.addEventListener(
+"click",
+exportPeriodicTablePDF
+);
+
+async function exportPeriodicTablePDF(){
+
+    const area =
+    document.getElementById(
+    "pdfExportArea"
+    );
+
+    await document.fonts?.ready;
+    await new Promise(resolve => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+    const areaRect =
+    area.getBoundingClientRect();
+
+    const captureWidth =
+    Math.ceil(
+    Math.max(area.scrollWidth, areaRect.width)
+    );
+
+    const captureHeight =
+    Math.ceil(
+    Math.max(area.scrollHeight, areaRect.height)
+    );
+
+    console.group("Periodic Table PDF export diagnostics");
+    console.log("DOM", {
+        pdfExportArea: {
+            rect: {
+                x: areaRect.x,
+                y: areaRect.y,
+                width: areaRect.width,
+                height: areaRect.height
+            },
+            scrollWidth: area.scrollWidth,
+            scrollHeight: area.scrollHeight,
+            elementCards: area.querySelectorAll(".element").length,
+            containsMainTable: area.contains(
+                document.querySelector(".table-container")
+            ),
+            containsLanthanoids:
+            area.contains(lanContainer),
+            containsActinides:
+            area.contains(actContainer)
+        },
+        mainContainer:
+        document.querySelector(".main-container").getBoundingClientRect(),
+        periodicTableWrapper:
+        document.querySelector(".periodic-table-wrapper").getBoundingClientRect(),
+        periodicTable:
+        document.querySelector(".table-container").getBoundingClientRect()
+    });
+
+    const canvas =
+    await html2canvas(area,{
+        scale:2,
+        useCORS:true,
+        backgroundColor:"#ffffff",
+        width:captureWidth,
+        height:captureHeight,
+        windowWidth:captureWidth,
+        windowHeight:captureHeight,
+        scrollX:0,
+        scrollY:0,
+        onclone:(clonedDocument)=>{
+            const clonedArea =
+            clonedDocument.getElementById("pdfExportArea");
+
+            const clonedMain =
+            clonedDocument.querySelector(".main-container");
+
+            if(clonedMain){
+                clonedMain.style.alignItems =
+                "flex-start";
+            }
+
+            if(clonedArea){
+                clonedArea.style.width =
+                `${captureWidth}px`;
+
+                clonedArea.style.height =
+                `${captureHeight}px`;
+
+                clonedArea.style.overflow =
+                "visible";
+
+                clonedArea
+                .querySelectorAll(".element")
+                .forEach(element=>{
+                    element.style.animation =
+                    "none";
+                });
+            }
+        }
+    });
+
+    console.log("Canvas", {
+        width: canvas.width,
+        height: canvas.height,
+        cssWidth: captureWidth,
+        cssHeight: captureHeight
+    });
+
+    const imgData =
+    canvas.toDataURL(
+    "image/png"
+    );
+
+    const { jsPDF } =
+    window.jspdf;
+
+    const pdf =
+    new jsPDF(
+    "landscape",
+    "mm",
+    "a4"
+    );
+    const propertyName =
+trendFilter.value === "none"
+?
+"Periodic Table"
+:
+trendDefinitions[
+trendFilter.value
+].title;
+
+pdf.setFontSize(18);
+
+pdf.text(
+`Periodic Table - ${propertyName}`,
+10,
+10
+);
+
+    const pdfWidth =
+    pdf.internal.pageSize.getWidth();
+
+    const pageHeight =
+pdf.internal.pageSize.getHeight();
+
+const margin =
+10;
+
+const titleHeight =
+12;
+
+const contentWidth =
+pdfWidth - (margin * 2);
+
+const contentTop =
+margin + titleHeight;
+
+const contentHeight =
+pageHeight - contentTop - margin;
+
+const imgHeight =
+(canvas.height * contentWidth)
+/ canvas.width;
+
+let heightLeft =
+imgHeight;
+
+let position =
+contentTop;
+
+console.log("PDF", {
+    pageWidth: pdfWidth,
+    pageHeight,
+    imageWidth: contentWidth,
+    imageHeight: imgHeight,
+    contentTop,
+    contentHeight,
+    pages: Math.ceil(imgHeight / contentHeight)
+});
+console.groupEnd();
+
+pdf.addImage(
+imgData,
+"PNG",
+margin,
+position,
+contentWidth,
+imgHeight
+);
+
+heightLeft -= contentHeight;
+
+while(heightLeft > 0){
+
+position =
+contentTop - (imgHeight - heightLeft);
+
+pdf.addPage();
+
+pdf.setFontSize(18);
+
+pdf.text(
+`Periodic Table - ${propertyName}`,
+margin,
+margin
+);
+
+pdf.addImage(
+imgData,
+"PNG",
+margin,
+position,
+contentWidth,
+imgHeight
+);
+
+heightLeft -= contentHeight;
+}
+
+  
+
+    const property =
+    trendFilter.value === "none"
+    ?
+    "PeriodicTable"
+    :
+    trendDefinitions[
+        trendFilter.value
+    ].title.replaceAll(" ","-");
+    pdf.save(
+    `${property}.pdf`
+    );
+
+}

--- a/public/Periodic Table/styles.css
+++ b/public/Periodic Table/styles.css
@@ -1091,3 +1091,18 @@ text-decoration:underline;
 color:#1d4ed8;
 
 }
+
+#exportPdfBtn{
+    padding:10px 18px;
+    border:none;
+    border-radius:10px;
+    cursor:pointer;
+    background:#2563eb;
+    color:white;
+    font-weight:600;
+    transition:.3s;
+}
+
+#exportPdfBtn:hover{
+    transform:translateY(-2px);
+}


### PR DESCRIPTION
## Related Issue

Closes #5332

## Summary

Added a dynamic PDF export feature to the Periodic Table visualization. Users can now download the currently displayed periodic table along with the selected property visualization, legend, and trend analysis for offline reference and sharing.

## Changes Made

* Added an **Export PDF** button to the Periodic Table interface.
* Integrated **html2canvas** and **jsPDF** for PDF generation.
* Implemented dynamic export of the currently rendered periodic table view.
* Included property-specific PDF naming based on the selected trend/property.
* Added support for exporting legends and trend analysis information.
* Refactored and cleaned up PDF export logic to improve maintainability.

## Testing

* [x] Tested locally
* [x] Verified responsive behavior where applicable
* [x] Checked accessibility impact where applicable
* [x] Confirmed there are no unrelated changes in the branch

## Screenshots

<img width="1885" height="915" alt="image" src="https://github.com/user-attachments/assets/c6560500-8fa7-4276-aed1-a07421b493d9" />
<img width="1485" height="860" alt="image" src="https://github.com/user-attachments/assets/d58d9b5b-d047-4852-ac05-0684d26d6e6a" />


## Impact

This enhancement allows students, educators, and users to easily save and share periodic table visualizations. It improves the educational value of the project by providing downloadable references for different chemical property trends.

## Checklist

* [x] Code follows project standards
* [x] Tested locally
* [x] No unrelated changes included
* [x] Responsive behavior verified
* [x] Accessibility considered
