### PR TITLE
feat(morse-translator): Add keyboard shortcuts for Play, Clear and Copy #4217

### DIFF
--- a/public/MorseCodeTranslator/index.html
+++ b/public/MorseCodeTranslator/index.html
@@ -1,99 +1,146 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Morse Code Translator</title>
-  <link rel="stylesheet" href="style.css">
-</head>
-<body>
-<a href="/" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 12px;border-radius:8px;background:white;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;box-shadow:0 8px 20px rgba(0, 0, 0);">← Back to Home</a>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Morse Code Translator</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <a
+      href="/"
+      class="project-back-button"
+      style="
+        position: fixed;
+        left: 18px;
+        top: 18px;
+        padding: 8px 12px;
+        border-radius: 8px;
+        background: white;
+        text-decoration: none;
+        z-index: 9999;
+        font-weight: 700;
+        font-family: Inter, system-ui, sans-serif;
+        box-shadow: 0 8px 20px rgba(0, 0, 0);
+      "
+      >← Back to Home</a
+    >
 
-
-  <div class="bg-orbs" aria-hidden="true">
-    <div class="orb orb-1"></div>
-    <div class="orb orb-2"></div>
-    <div class="orb orb-3"></div>
-  </div>
-  <main class="container">
-    <header>
-      <div class="signal-bars" aria-hidden="true">
-        <span></span><span></span><span></span><span></span>
-      </div>
-      <h1>Morse Code Translator</h1>
-      <p>Encode and decode messages — and hear them too</p>
-    </header>
-    <div class="mode-toggle" role="group" aria-label="Translation mode">
-      <button class="mode-btn active" id="encode-btn">Text → Morse</button>
-      <button class="mode-btn" id="decode-btn">Morse → Text</button>
+    <div class="bg-orbs" aria-hidden="true">
+      <div class="orb orb-1"></div>
+      <div class="orb orb-2"></div>
+      <div class="orb orb-3"></div>
     </div>
-    <div class="panels">
-      <div class="panel glass">
-        <div class="panel-header">
-          <span class="panel-label" id="input-label">Text</span>
-          <button class="icon-btn" id="clear-btn" title="Clear input" aria-label="Clear input">✕</button>
+    <main class="container">
+      <header>
+        <div class="signal-bars" aria-hidden="true">
+          <span></span><span></span><span></span><span></span>
         </div>
-        <textarea
-          id="input"
-          placeholder="Type your message..."
-          aria-label="Input text"
-          spellcheck="false"
-        ></textarea>
-        <div class="char-count"><span id="char-count">0</span> characters</div>
+        <h1>Morse Code Translator</h1>
+        <p>Encode and decode messages — and hear them too</p>
+      </header>
+      <div class="mode-toggle" role="group" aria-label="Translation mode">
+        <button class="mode-btn active" id="encode-btn">Text → Morse</button>
+        <button class="mode-btn" id="decode-btn">Morse → Text</button>
       </div>
+      <div class="panels">
+        <div class="panel glass">
+          <div class="panel-header">
+            <span class="panel-label" id="input-label">Text</span>
+            <button
+              class="icon-btn"
+              id="clear-btn"
+              title="Clear input"
+              aria-label="Clear input"
+            >
+              ✕
+            </button>
+          </div>
+          <textarea
+            id="input"
+            placeholder="Type your message..."
+            aria-label="Input text"
+            spellcheck="false"
+          ></textarea>
+          <div class="char-count">
+            <span id="char-count">0</span> characters
+          </div>
+        </div>
 
-      <!-- ── NEW: swap button added inside existing divider ──────── -->
-      <div class="divider" aria-hidden="true">
-        <div class="arrow-wrap">
-          <span class="arrow">→</span>
+        <!-- ── NEW: swap button added inside existing divider ──────── -->
+        <div class="divider" aria-hidden="true">
+          <div class="arrow-wrap">
+            <span class="arrow">→</span>
+          </div>
+          <button
+            class="swap-btn"
+            id="swap-btn"
+            title="Swap panels"
+            aria-label="Swap input and output panels"
+          >
+            ⇄
+          </button>
         </div>
-        <button
-          class="swap-btn"
-          id="swap-btn"
-          title="Swap panels"
-          aria-label="Swap input and output panels"
-        >⇄</button>
-      </div>
 
-      <div class="panel glass">
-        <div class="panel-header">
-          <span class="panel-label" id="output-label">Morse Code</span>
-          <button class="icon-btn" id="copy-btn" title="Copy output" aria-label="Copy output">&#x2398;</button>
+        <div class="panel glass">
+          <div class="panel-header">
+            <span class="panel-label" id="output-label">Morse Code</span>
+            <button
+              class="icon-btn"
+              id="copy-btn"
+              title="Copy output"
+              aria-label="Copy output"
+            >
+              &#x2398;
+            </button>
+          </div>
+          <div id="output" class="output-area" role="status" aria-live="polite">
+            —
+          </div>
         </div>
-        <div id="output" class="output-area" role="status" aria-live="polite">—</div>
       </div>
-    </div>
-    <div class="audio-controls glass">
-      <button class="play-btn" id="play-btn" aria-label="Play Morse audio">
-        <span id="play-icon" aria-hidden="true">▶</span>
-        <span id="play-label">Play Audio</span>
+      <div class="audio-controls glass">
+        <button class="play-btn" id="play-btn" aria-label="Play Morse audio">
+          <span id="play-icon" aria-hidden="true">▶</span>
+          <span id="play-label">Play Audio</span>
+        </button>
+        <div class="speed-control">
+          <span class="speed-label">Slow</span>
+          <input
+            type="range"
+            id="speed"
+            min="5"
+            max="30"
+            value="15"
+            aria-label="Playback speed in WPM"
+          />
+          <span class="speed-label">Fast</span>
+          <span class="speed-val" id="speed-val">15 WPM</span>
+        </div>
+      </div>
+      <button
+        class="ref-toggle glass"
+        aria-expanded="false"
+        id="ref-toggle-btn"
+      >
+        Morse Reference <span id="ref-arrow">▾</span>
       </button>
-      <div class="speed-control">
-        <span class="speed-label">Slow</span>
-        <input
-          type="range"
-          id="speed"
-          min="5"
-          max="30"
-          value="15"
-          aria-label="Playback speed in WPM"
-        >
-        <span class="speed-label">Fast</span>
-        <span class="speed-val" id="speed-val">15 WPM</span>
-      </div>
+      <div
+        class="ref-table"
+        id="ref-table"
+        role="table"
+        aria-label="Morse code reference chart"
+      ></div>
+    </main>
+    <!-- Keyboard shortcuts hint bar -->
+    <div class="kbd-hints" aria-label="Keyboard shortcuts">
+      <span class="kbd-hint"><kbd>Ctrl</kbd>+<kbd>Enter</kbd> Play</span>
+      <span class="kbd-hint"><kbd>Esc</kbd> Clear</span>
+      <span class="kbd-hint"
+        ><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> Copy</span
+      >
     </div>
-    <button class="ref-toggle glass" aria-expanded="false" id="ref-toggle-btn">
-      Morse Reference <span id="ref-arrow">▾</span>
-    </button>
-    <div class="ref-table" id="ref-table" role="table" aria-label="Morse code reference chart"></div>
-  </main>
-  <!-- Keyboard shortcuts hint bar -->
-  <div class="kbd-hints" aria-label="Keyboard shortcuts">
-    <span class="kbd-hint"><kbd>Ctrl</kbd>+<kbd>Enter</kbd> Play</span>
-    <span class="kbd-hint"><kbd>Esc</kbd> Clear</span>
-    <span class="kbd-hint"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> Copy</span>
-  </div>
 
-  <script src="script.js"></script>
-</body>
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/public/MorseCodeTranslator/index.html
+++ b/public/MorseCodeTranslator/index.html
@@ -93,6 +93,14 @@
             >
               &#x2398;
             </button>
+            <button
+              class="icon-btn"
+              id="download-btn"
+              title="Download output as .txt"
+              aria-label="Download output as text file"
+            >
+              ↓
+            </button>
           </div>
           <div id="output" class="output-area" role="status" aria-live="polite">
             —

--- a/public/MorseCodeTranslator/index.html
+++ b/public/MorseCodeTranslator/index.html
@@ -87,6 +87,13 @@
     </button>
     <div class="ref-table" id="ref-table" role="table" aria-label="Morse code reference chart"></div>
   </main>
+  <!-- Keyboard shortcuts hint bar -->
+  <div class="kbd-hints" aria-label="Keyboard shortcuts">
+    <span class="kbd-hint"><kbd>Ctrl</kbd>+<kbd>Enter</kbd> Play</span>
+    <span class="kbd-hint"><kbd>Esc</kbd> Clear</span>
+    <span class="kbd-hint"><kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>C</kbd> Copy</span>
+  </div>
+
   <script src="script.js"></script>
 </body>
 </html>

--- a/public/MorseCodeTranslator/script.js
+++ b/public/MorseCodeTranslator/script.js
@@ -364,6 +364,25 @@ document.addEventListener('DOMContentLoaded', () => {
   el('ref-toggle-btn').addEventListener('click', toggleRef);
   el('encode-btn').addEventListener('click', () => setMode('encode'));
   el('decode-btn').addEventListener('click', () => setMode('decode'));
-  el('swap-btn').addEventListener('click', swapPanels); // NEW
+
+  // ── Keyboard shortcuts ──────────────────────────────────────────
+  // When inside textarea: only Escape (clear) and Ctrl+Enter (play)
+  // Outside textarea: Ctrl+Shift+C (copy)
+  document.addEventListener('keydown', (e) => {
+    if (e.target.tagName === 'TEXTAREA') {
+      if (e.key === 'Escape') { clearInput(); return; }
+      if (e.ctrlKey && e.key === 'Enter') {
+        e.preventDefault();
+        togglePlay();
+        return;
+      }
+      return;
+    }
+    if (e.ctrlKey && e.shiftKey && e.key === 'C') {
+      e.preventDefault();
+      copyOutput();
+    }
+  });
+
   buildRefTable();
 });

--- a/public/MorseCodeTranslator/script.js
+++ b/public/MorseCodeTranslator/script.js
@@ -149,7 +149,19 @@ const clearInput = () => {
   el("output").textContent = "—";
   el("char-count").textContent = "0";
 };
-
+// ── Download output as .txt file ──────────────────────────────────
+const downloadOutput = () => {
+  const text = el("output").textContent;
+  if (text === "—" || !text.trim()) return;
+  const blob = new Blob([text], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `morse-${mode}-${Date.now()}.txt`;
+  a.click();
+  URL.revokeObjectURL(url);
+  showToast("Downloaded!");
+};
 const copyOutput = () => {
   const text = el("output").textContent;
   if (text === "—" || text === "-") return;
@@ -411,6 +423,7 @@ document.addEventListener("DOMContentLoaded", () => {
   el("clear-btn").addEventListener("click", clearInput);
   el("copy-btn").addEventListener("click", copyOutput);
   el("play-btn").addEventListener("click", togglePlay);
+  el("download-btn").addEventListener("click", downloadOutput);
   el("speed").addEventListener("input", updateSpeed);
   el("ref-toggle-btn").addEventListener("click", toggleRef);
   el("encode-btn").addEventListener("click", () => setMode("encode"));

--- a/public/MorseCodeTranslator/script.js
+++ b/public/MorseCodeTranslator/script.js
@@ -1,16 +1,55 @@
 const MORSE_MAP = {
-  'A':'.-',   'B':'-...', 'C':'-.-.', 'D':'-..', 'E':'.',
-  'F':'..-.', 'G':'--.',  'H':'....', 'I':'..',  'J':'.---',
-  'K':'-.-',  'L':'.-..', 'M':'--',   'N':'-.',  'O':'---',
-  'P':'.--.', 'Q':'--.-', 'R':'.-.',  'S':'...', 'T':'-',
-  'U':'..-',  'V':'...-', 'W':'.--',  'X':'-..-','Y':'-.--',
-  'Z':'--..',
-  '0':'-----', '1':'.----', '2':'..---', '3':'...--', '4':'....-',
-  '5':'.....', '6':'-....', '7':'--...', '8':'---..', '9':'----.',
-  '.':'.-.-.-', ',':'--..--', '?':'..--..', '!':'-.-.--',
-  '/':'-..-.', '(':'-.--.', ')':'-.--.-', '&':'.-...',
-  ':':'---...', ';':'-.-.-.', '=':'-...-', '+':'.-.-.',
-  '-':'-....-', '_':'..--.-', '@':'.--.-.'
+  A: ".-",
+  B: "-...",
+  C: "-.-.",
+  D: "-..",
+  E: ".",
+  F: "..-.",
+  G: "--.",
+  H: "....",
+  I: "..",
+  J: ".---",
+  K: "-.-",
+  L: ".-..",
+  M: "--",
+  N: "-.",
+  O: "---",
+  P: ".--.",
+  Q: "--.-",
+  R: ".-.",
+  S: "...",
+  T: "-",
+  U: "..-",
+  V: "...-",
+  W: ".--",
+  X: "-..-",
+  Y: "-.--",
+  Z: "--..",
+  0: "-----",
+  1: ".----",
+  2: "..---",
+  3: "...--",
+  4: "....-",
+  5: ".....",
+  6: "-....",
+  7: "--...",
+  8: "---..",
+  9: "----.",
+  ".": ".-.-.-",
+  ",": "--..--",
+  "?": "..--..",
+  "!": "-.-.--",
+  "/": "-..-.",
+  "(": "-.--.",
+  ")": "-.--.-",
+  "&": ".-...",
+  ":": "---...",
+  ";": "-.-.-.",
+  "=": "-...-",
+  "+": ".-.-.",
+  "-": "-....-",
+  _: "..--.-",
+  "@": ".--.-.",
 };
 
 const REVERSE_MAP = {};
@@ -18,11 +57,11 @@ for (const k in MORSE_MAP) {
   REVERSE_MAP[MORSE_MAP[k]] = k;
 }
 
-let mode      = 'encode';
-let audioCtx  = null;
+let mode = "encode";
+let audioCtx = null;
 let isPlaying = false;
-let stopFlag  = false;
-let wpm       = 15;
+let stopFlag = false;
+let wpm = 15;
 
 // ── Helpers ───────────────────────────────────────────────────────
 
@@ -32,71 +71,71 @@ const el = (id) => document.getElementById(id);
 
 const setMode = (m) => {
   mode = m;
-  el('encode-btn').classList.toggle('active', m === 'encode');
-  el('decode-btn').classList.toggle('active', m === 'decode');
-  el('input-label').textContent  = m === 'encode' ? 'Text' : 'Morse Code';
-  el('output-label').textContent = m === 'encode' ? 'Morse Code' : 'Text';
-  el('input').placeholder = m === 'encode'
-    ? 'Type your message...'
-    : 'Enter Morse code — space between letters, / between words...';
-  el('input').value            = '';
-  el('output').textContent     = '—';
-  el('char-count').textContent = '0';
+  el("encode-btn").classList.toggle("active", m === "encode");
+  el("decode-btn").classList.toggle("active", m === "decode");
+  el("input-label").textContent = m === "encode" ? "Text" : "Morse Code";
+  el("output-label").textContent = m === "encode" ? "Morse Code" : "Text";
+  el("input").placeholder =
+    m === "encode"
+      ? "Type your message..."
+      : "Enter Morse code — space between letters, / between words...";
+  el("input").value = "";
+  el("output").textContent = "—";
+  el("char-count").textContent = "0";
 };
 
 // ── Translation ───────────────────────────────────────────────────
 
 const encodeToMorse = (text) => {
   const result = [];
-  const upper  = text.toUpperCase();
+  const upper = text.toUpperCase();
   for (let i = 0; i < upper.length; i++) {
     const ch = upper[i];
-    if (ch === ' ')         result.push('/');
+    if (ch === " ") result.push("/");
     else if (MORSE_MAP[ch]) result.push(MORSE_MAP[ch]);
-    else                    result.push('?');
+    else result.push("?");
   }
-  return result.join(' ');
+  return result.join(" ");
 };
 
 const decodeFromMorse = (morse) => {
-  const words   = morse.trim().split(/\s*\/\s*/);
+  const words = morse.trim().split(/\s*\/\s*/);
   const decoded = [];
   for (let i = 0; i < words.length; i++) {
     const codes = words[i].trim().split(/\s+/);
-    let word = '';
+    let word = "";
     for (let j = 0; j < codes.length; j++) {
       const c = codes[j];
-      word += REVERSE_MAP[c] || (c ? '?' : '');
+      word += REVERSE_MAP[c] || (c ? "?" : "");
     }
     decoded.push(word);
   }
-  return decoded.join(' ');
+  return decoded.join(" ");
 };
 
-
 const buildOutputSpans = (morseText) => {
-  const output = el('output');
-  output.innerHTML = '';
-  morseText.split(' ').forEach((tok, i, arr) => {
-    const span = document.createElement('span');
-    span.className   = 'morse-token';
+  const output = el("output");
+  output.innerHTML = "";
+  morseText.split(" ").forEach((tok, i, arr) => {
+    const span = document.createElement("span");
+    span.className = "morse-token";
     span.dataset.idx = i;
     span.textContent = tok;
     output.appendChild(span);
-    if (i < arr.length - 1) output.appendChild(document.createTextNode(' '));
+    if (i < arr.length - 1) output.appendChild(document.createTextNode(" "));
   });
 };
 
 const translate = () => {
-  const input = el('input').value;
-  el('char-count').textContent = input.length;
-  const output = el('output');
+  const input = el("input").value;
+  el("char-count").textContent = input.length;
+  const output = el("output");
   if (!input.trim()) {
-    output.innerHTML     = '';
-    output.textContent   = '—';
+    output.innerHTML = "";
+    output.textContent = "—";
     return;
   }
-  if (mode === 'encode') {
+  if (mode === "encode") {
     // render as spans for visual playback highlight
     buildOutputSpans(encodeToMorse(input));
   } else {
@@ -106,32 +145,36 @@ const translate = () => {
 };
 
 const clearInput = () => {
-  el('input').value            = '';
-  el('output').textContent     = '—';
-  el('char-count').textContent = '0';
+  el("input").value = "";
+  el("output").textContent = "—";
+  el("char-count").textContent = "0";
 };
 
-
-
 const copyOutput = () => {
-  const text = el('output').textContent;
-  if (text === '—' || text === '-') return;
+  const text = el("output").textContent;
+  if (text === "—" || text === "-") return;
 
-  const btn  = el('copy-btn');
+  const btn = el("copy-btn");
   const prev = btn.textContent;
 
   const markCopied = () => {
-    btn.textContent = '✓';
-    btn.style.color = 'var(--accent)';
-    setTimeout(() => { btn.textContent = prev; btn.style.color = ''; }, 1600);
-    showToast('Copied to clipboard');
+    btn.textContent = "✓";
+    btn.style.color = "var(--accent)";
+    setTimeout(() => {
+      btn.textContent = prev;
+      btn.style.color = "";
+    }, 1600);
+    showToast("Copied to clipboard");
   };
 
   if (navigator.clipboard && navigator.clipboard.writeText) {
-    navigator.clipboard.writeText(text).then(markCopied).catch(() => {
-      fallbackCopy(text);
-      markCopied();
-    });
+    navigator.clipboard
+      .writeText(text)
+      .then(markCopied)
+      .catch(() => {
+        fallbackCopy(text);
+        markCopied();
+      });
   } else {
     fallbackCopy(text);
     markCopied();
@@ -139,142 +182,149 @@ const copyOutput = () => {
 };
 
 const fallbackCopy = (text) => {
-  const ta          = document.createElement('textarea');
-  ta.value          = text;
-  ta.style.position = 'fixed';
-  ta.style.opacity  = '0';
+  const ta = document.createElement("textarea");
+  ta.value = text;
+  ta.style.position = "fixed";
+  ta.style.opacity = "0";
   document.body.appendChild(ta);
   ta.select();
-  try { document.execCommand('copy'); } catch (e) { /* silent */ }
+  try {
+    document.execCommand("copy");
+  } catch (e) {
+    /* silent */
+  }
   document.body.removeChild(ta);
 };
 
 const showToast = (msg) => {
-  let toast = el('toast');
+  let toast = el("toast");
   if (!toast) {
-    toast           = document.createElement('div');
-    toast.id        = 'toast';
-    toast.className = 'toast';
+    toast = document.createElement("div");
+    toast.id = "toast";
+    toast.className = "toast";
     document.body.appendChild(toast);
   }
   toast.textContent = msg;
-  toast.classList.add('show');
+  toast.classList.add("show");
   clearTimeout(toast._timer);
-  toast._timer = setTimeout(() => toast.classList.remove('show'), 2200);
+  toast._timer = setTimeout(() => toast.classList.remove("show"), 2200);
 };
 
 // ── Speed ─────────────────────────────────────────────────────────
 
 const updateSpeed = () => {
-  wpm = parseInt(el('speed').value, 10);
-  el('speed-val').textContent = `${wpm} WPM`;
+  wpm = parseInt(el("speed").value, 10);
+  el("speed-val").textContent = `${wpm} WPM`;
 };
 
 // ── Audio ─────────────────────────────────────────────────────────
 
 const getCtx = () => {
   const AC = window.AudioContext || window.webkitAudioContext;
-  if (!audioCtx || audioCtx.state === 'closed') audioCtx = new AC();
-  if (audioCtx.state === 'suspended') audioCtx.resume();
+  if (!audioCtx || audioCtx.state === "closed") audioCtx = new AC();
+  if (audioCtx.state === "suspended") audioCtx.resume();
   return audioCtx;
 };
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
-const playTone = (ctx, durationMs, freq = 620) => new Promise((resolve) => {
-  const osc  = ctx.createOscillator();
-  const gain = ctx.createGain();
-  osc.connect(gain);
-  gain.connect(ctx.destination);
-  osc.type            = 'sine';
-  osc.frequency.value = freq;
+const playTone = (ctx, durationMs, freq = 620) =>
+  new Promise((resolve) => {
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = "sine";
+    osc.frequency.value = freq;
 
-  const t    = ctx.currentTime;
-  const d    = durationMs / 1000;
-  const ramp = Math.min(0.008, d * 0.1);
+    const t = ctx.currentTime;
+    const d = durationMs / 1000;
+    const ramp = Math.min(0.008, d * 0.1);
 
-  gain.gain.setValueAtTime(0, t);
-  gain.gain.linearRampToValueAtTime(0.38, t + ramp);
-  gain.gain.setValueAtTime(0.38, t + d - ramp);
-  gain.gain.linearRampToValueAtTime(0, t + d);
+    gain.gain.setValueAtTime(0, t);
+    gain.gain.linearRampToValueAtTime(0.38, t + ramp);
+    gain.gain.setValueAtTime(0.38, t + d - ramp);
+    gain.gain.linearRampToValueAtTime(0, t + d);
 
-  osc.start(t);
-  osc.stop(t + d);
-  osc.onended = resolve;
-});
+    osc.start(t);
+    osc.stop(t + d);
+    osc.onended = resolve;
+  });
 
 const setPlayState = (playing) => {
   isPlaying = playing;
-  const btn   = el('play-btn');
-  const icon  = el('play-icon');
-  const label = el('play-label');
+  const btn = el("play-btn");
+  const icon = el("play-icon");
+  const label = el("play-label");
   if (playing) {
-    btn.classList.add('playing');
-    icon.textContent  = '■';
-    label.textContent = 'Stop';
+    btn.classList.add("playing");
+    icon.textContent = "■";
+    label.textContent = "Stop";
   } else {
-    btn.classList.remove('playing');
-    icon.textContent  = '▶';
-    label.textContent = 'Play Audio';
+    btn.classList.remove("playing");
+    icon.textContent = "▶";
+    label.textContent = "Play Audio";
   }
 };
 
 // ──  highlight/clear helpers for visual playback ──────────────
 const highlightToken = (idx) => {
-  document.querySelectorAll('.morse-token').forEach((s, i) => {
-    s.classList.toggle('active-token', i === idx);
+  document.querySelectorAll(".morse-token").forEach((s, i) => {
+    s.classList.toggle("active-token", i === idx);
   });
 };
 
 const clearHighlight = () => {
-  document.querySelectorAll('.morse-token')
-    .forEach(s => s.classList.remove('active-token'));
+  document
+    .querySelectorAll(".morse-token")
+    .forEach((s) => s.classList.remove("active-token"));
 };
 
-
 const togglePlay = async () => {
-  if (isPlaying) { stopFlag = true; return; }
+  if (isPlaying) {
+    stopFlag = true;
+    return;
+  }
 
-  const morseText = mode === 'encode'
-    ? el('output').textContent
-    : el('input').value;
+  const morseText =
+    mode === "encode" ? el("output").textContent : el("input").value;
 
-  if (!morseText || morseText === '—' || !morseText.trim()) return;
+  if (!morseText || morseText === "—" || !morseText.trim()) return;
 
-  const dot       = 1200 / wpm;
-  const dash      = dot * 3;
-  const elemGap   = dot;
+  const dot = 1200 / wpm;
+  const dash = dot * 3;
+  const elemGap = dot;
   const letterGap = dot * 3;
-  const wordGap   = dot * 7;
+  const wordGap = dot * 7;
 
   const ctx = getCtx();
-  stopFlag  = false;
+  stopFlag = false;
   setPlayState(true);
 
-  const tokens = morseText.split(' ');
+  const tokens = morseText.split(" ");
 
   for (let i = 0; i < tokens.length; i++) {
     if (stopFlag) break;
     const tok = tokens[i];
 
-    highlightToken(i); 
+    highlightToken(i);
 
-    if (tok === '/') {
+    if (tok === "/") {
       await sleep(wordGap - letterGap);
     } else {
       for (let j = 0; j < tok.length; j++) {
         if (stopFlag) break;
-        if (tok[j] === '.')      await playTone(ctx, dot);
-        else if (tok[j] === '-') await playTone(ctx, dash);
+        if (tok[j] === ".") await playTone(ctx, dot);
+        else if (tok[j] === "-") await playTone(ctx, dash);
         if (!stopFlag && j < tok.length - 1) await sleep(elemGap);
       }
-      if (!stopFlag && i < tokens.length - 1 && tokens[i + 1] !== '/') {
+      if (!stopFlag && i < tokens.length - 1 && tokens[i + 1] !== "/") {
         await sleep(letterGap);
       }
     }
   }
 
-  clearHighlight(); 
+  clearHighlight();
   stopFlag = false;
   setPlayState(false);
 };
@@ -284,35 +334,35 @@ const togglePlay = async () => {
 // Only addEventListener added.
 
 const buildRefTable = () => {
-  const table = el('ref-table');
+  const table = el("ref-table");
   for (const char in MORSE_MAP) {
-    const item = document.createElement('div');
-    item.className = 'ref-item';
-    item.title     = `Click to insert "${char}"`;
+    const item = document.createElement("div");
+    item.className = "ref-item";
+    item.title = `Click to insert "${char}"`;
 
-    const charEl       = document.createElement('span');
-    charEl.className   = 'ref-char';
+    const charEl = document.createElement("span");
+    charEl.className = "ref-char";
     charEl.textContent = char;
 
-    const codeEl       = document.createElement('span');
-    codeEl.className   = 'ref-code';
+    const codeEl = document.createElement("span");
+    codeEl.className = "ref-code";
     codeEl.textContent = MORSE_MAP[char];
 
     item.appendChild(charEl);
     item.appendChild(codeEl);
 
     // NEW: click inserts character (encode mode) or morse (decode mode)
-    item.addEventListener('click', () => {
-      const inputEl = el('input');
-      if (mode === 'encode') {
+    item.addEventListener("click", () => {
+      const inputEl = el("input");
+      if (mode === "encode") {
         inputEl.value += char;
       } else {
         const current = inputEl.value;
         inputEl.value = current
-          ? current.trimEnd() + ' ' + MORSE_MAP[char]
+          ? current.trimEnd() + " " + MORSE_MAP[char]
           : MORSE_MAP[char];
       }
-      inputEl.dispatchEvent(new Event('input'));
+      inputEl.dispatchEvent(new Event("input"));
       inputEl.focus();
       showToast(`Inserted "${char}"`);
     });
@@ -322,63 +372,67 @@ const buildRefTable = () => {
 };
 
 const toggleRef = () => {
-  const table = el('ref-table');
-  const btn   = el('ref-toggle-btn');
-  const arrow = el('ref-arrow');
-  const open  = table.classList.toggle('open');
-  btn.setAttribute('aria-expanded', open);
-  arrow.textContent = open ? '▴' : '▾';
+  const table = el("ref-table");
+  const btn = el("ref-toggle-btn");
+  const arrow = el("ref-arrow");
+  const open = table.classList.toggle("open");
+  btn.setAttribute("aria-expanded", open);
+  arrow.textContent = open ? "▴" : "▾";
 };
 
 // ──  Swap panels ──────────────────────────────────────────────
 // Moves output → input and flips mode.
 const swapPanels = () => {
-  const outputText = el('output').textContent;
-  if (!outputText || outputText === '—') return;
+  const outputText = el("output").textContent;
+  if (!outputText || outputText === "—") return;
 
-  const newMode = mode === 'encode' ? 'decode' : 'encode';
+  const newMode = mode === "encode" ? "decode" : "encode";
   mode = newMode;
 
-  el('encode-btn').classList.toggle('active', mode === 'encode');
-  el('decode-btn').classList.toggle('active', mode === 'decode');
-  el('input-label').textContent  = mode === 'encode' ? 'Text' : 'Morse Code';
-  el('output-label').textContent = mode === 'encode' ? 'Morse Code' : 'Text';
-  el('input').placeholder = mode === 'encode'
-    ? 'Type your message...'
-    : 'Enter Morse code — space between letters, / between words...';
+  el("encode-btn").classList.toggle("active", mode === "encode");
+  el("decode-btn").classList.toggle("active", mode === "decode");
+  el("input-label").textContent = mode === "encode" ? "Text" : "Morse Code";
+  el("output-label").textContent = mode === "encode" ? "Morse Code" : "Text";
+  el("input").placeholder =
+    mode === "encode"
+      ? "Type your message..."
+      : "Enter Morse code — space between letters, / between words...";
 
-  el('input').value            = outputText;
-  el('char-count').textContent = outputText.length;
-  el('input').dispatchEvent(new Event('input'));
-  showToast('Panels swapped!');
+  el("input").value = outputText;
+  el("char-count").textContent = outputText.length;
+  el("input").dispatchEvent(new Event("input"));
+  showToast("Panels swapped!");
 };
 
 // ── Init ──────────────────────────────────────────────────────────
 
-document.addEventListener('DOMContentLoaded', () => {
-  el('input').addEventListener('input', translate);
-  el('clear-btn').addEventListener('click', clearInput);
-  el('copy-btn').addEventListener('click', copyOutput);
-  el('play-btn').addEventListener('click', togglePlay);
-  el('speed').addEventListener('input', updateSpeed);
-  el('ref-toggle-btn').addEventListener('click', toggleRef);
-  el('encode-btn').addEventListener('click', () => setMode('encode'));
-  el('decode-btn').addEventListener('click', () => setMode('decode'));
+document.addEventListener("DOMContentLoaded", () => {
+  el("input").addEventListener("input", translate);
+  el("clear-btn").addEventListener("click", clearInput);
+  el("copy-btn").addEventListener("click", copyOutput);
+  el("play-btn").addEventListener("click", togglePlay);
+  el("speed").addEventListener("input", updateSpeed);
+  el("ref-toggle-btn").addEventListener("click", toggleRef);
+  el("encode-btn").addEventListener("click", () => setMode("encode"));
+  el("decode-btn").addEventListener("click", () => setMode("decode"));
 
   // ── Keyboard shortcuts ──────────────────────────────────────────
   // When inside textarea: only Escape (clear) and Ctrl+Enter (play)
   // Outside textarea: Ctrl+Shift+C (copy)
-  document.addEventListener('keydown', (e) => {
-    if (e.target.tagName === 'TEXTAREA') {
-      if (e.key === 'Escape') { clearInput(); return; }
-      if (e.ctrlKey && e.key === 'Enter') {
+  document.addEventListener("keydown", (e) => {
+    if (e.target.tagName === "TEXTAREA") {
+      if (e.key === "Escape") {
+        clearInput();
+        return;
+      }
+      if (e.ctrlKey && e.key === "Enter") {
         e.preventDefault();
         togglePlay();
         return;
       }
       return;
     }
-    if (e.ctrlKey && e.shiftKey && e.key === 'C') {
+    if (e.ctrlKey && e.shiftKey && e.key === "C") {
       e.preventDefault();
       copyOutput();
     }

--- a/public/MorseCodeTranslator/style.css
+++ b/public/MorseCodeTranslator/style.css
@@ -547,3 +547,34 @@ input[type="range"]::-moz-range-thumb {
     grid-template-columns: repeat(auto-fill, minmax(62px, 1fr));
   }
 }
+/* ── Keyboard hints bar ────────────────────────────────────────── */
+.kbd-hints {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  margin-top: 1rem;
+  opacity: 0.5;
+  font-size: 0.75rem;
+  color: var(--text-dim);
+}
+
+.kbd-hint {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+kbd {
+  background: var(--surface-mid);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-size: 0.7rem;
+  font-family: inherit;
+}
+
+@media (max-width: 640px) {
+  .kbd-hints { display: none; }
+}

--- a/public/MorseCodeTranslator/style.css
+++ b/public/MorseCodeTranslator/style.css
@@ -1,30 +1,43 @@
 :root {
-  --bg:           #06080f;
-  --surface:      rgba(255, 255, 255, 0.04);
-  --surface-mid:  rgba(255, 255, 255, 0.07);
-  --border:       rgba(255, 255, 255, 0.08);
-  --border-accent:rgba(100, 255, 218, 0.22);
-  --accent:       #64ffda;
-  --accent-dim:   rgba(100, 255, 218, 0.12);
-  --accent-glow:  rgba(100, 255, 218, 0.25);
-  --danger:       #ff6464;
-  --danger-dim:   rgba(255, 100, 100, 0.12);
-  --text:         #c8d3e0;
-  --text-dim:     #525e6e;
-  --text-bright:  #eaf0f8;
-  --radius-sm:    8px;
-  --radius-md:    14px;
-  --radius-lg:    18px;
-  --neo-shadow:   3px 3px 10px rgba(0,0,0,.45), -1px -1px 5px rgba(255,255,255,.025);
-  --neo-inset:    inset 2px 2px 6px rgba(0,0,0,.4), inset -1px -1px 4px rgba(255,255,255,.02);
+  --bg: #06080f;
+  --surface: rgba(255, 255, 255, 0.04);
+  --surface-mid: rgba(255, 255, 255, 0.07);
+  --border: rgba(255, 255, 255, 0.08);
+  --border-accent: rgba(100, 255, 218, 0.22);
+  --accent: #64ffda;
+  --accent-dim: rgba(100, 255, 218, 0.12);
+  --accent-glow: rgba(100, 255, 218, 0.25);
+  --danger: #ff6464;
+  --danger-dim: rgba(255, 100, 100, 0.12);
+  --text: #c8d3e0;
+  --text-dim: #525e6e;
+  --text-bright: #eaf0f8;
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-lg: 18px;
+  --neo-shadow:
+    3px 3px 10px rgba(0, 0, 0, 0.45), -1px -1px 5px rgba(255, 255, 255, 0.025);
+  --neo-inset:
+    inset 2px 2px 6px rgba(0, 0, 0, 0.4),
+    inset -1px -1px 4px rgba(255, 255, 255, 0.02);
 }
 
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
 
 body {
   background: var(--bg);
   color: var(--text);
-  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  font-family:
+    "Segoe UI",
+    system-ui,
+    -apple-system,
+    sans-serif;
   min-height: 100vh;
   overflow-x: hidden;
   line-height: 1.6;
@@ -46,29 +59,55 @@ body {
 }
 
 .orb-1 {
-  width: 480px; height: 480px;
-  background: radial-gradient(circle, rgba(100,255,218,.18), transparent 70%);
-  top: -160px; left: -140px;
+  width: 480px;
+  height: 480px;
+  background: radial-gradient(
+    circle,
+    rgba(100, 255, 218, 0.18),
+    transparent 70%
+  );
+  top: -160px;
+  left: -140px;
   animation: drift1 18s ease-in-out infinite alternate;
 }
 
 .orb-2 {
-  width: 560px; height: 560px;
-  background: radial-gradient(circle, rgba(124,58,237,.16), transparent 70%);
-  bottom: -180px; right: -160px;
+  width: 560px;
+  height: 560px;
+  background: radial-gradient(
+    circle,
+    rgba(124, 58, 237, 0.16),
+    transparent 70%
+  );
+  bottom: -180px;
+  right: -160px;
   animation: drift2 22s ease-in-out infinite alternate;
 }
 
 .orb-3 {
-  width: 300px; height: 300px;
-  background: radial-gradient(circle, rgba(56,189,248,.1), transparent 70%);
-  top: 50%; left: 55%;
+  width: 300px;
+  height: 300px;
+  background: radial-gradient(circle, rgba(56, 189, 248, 0.1), transparent 70%);
+  top: 50%;
+  left: 55%;
   animation: drift3 15s ease-in-out infinite alternate;
 }
 
-@keyframes drift1 { to { transform: translate(40px, 30px); } }
-@keyframes drift2 { to { transform: translate(-35px, -25px); } }
-@keyframes drift3 { to { transform: translate(-20px, 30px); } }
+@keyframes drift1 {
+  to {
+    transform: translate(40px, 30px);
+  }
+}
+@keyframes drift2 {
+  to {
+    transform: translate(-35px, -25px);
+  }
+}
+@keyframes drift3 {
+  to {
+    transform: translate(-20px, 30px);
+  }
+}
 
 /* ── Layout ────────────────────────────────────────────────────── */
 .container {
@@ -101,28 +140,45 @@ header {
   animation: pulse 1.4s ease-in-out infinite;
 }
 
-.signal-bars span:nth-child(1) { height: 10px; animation-delay: 0s; }
-.signal-bars span:nth-child(2) { height: 20px; animation-delay: .18s; }
-.signal-bars span:nth-child(3) { height: 30px; animation-delay: .36s; }
-.signal-bars span:nth-child(4) { height: 36px; animation-delay: .54s; }
+.signal-bars span:nth-child(1) {
+  height: 10px;
+  animation-delay: 0s;
+}
+.signal-bars span:nth-child(2) {
+  height: 20px;
+  animation-delay: 0.18s;
+}
+.signal-bars span:nth-child(3) {
+  height: 30px;
+  animation-delay: 0.36s;
+}
+.signal-bars span:nth-child(4) {
+  height: 36px;
+  animation-delay: 0.54s;
+}
 
 @keyframes pulse {
-  0%, 100% { opacity: .25; }
-  50%       { opacity: 1;   }
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 1;
+  }
 }
 
 h1 {
   font-size: clamp(1.6rem, 4vw, 2.2rem);
   font-weight: 700;
-  letter-spacing: -.025em;
+  letter-spacing: -0.025em;
   color: var(--text-bright);
 }
 
 header p {
   color: var(--text-dim);
-  font-size: .9rem;
-  margin-top: .4rem;
-  letter-spacing: .01em;
+  font-size: 0.9rem;
+  margin-top: 0.4rem;
+  letter-spacing: 0.01em;
 }
 
 /* ── Glass base ────────────────────────────────────────────────── */
@@ -137,7 +193,7 @@ header p {
 /* ── Mode toggle ───────────────────────────────────────────────── */
 .mode-toggle {
   display: flex;
-  background: rgba(255,255,255,.03);
+  background: rgba(255, 255, 255, 0.03);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
   padding: 4px;
@@ -147,15 +203,18 @@ header p {
 }
 
 .mode-btn {
-  padding: .45rem 1.4rem;
+  padding: 0.45rem 1.4rem;
   border: none;
   background: transparent;
   color: var(--text-dim);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: .88rem;
+  font-size: 0.88rem;
   font-family: inherit;
-  transition: color .2s, background .2s, box-shadow .2s;
+  transition:
+    color 0.2s,
+    background 0.2s,
+    box-shadow 0.2s;
 }
 
 .mode-btn.active {
@@ -164,13 +223,15 @@ header p {
   box-shadow: 0 0 0 1px var(--border-accent);
 }
 
-.mode-btn:not(.active):hover { color: var(--text); }
+.mode-btn:not(.active):hover {
+  color: var(--text);
+}
 
 /* ── Panels ────────────────────────────────────────────────────── */
 .panels {
   display: grid;
   grid-template-columns: 1fr 48px 1fr;
-  gap: .75rem;
+  gap: 0.75rem;
   margin-bottom: 1.25rem;
   align-items: stretch;
 }
@@ -185,14 +246,14 @@ header p {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: .75rem;
+  margin-bottom: 0.75rem;
 }
 
 .panel-label {
-  font-size: .72rem;
+  font-size: 0.72rem;
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: .1em;
+  letter-spacing: 0.1em;
   color: var(--text-dim);
 }
 
@@ -200,15 +261,19 @@ header p {
   width: 28px;
   height: 28px;
   border: 1px solid var(--border);
-  background: rgba(255,255,255,.03);
+  background: rgba(255, 255, 255, 0.03);
   color: var(--text-dim);
   border-radius: var(--radius-sm);
   cursor: pointer;
-  font-size: .78rem;
+  font-size: 0.78rem;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: color .2s, background .2s, border-color .2s, box-shadow .2s;
+  transition:
+    color 0.2s,
+    background 0.2s,
+    border-color 0.2s,
+    box-shadow 0.2s;
   box-shadow: var(--neo-shadow);
 }
 
@@ -225,20 +290,23 @@ textarea#input {
   outline: none;
   color: var(--text-bright);
   font-family: inherit;
-  font-size: .98rem;
+  font-size: 0.98rem;
   resize: none;
   line-height: 1.7;
   min-height: 160px;
 }
 
-textarea#input::placeholder { color: var(--text-dim); opacity: .7; }
+textarea#input::placeholder {
+  color: var(--text-dim);
+  opacity: 0.7;
+}
 
 .output-area {
   flex: 1;
-  font-family: 'Courier New', 'Lucida Console', monospace;
+  font-family: "Courier New", "Lucida Console", monospace;
   font-size: 1.05rem;
   line-height: 2;
-  letter-spacing: .14em;
+  letter-spacing: 0.14em;
   color: var(--accent);
   word-break: break-all;
   min-height: 160px;
@@ -247,10 +315,10 @@ textarea#input::placeholder { color: var(--text-dim); opacity: .7; }
 }
 
 .char-count {
-  font-size: .72rem;
+  font-size: 0.72rem;
   color: var(--text-dim);
   text-align: right;
-  margin-top: .6rem;
+  margin-top: 0.6rem;
 }
 
 /* ── Divider arrow ─────────────────────────────────────────────── */
@@ -270,7 +338,7 @@ textarea#input::placeholder { color: var(--text-dim); opacity: .7; }
   justify-content: center;
   border: 1px solid var(--border);
   border-radius: 50%;
-  background: rgba(255,255,255,.03);
+  background: rgba(255, 255, 255, 0.03);
   box-shadow: var(--neo-shadow);
   color: var(--text-dim);
   font-size: 1rem;
@@ -292,12 +360,17 @@ textarea#input::placeholder { color: var(--text-dim); opacity: .7; }
   cursor: pointer;
   flex-shrink: 0;
   box-shadow: var(--neo-shadow);
-  transition: background .2s, box-shadow .2s, transform .2s;
+  transition:
+    background 0.2s,
+    box-shadow 0.2s,
+    transform 0.2s;
 }
 
 .swap-btn:hover {
-  background: rgba(100,255,218,.2);
-  box-shadow: 0 0 14px var(--accent-glow), var(--neo-shadow);
+  background: rgba(100, 255, 218, 0.2);
+  box-shadow:
+    0 0 14px var(--accent-glow),
+    var(--neo-shadow);
   transform: rotate(180deg);
 }
 
@@ -314,35 +387,37 @@ textarea#input::placeholder { color: var(--text-dim); opacity: .7; }
 .play-btn {
   display: flex;
   align-items: center;
-  gap: .55rem;
-  padding: .6rem 1.3rem;
+  gap: 0.55rem;
+  padding: 0.6rem 1.3rem;
   background: var(--accent-dim);
   color: var(--accent);
   border: 1px solid var(--border-accent);
   border-radius: var(--radius-md);
   cursor: pointer;
-  font-size: .88rem;
+  font-size: 0.88rem;
   font-family: inherit;
   font-weight: 600;
-  letter-spacing: .02em;
+  letter-spacing: 0.02em;
   white-space: nowrap;
-  transition: all .2s;
+  transition: all 0.2s;
   box-shadow: var(--neo-shadow);
 }
 
 .play-btn:hover {
-  background: rgba(100,255,218,.18);
-  box-shadow: 0 0 18px var(--accent-glow), var(--neo-shadow);
+  background: rgba(100, 255, 218, 0.18);
+  box-shadow:
+    0 0 18px var(--accent-glow),
+    var(--neo-shadow);
 }
 
 .play-btn.playing {
   background: var(--danger-dim);
   color: var(--danger);
-  border-color: rgba(255,100,100,.3);
+  border-color: rgba(255, 100, 100, 0.3);
 }
 
 .play-btn:disabled {
-  opacity: .35;
+  opacity: 0.35;
   cursor: not-allowed;
   box-shadow: none;
 }
@@ -350,13 +425,13 @@ textarea#input::placeholder { color: var(--text-dim); opacity: .7; }
 .speed-control {
   display: flex;
   align-items: center;
-  gap: .65rem;
+  gap: 0.65rem;
   flex: 1;
   min-width: 200px;
 }
 
 .speed-label {
-  font-size: .75rem;
+  font-size: 0.75rem;
   color: var(--text-dim);
   white-space: nowrap;
 }
@@ -380,11 +455,13 @@ input[type="range"]::-webkit-slider-thumb {
   border-radius: 50%;
   cursor: pointer;
   box-shadow: 0 0 10px var(--accent-glow);
-  transition: box-shadow .2s;
+  transition: box-shadow 0.2s;
 }
 
 input[type="range"]::-webkit-slider-thumb:hover {
-  box-shadow: 0 0 16px var(--accent-glow), 0 0 4px var(--accent);
+  box-shadow:
+    0 0 16px var(--accent-glow),
+    0 0 4px var(--accent);
 }
 
 input[type="range"]::-moz-range-thumb {
@@ -399,7 +476,7 @@ input[type="range"]::-moz-range-thumb {
 .speed-val {
   color: var(--accent);
   font-weight: 700;
-  font-size: .8rem;
+  font-size: 0.8rem;
   min-width: 58px;
   text-align: right;
 }
@@ -410,23 +487,25 @@ input[type="range"]::-moz-range-thumb {
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: .8rem 1.25rem;
+  padding: 0.8rem 1.25rem;
   color: var(--text-dim);
   cursor: pointer;
   font-family: inherit;
-  font-size: .88rem;
-  letter-spacing: .02em;
-  transition: color .2s;
-  margin-bottom: .6rem;
+  font-size: 0.88rem;
+  letter-spacing: 0.02em;
+  transition: color 0.2s;
+  margin-bottom: 0.6rem;
   border-radius: var(--radius-md) !important;
 }
 
-.ref-toggle:hover { color: var(--text); }
+.ref-toggle:hover {
+  color: var(--text);
+}
 
 .ref-table {
   display: none;
   grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
-  gap: .45rem;
+  gap: 0.45rem;
   padding: 1rem;
   background: var(--surface);
   border: 1px solid var(--border);
@@ -434,50 +513,56 @@ input[type="range"]::-moz-range-thumb {
   margin-bottom: 1rem;
 }
 
-.ref-table.open { display: grid; }
+.ref-table.open {
+  display: grid;
+}
 
 .ref-item {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: .5rem .35rem;
-  background: rgba(255,255,255,.025);
-  border: 1px solid rgba(255,255,255,.04);
+  padding: 0.5rem 0.35rem;
+  background: rgba(255, 255, 255, 0.025);
+  border: 1px solid rgba(255, 255, 255, 0.04);
   border-radius: var(--radius-sm);
   gap: 3px;
-  transition: background .15s, border-color .15s;
+  transition:
+    background 0.15s,
+    border-color 0.15s;
 }
 
 .ref-item:hover {
   background: var(--accent-dim);
-  border-color: rgba(100,255,218,.15);
+  border-color: rgba(100, 255, 218, 0.15);
 }
 
 /* ── NEW: Clickable ref item active state ──────────────────────── */
 .ref-item:active {
   transform: scale(0.95);
-  background: rgba(100,255,218,.2);
+  background: rgba(100, 255, 218, 0.2);
   border-color: var(--border-accent);
 }
 
 .ref-char {
   font-weight: 700;
   color: var(--text-bright);
-  font-size: .88rem;
+  font-size: 0.88rem;
 }
 
 .ref-code {
-  font-family: 'Courier New', monospace;
-  font-size: .7rem;
+  font-family: "Courier New", monospace;
+  font-size: 0.7rem;
   color: var(--accent);
-  letter-spacing: .1em;
+  letter-spacing: 0.1em;
 }
 
 /* ── NEW: Visual playback highlight ────────────────────────────── */
 .morse-token {
   display: inline;
   border-radius: 3px;
-  transition: background .08s, color .08s;
+  transition:
+    background 0.08s,
+    color 0.08s;
 }
 
 .morse-token.active-token {
@@ -494,15 +579,17 @@ input[type="range"]::-moz-range-thumb {
   bottom: 2rem;
   left: 50%;
   transform: translateX(-50%) translateY(20px);
-  background: rgba(100,255,218,.15);
+  background: rgba(100, 255, 218, 0.15);
   border: 1px solid var(--border-accent);
   color: var(--accent);
-  padding: .6rem 1.4rem;
+  padding: 0.6rem 1.4rem;
   border-radius: 50px;
-  font-size: .85rem;
+  font-size: 0.85rem;
   font-weight: 600;
   opacity: 0;
-  transition: opacity .25s, transform .25s;
+  transition:
+    opacity 0.25s,
+    transform 0.25s;
   pointer-events: none;
   z-index: 100;
   backdrop-filter: blur(10px);
@@ -523,7 +610,7 @@ input[type="range"]::-moz-range-thumb {
   .divider {
     flex-direction: row;
     justify-content: center;
-    padding: .2rem 0;
+    padding: 0.2rem 0;
     gap: 12px;
   }
 
@@ -531,17 +618,23 @@ input[type="range"]::-moz-range-thumb {
     transform: rotate(90deg);
   }
 
-  h1 { font-size: 1.5rem; }
+  h1 {
+    font-size: 1.5rem;
+  }
 
   .audio-controls {
     flex-direction: column;
     align-items: stretch;
-    gap: .9rem;
+    gap: 0.9rem;
   }
 
-  .play-btn { justify-content: center; }
+  .play-btn {
+    justify-content: center;
+  }
 
-  .speed-control { min-width: unset; }
+  .speed-control {
+    min-width: unset;
+  }
 
   .ref-table {
     grid-template-columns: repeat(auto-fill, minmax(62px, 1fr));
@@ -576,5 +669,7 @@ kbd {
 }
 
 @media (max-width: 640px) {
-  .kbd-hints { display: none; }
+  .kbd-hints {
+    display: none;
+  }
 }


### PR DESCRIPTION
## Related Issues
Closes #4216
Closes #4217

## Description

**1. Keyboard Shortcuts (#4217)**
| Shortcut | Action |
|----------|--------|
| `Ctrl + Enter` | Play / Stop audio |
| `Escape` | Clear input |
| `Ctrl + Shift + C` | Copy output |
Added keyboard hints bar at bottom of page (hidden on mobile).

**2. Download Output as .txt (#4216)**
Added ↓ button next to copy button. Saves output as morse-[mode]-[timestamp].txt
using Blob API with proper memory cleanup via revokeObjectURL.
Shows toast notification on successful download.

## Type of PR
- [X] Bug fix
- [X] Feature enhancement
- [ ] Documentation update
- [ ] Security enhancement
- [ ] Other

## Checklist
- [X] I have performed a self-review of my code.
- [X] I have read and followed the Contribution Guidelines.
- [X] I have tested the changes thoroughly before submitting this pull request.
- [X] I have provided relevant issue numbers, screenshots, and videos after making the changes.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have followed the code style guidelines of this project.
- [X] I have checked for any existing open issues that my pull request may address.
- [X] I have ensured that my changes do not break