### PR TITLE
feat: Add global keyboard shortcut (/) to focus search bar

### DIFF
--- a/index.js
+++ b/index.js
@@ -1326,6 +1326,13 @@ function initSearch() {
     }, 180)
   );
 
+  document.addEventListener('keydown', (e) => {
+    if (e.key === '/' && document.activeElement.tagName !== 'INPUT' && document.activeElement.tagName !== 'TEXTAREA') {
+      e.preventDefault();
+      input.focus();
+    }
+  });
+
   // Tech stack dropdown filter listener
   const techStack = document.getElementById('techStackFilter');
   if (techStack) {


### PR DESCRIPTION
## Description
Closes #5483

This PR introduces a major quality-of-life improvement for keyboard navigation. Users can now press the forward slash key (`/`) anywhere on the page to instantly focus the `#searchInput` field, matching the standard developer UX found on GitHub and NPM.

### Changes Made
- Added a global `keydown` event listener in `initSearch()` inside `index.js`.
- Implemented logic to check `e.key === '/'`.
- Added safeguards to ensure the default behavior is not prevented if the user is already typing inside an input or textarea element.

## Type of PR
- [ ] Bug fix
- [x] Feature enhancement
- [ ] Documentation update

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have tested the changes thoroughly before submitting this pull request.
- [x] I have ensured that my changes do not break any existing functionality.