### PR TITLE
ci: add git branch prefix convention validation pipeline

### DIFF
--- a/.github/workflows/branch-name-validator.yml
+++ b/.github/workflows/branch-name-validator.yml
@@ -1,0 +1,26 @@
+name: "Git Branch Prefix Validator"
+
+on:
+  pull_request:
+    types: [opened, edited, synchronized]
+
+jobs:
+  validate-branch-prefix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify Branch Prefix Conventions
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const branchName = pr.head.ref;
+            
+            // Standard prefix naming prefixes
+            const allowedPrefixes = ['feat/', 'fix/', 'docs/', 'refactor/', 'perf/', 'accessibility/', 'ci/', 'enhancement/', 'bugfix/'];
+            const isValid = allowedPrefixes.some(prefix => branchName.startsWith(prefix));
+            
+            if (!isValid) {
+              core.setFailed(`Branch name "${branchName}" violates repository conventions. Source branches must be prefixed with one of the following prefixes: ${allowedPrefixes.join(', ')}`);
+            } else {
+              console.log(`Branch name "${branchName}" is fully compliant with conventions!`);
+            }


### PR DESCRIPTION
Closes #5454 

# Summary
Implements standard branch namespace conventions checking inside the PR pipeline.

# Changes Made
- Added `.github/workflows/branch-name-validator.yml`

# Testing
- Verified successful validation on valid branches
- Confirmed blocking behavior on unaligned names

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
