### PR TITLE
Add calculation history panel

### DIFF
--- a/public/Calculator/Calculator.js
+++ b/public/Calculator/Calculator.js
@@ -129,6 +129,16 @@ function normalizeExpression(expression) {
 }
 
 function addHistoryEntry(expression, result) {
+    const latestEntry = history[0];
+
+    if (
+        latestEntry &&
+        latestEntry.expression === expression &&
+        latestEntry.result === result
+    ) {
+        return;
+    }
+
     history.unshift({ expression, result });
 
     if (history.length > MAX_HISTORY_ENTRIES) {
@@ -161,9 +171,9 @@ function createHistoryItem(entry) {
     div.textContent = `${entry.expression} = ${entry.result}`;
 
     div.addEventListener('click', () => {
-        string = entry.result;
-        input.value = entry.result;
-        calculated = true;
+        string = entry.expression;
+        input.value = entry.expression;
+        calculated = false;
     });
 
     return div;
@@ -177,6 +187,8 @@ function renderHistory() {
         historyList.appendChild(createHistoryItem(entry));
     });
 }
+
+renderHistory();
 
 const arr = Array.from(buttons);
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #5578 

### Summary
Added a calculation history feature to the Scientific Calculator. Users can now view previously evaluated expressions and results, and quickly restore a past calculation by selecting it from the history panel.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [X] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
Added a calculation history panel that records evaluated expressions and results.
Implemented history item selection to restore previous expressions into the calculator.
Prevented duplicate consecutive history entries.
Integrated the history UI with the existing calculator design and responsive layout.
Preserved all existing calculator functionality and scientific operations.

---

## 🧪 Testing and Verification

### Local Validation
- [X] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [ ] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [X] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [X] Verified responsive layout on Mobile viewports (using DevTools)
- [X] Verified responsive layout on Tablet viewports
- [X] Keyboard navigation and focus outlines checked
- [X] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
<img width="1190" height="911" alt="image" src="https://github.com/user-attachments/assets/7e7a0766-6f13-483e-8c9b-e254de8294da" />
<img width="1114" height="913" alt="image" src="https://github.com/user-attachments/assets/e0490e8d-780f-4b28-9e2e-6c229dfd937f" />


---

## 🤝 Contributor Checklist
- [X] My code follows the code style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation / README files accordingly.
- [X] My changes generate no new warnings or console errors.
- [X] There are no unrelated changes or formatter noise in this PR.
