### PR TITLE
Enhance history panel with empty state and entry deletion

### DIFF
--- a/public/Calculator/Calculator.css
+++ b/public/Calculator/Calculator.css
@@ -199,6 +199,26 @@ input::placeholder {
     background: rgba(110, 222, 10, 0.08);
     border-color: rgba(110, 222, 10, 0.28);
 }
+.history-empty {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    text-align: center;
+    color: var(--muted);
+    padding: 24px;
+}
+
+.history-empty h3 {
+    font-size: 1.2rem;
+    margin-bottom: 8px;
+    color: var(--text);
+}
+
+.history-empty p {
+    font-size: 0.95rem;
+}
 
 #clearHistory {
     width: 100%;
@@ -326,4 +346,29 @@ input::placeholder {
         font-size: 2.5rem;
         padding: 20px 18px;
     }
+}
+
+.history-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.history-content {
+    flex: 1;
+}
+
+.history-delete {
+    background: transparent;
+    border: none;
+    color: var(--danger);
+    font-size: 1rem;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 8px;
+    transition: background 0.2s ease;
+}
+
+.history-delete:hover {
+    background: rgba(255, 93, 77, 0.15);
 }

--- a/public/Calculator/Calculator.js
+++ b/public/Calculator/Calculator.js
@@ -165,16 +165,36 @@ function isSavableResult(result) {
     return true;
 }
 
-function createHistoryItem(entry) {
+function createHistoryItem(entry, index) {
     const div = document.createElement('div');
     div.classList.add('history-item');
-    div.textContent = `${entry.expression} = ${entry.result}`;
 
-    div.addEventListener('click', () => {
+    const content = document.createElement('div');
+    content.classList.add('history-content');
+    content.textContent = `${entry.expression} = ${entry.result}`;
+
+    content.addEventListener('click', () => {
         string = entry.expression;
         input.value = entry.expression;
         calculated = false;
     });
+
+    const deleteBtn = document.createElement('button');
+    deleteBtn.classList.add('history-delete');
+    deleteBtn.innerHTML = '✕';
+    deleteBtn.setAttribute('aria-label', 'Delete history entry');
+
+    deleteBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+
+        history.splice(index, 1);
+
+        saveHistory();
+        renderHistory();
+    });
+
+    div.appendChild(content);
+    div.appendChild(deleteBtn);
 
     return div;
 }
@@ -183,8 +203,25 @@ function renderHistory() {
     const historyList = document.getElementById('historyList');
     historyList.innerHTML = '';
 
-    history.forEach(entry => {
-        historyList.appendChild(createHistoryItem(entry));
+    if (history.length === 0) {
+        const emptyState = document.createElement('div');
+
+        emptyState.classList.add('history-empty');
+
+        emptyState.innerHTML = `
+            <h3>No calculations yet</h3>
+            <p>Your recent calculations will appear here.</p>
+        `;
+
+        historyList.appendChild(emptyState);
+
+        return;
+    }
+
+    history.forEach((entry, index) => {
+        historyList.appendChild(
+            createHistoryItem(entry, index)
+        );
     });
 }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #5580

### Summary

Enhanced the calculator history panel by adding an informative empty state and support for deleting individual history entries. These improvements make history management more intuitive while preserving existing calculator functionality and design consistency.

### Type of Change

* [x] 🚀 New feature or UI/UX enhancement

---

## 🛠️ Changes Made

* Added a user-friendly empty state displayed when no calculation history exists.
* Implemented individual history entry deletion with dedicated delete controls.
* Added accessibility support for history deletion actions using appropriate labels.
* Ensured history updates immediately after entry removal.
* Preserved existing history restoration and clear history functionality.

---

## 🧪 Testing and Verification

### Local Validation

* [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check

* [x] Tested and verified in **Google Chrome**
* [ ] Tested and verified in **Mozilla Firefox**
* [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks

* [x] Verified responsive layout on Mobile viewports (using DevTools)
* [x] Verified responsive layout on Tablet viewports
* [x] Keyboard navigation and focus outlines checked
* [x] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording

<img width="1120" height="906" alt="image" src="https://github.com/user-attachments/assets/3d3b340b-eaf2-49e2-aab2-4549c2adca77" />
<img width="1258" height="912" alt="image" src="https://github.com/user-attachments/assets/0a9b06e2-6fec-4d88-b56c-7562a9cc901f" />

---

## 🤝 Contributor Checklist

* [x] My code follows the code style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have updated the documentation / README files accordingly.
* [x] My changes generate no new warnings or console errors.
* [x] There are no unrelated changes or formatter noise in this PR.
