### PR TITLE
fix: handle APOD video responses and invalid API payloads

### DIFF
--- a/public/NASA-APOD/popup.js
+++ b/public/NASA-APOD/popup.js
@@ -1,103 +1,103 @@
 const NASA_API_KEY = ""; //add your api key. Get it from NASA APOD API(Its free!)
 const NASA_APOD_URL = `https://api.nasa.gov/planetary/apod?api_key=${NASA_API_KEY}`;
 
-let currentApodDate = '';
-let currentApodTitle = '';
-
+let currentApodDate = "";
+let currentApodTitle = "";
 
 async function fetchAPOD(date = null) {
-    const loader = document.getElementById('loader');
-    const image = document.getElementById('image');
-    const contentContainer = document.querySelector('.content-container');
-    
-    loader.classList.add('visible');
-    image.classList.add('loading');
-    contentContainer.classList.add('loading');
-    
-    try {
-      const url = date 
-        ? `${NASA_APOD_URL}&date=${date}`
-        : NASA_APOD_URL;
-      
-      const response = await fetch(url);
+  const loader = document.getElementById("loader");
+  const image = document.getElementById("image");
+  const contentContainer = document.querySelector(".content-container");
 
-if (!response.ok) {
-  throw new Error(`NASA API Error: ${response.status}`);
-}
+  loader.classList.add("visible");
+  image.classList.add("loading");
+  contentContainer.classList.add("loading");
 
-const data = await response.json();
+  try {
+    const url = date ? `${NASA_APOD_URL}&date=${date}` : NASA_APOD_URL;
 
-if (!data.url) {
-  throw new Error("Invalid APOD response");
-}
-  
-      currentApodDate = data.date;
-      
-      currentApodTitle = data.title;
-      
-    document.getElementById("title").textContent = data.title;
-document.getElementById("description").textContent = data.explanation;
+    const response = await fetch(url);
 
-if (data.media_type === "image") {
-  const img = new Image();
-
-  await new Promise((resolve, reject) => {
-    img.onload = resolve;
-    img.onerror = reject;
-    img.src = data.url;
-
-    setTimeout(reject, 10000);
-  });
-
-  image.src = data.url;
-} else if (data.media_type === "video") {
-  image.src = "/api/placeholder/400/250";
-
-  document.getElementById("description").textContent =
-    `${data.explanation}\n\nVideo URL: ${data.url}`;
-} else {
-  throw new Error(`Unsupported media type: ${data.media_type}`);
-}
-
-      const bookmarks = await getBookmarks();
-      updateBookmarkButton(bookmarks.some(bookmark => bookmark.date === currentApodDate));
-
-      await new Promise(resolve => setTimeout(resolve, 50));
-
-      image.classList.remove('loading');
-      contentContainer.classList.remove('loading');
-      
-    } catch (error) {
-      console.error("Error fetching APOD:", error);
-      document.getElementById("title").textContent = "Error Loading Content";
-      document.getElementById("image").src = "/api/placeholder/400/250";
-      document.getElementById("description").textContent = 
-        "Unable to load APOD data. Please try again later.";
-    } finally {
-      setTimeout(() => {
-        loader.classList.remove('visible');
-      }, 0);
+    if (!response.ok) {
+      throw new Error(`NASA API Error: ${response.status}`);
     }
-  }
 
-  document.getElementById('image').addEventListener('load', function() {
-    this.classList.remove('loading');
-  });
+    const data = await response.json();
+
+    if (!data.url) {
+      throw new Error("Invalid APOD response");
+    }
+
+    currentApodDate = data.date;
+
+    currentApodTitle = data.title;
+
+    document.getElementById("title").textContent = data.title;
+    document.getElementById("description").textContent = data.explanation;
+
+    if (data.media_type === "image") {
+      const img = new Image();
+
+      await new Promise((resolve, reject) => {
+        img.onload = resolve;
+        img.onerror = reject;
+        img.src = data.url;
+
+        setTimeout(reject, 10000);
+      });
+
+      image.src = data.url;
+    } else if (data.media_type === "video") {
+      image.src = "/api/placeholder/400/250";
+
+      document.getElementById("description").textContent =
+        `${data.explanation}\n\nVideo URL: ${data.url}`;
+    } else {
+      throw new Error(`Unsupported media type: ${data.media_type}`);
+    }
+
+    const bookmarks = await getBookmarks();
+    updateBookmarkButton(
+      bookmarks.some((bookmark) => bookmark.date === currentApodDate),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    image.classList.remove("loading");
+    contentContainer.classList.remove("loading");
+  } catch (error) {
+    console.error("Error fetching APOD:", error);
+    document.getElementById("title").textContent = "Error Loading Content";
+    document.getElementById("image").src = "/api/placeholder/400/250";
+    document.getElementById("description").textContent =
+      "Unable to load APOD data. Please try again later.";
+  } finally {
+    setTimeout(() => {
+      loader.classList.remove("visible");
+    }, 0);
+  }
+}
+
+document.getElementById("image").addEventListener("load", function () {
+  this.classList.remove("loading");
+});
 
 async function getBookmarks() {
-  const result = await chrome.storage.local.get('apodBookmarks');
+  const result = await chrome.storage.local.get("apodBookmarks");
   return result.apodBookmarks || [];
 }
 
 async function toggleBookmark() {
   const bookmarks = await getBookmarks();
-  const index = bookmarks.findIndex(bookmark => bookmark.date === currentApodDate);
-  
+  const index = bookmarks.findIndex(
+    (bookmark) => bookmark.date === currentApodDate,
+  );
+
   if (index === -1) {
     bookmarks.push({
       date: currentApodDate,
       title: currentApodTitle,
-      description: document.getElementById("description").textContent
+      description: document.getElementById("description").textContent,
     });
   } else {
     bookmarks.splice(index, 1);
@@ -105,99 +105,106 @@ async function toggleBookmark() {
 
   await chrome.storage.local.set({ apodBookmarks: bookmarks });
   updateBookmarkButton(index === -1);
-  
-  if (document.getElementById('bookmarks-view').classList.contains('active')) {
+
+  if (document.getElementById("bookmarks-view").classList.contains("active")) {
     renderBookmarksList();
   }
 }
 
 function updateBookmarkButton(isBookmarked) {
-  const btn = document.getElementById('bookmark-btn');
-  const icon = btn.querySelector('i');
-  
+  const btn = document.getElementById("bookmark-btn");
+  const icon = btn.querySelector("i");
+
   if (isBookmarked) {
-    icon.className = 'fas fa-star';
-    btn.classList.add('active');
+    icon.className = "fas fa-star";
+    btn.classList.add("active");
   } else {
-    icon.className = 'far fa-star';
-    btn.classList.remove('active');
+    icon.className = "far fa-star";
+    btn.classList.remove("active");
   }
 }
 
 async function renderBookmarksList() {
-  const bookmarksList = document.getElementById('bookmarks-list');
+  const bookmarksList = document.getElementById("bookmarks-list");
   const bookmarks = await getBookmarks();
-  
-  bookmarksList.innerHTML = bookmarks.length === 0 
-    ? '<p class="description-container">No bookmarks yet</p>'
-    : bookmarks.map(bookmark => `
+
+  bookmarksList.innerHTML =
+    bookmarks.length === 0
+      ? '<p class="description-container">No bookmarks yet</p>'
+      : bookmarks
+          .map(
+            (bookmark) => `
       <div class="bookmark-item" data-date="${bookmark.date}">
         <div class="bookmark-date">${formatDate(bookmark.date)}</div>
         <div class="bookmark-title">${bookmark.title}</div>
         <div class="bookmark-description">${bookmark.description}</div>
       </div>
-    `).join('');
+    `,
+          )
+          .join("");
 
-  document.querySelectorAll('.bookmark-item').forEach(item => {
-    item.addEventListener('click', () => {
+  document.querySelectorAll(".bookmark-item").forEach((item) => {
+    item.addEventListener("click", () => {
       fetchAPOD(item.dataset.date);
-      toggleView('main-view');
+      toggleView("main-view");
     });
   });
 }
 
 function formatDate(dateString) {
-  return new Date(dateString).toLocaleDateString('en-US', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric'
+  return new Date(dateString).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
   });
 }
 
 function toggleView(viewId) {
-  const mainView = document.getElementById('main-view');
-  const bookmarksView = document.getElementById('bookmarks-view');
-  const bookmarksBtn = document.getElementById('bookmarks-list-btn');
-  
-  if (viewId === 'bookmarks-view') {
-    mainView.classList.add('hidden');
-    bookmarksView.classList.remove('hidden');
-    bookmarksView.classList.add('active');
-    bookmarksBtn.classList.add('active');
+  const mainView = document.getElementById("main-view");
+  const bookmarksView = document.getElementById("bookmarks-view");
+  const bookmarksBtn = document.getElementById("bookmarks-list-btn");
+
+  if (viewId === "bookmarks-view") {
+    mainView.classList.add("hidden");
+    bookmarksView.classList.remove("hidden");
+    bookmarksView.classList.add("active");
+    bookmarksBtn.classList.add("active");
     renderBookmarksList();
   } else {
-    mainView.classList.remove('hidden');
-    bookmarksView.classList.add('hidden');
-    bookmarksView.classList.remove('active');
-    bookmarksBtn.classList.remove('active');
+    mainView.classList.remove("hidden");
+    bookmarksView.classList.add("hidden");
+    bookmarksView.classList.remove("active");
+    bookmarksBtn.classList.remove("active");
   }
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-
-  const dateInput = document.getElementById('date-search');
-  const today = new Date().toISOString().split('T')[0];
+  const dateInput = document.getElementById("date-search");
+  const today = new Date().toISOString().split("T")[0];
   dateInput.max = today;
-  
+
   const urlParams = new URLSearchParams(window.location.search);
-  const date = urlParams.get('date');
-  
+  const date = urlParams.get("date");
+
   if (date) {
     dateInput.value = date;
   }
-  
+
   fetchAPOD(date);
 
-
-  document.getElementById('bookmark-btn').addEventListener('click', toggleBookmark);
-  document.getElementById('bookmarks-list-btn').addEventListener('click', () => {
-    toggleView('bookmarks-view');
-  });
-  document.getElementById('search-btn').addEventListener('click', () => {
+  document
+    .getElementById("bookmark-btn")
+    .addEventListener("click", toggleBookmark);
+  document
+    .getElementById("bookmarks-list-btn")
+    .addEventListener("click", () => {
+      toggleView("bookmarks-view");
+    });
+  document.getElementById("search-btn").addEventListener("click", () => {
     const searchDate = dateInput.value;
     if (searchDate) {
       fetchAPOD(searchDate);
-      toggleView('main-view');
+      toggleView("main-view");
     }
   });
 });

--- a/public/NASA-APOD/popup.js
+++ b/public/NASA-APOD/popup.js
@@ -20,25 +20,44 @@ async function fetchAPOD(date = null) {
         : NASA_APOD_URL;
       
       const response = await fetch(url);
-      const data = await response.json();
+
+if (!response.ok) {
+  throw new Error(`NASA API Error: ${response.status}`);
+}
+
+const data = await response.json();
+
+if (!data.url) {
+  throw new Error("Invalid APOD response");
+}
   
       currentApodDate = data.date;
+      
       currentApodTitle = data.title;
       
+    document.getElementById("title").textContent = data.title;
+document.getElementById("description").textContent = data.explanation;
 
-      const img = new Image();
-      
-      await new Promise((resolve, reject) => {
-        img.onload = resolve;
-        img.onerror = reject;
-        img.src = data.url;
+if (data.media_type === "image") {
+  const img = new Image();
 
-        setTimeout(reject, 10000);
-      });
+  await new Promise((resolve, reject) => {
+    img.onload = resolve;
+    img.onerror = reject;
+    img.src = data.url;
 
-      document.getElementById("title").textContent = data.title;
-      document.getElementById("description").textContent = data.explanation;
-      image.src = data.url;
+    setTimeout(reject, 10000);
+  });
+
+  image.src = data.url;
+} else if (data.media_type === "video") {
+  image.src = "/api/placeholder/400/250";
+
+  document.getElementById("description").textContent =
+    `${data.explanation}\n\nVideo URL: ${data.url}`;
+} else {
+  throw new Error(`Unsupported media type: ${data.media_type}`);
+}
 
       const bookmarks = await getBookmarks();
       updateBookmarkButton(bookmarks.some(bookmark => bookmark.date === currentApodDate));


### PR DESCRIPTION

## Related Issue

Closes #5358

## Summary

This PR fixes an issue where the NASA APOD popup assumes every API response is an image.

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

* Added validation for `response.ok` before processing API data.
* Added validation for invalid or missing `url` values.
* Added handling for `media_type === "image"`.
* Added handling for `media_type === "video"`.
* Added fallback handling for unsupported media types.
* Prevented video URLs from being treated as image sources.

## Testing

* Verified extension loads successfully.
* Verified image responses continue to use the existing image preload flow.
* Verified invalid API responses show an error instead of attempting image loading.
* Verified video responses are handled separately from image responses.
