### PR TITLE
fix: Add missing :focus-visible outline to category filter chips

### DIFF
--- a/style.css
+++ b/style.css
@@ -1277,6 +1277,11 @@ input:focus,
   background: rgba(255, 255, 255, 0.01);
 }
 
+.chip:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .chip.active {
   background: var(--accent-dim);
   border-color: var(--border-accent);


### PR DESCRIPTION
## Description
Closes #5486

This PR resolves an accessibility bug where the category filter chips (`.chip` buttons) lacked a clear visual focus indicator for keyboard users.

### Changes Made
- Added a `.chip:focus-visible` rule in `style.css`.
- Applied a 2px solid outline using the `var(--accent)` color with a 2px offset to ensure it complies with WCAG 2.1 Success Criterion 2.4.7 (Focus Visible) while matching the existing design system.

## Type of PR
- [x] Bug fix
- [ ] Feature enhancement
- [ ] Documentation update

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have ensured that my changes do not break any existing functionality.