### PR TITLE
fix: Use semantic <h3> tag for project card names for screen readers

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,7 +261,7 @@ getProjectDescription(project);
                   ${sourceOnlyBadge}
                 </span>
             </div>
-            <div class="card-name">${name}</div>
+            <h3 class="card-name">${name}</h3>
             ${
               showDescription
                 ? `<div class="card-description">

--- a/style.css
+++ b/style.css
@@ -1482,6 +1482,7 @@ input:focus,
 }
 
 .card-name {
+  margin: 0;
   font-family: 'Inter Tight', sans-serif;
   font-size: 1.02rem;
   font-weight: 700;


### PR DESCRIPTION
## Description
Closes #5485

This PR improves the structural accessibility of the project grid by replacing generic `<div>` tags with semantic `<h3>` heading tags for the project titles. This allows screen reader users to properly navigate the grid using heading shortcuts.

### Changes Made
- In `index.js`, changed `<div class="card-name">` to `<h3 class="card-name">` inside `renderGrid`.
- In `style.css`, added `margin: 0;` to `.card-name` to override the browser's default heading margins, ensuring the UI remains visually identical.

## Type of PR
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have ensured that my changes do not break any existing functionality.