### PR TITLE
Fix Candy Crush drag and drop functionality

### DIFF
--- a/public/Candy_Crush_Game/index.html
+++ b/public/Candy_Crush_Game/index.html
@@ -5,7 +5,7 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>Candy Crush</title>
-        <link rel="stylesheet" href="style.css">
+        <link rel="stylesheet" href="./style.css">
         <link rel="icon" href="../favv.png" type="image/x-icon" />
         <link href="https://fonts.googleapis.com/css2?family=Luckiest+Guy&display=swap" rel="stylesheet">
         <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -13,7 +13,7 @@
 <link href="https://fonts.googleapis.com/css2?family=Lobster&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
 
-        <script src="script.js"></script>
+        <script src="./script.js"></script>
     </head>
 
     <body>

--- a/public/Candy_Crush_Game/script.js
+++ b/public/Candy_Crush_Game/script.js
@@ -47,6 +47,7 @@ function startGame() {
                 (r >= 2 && board[r - 1][c].src.includes(candy) && board[r - 2][c].src.includes(candy))
             );
             let tile = document.createElement("img");
+            tile.draggable = true;
             tile.id = r + "-" + c;
             tile.src = "./images/" + candy + ".png";
 

--- a/public/Candy_Crush_Game/style.css
+++ b/public/Candy_Crush_Game/style.css
@@ -108,7 +108,6 @@ li:hover{
     height: 100%;
     object-fit: contain;
     user-select: none;
-    -webkit-user-drag: none;
 }
 
 #combo-display {


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #5568 

### Summary

Fixed the Candy Crush game drag-and-drop functionality. The game board was loading correctly, but candies could not be dragged or swapped due to CSS preventing image dragging. This update restores proper drag interactions, allowing users to swap candies and play the game as intended.

### Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 🛠️ Changes Made

* Fixed Candy Crush drag-and-drop interactions.
* Removed/updated CSS that prevented candy images from being draggable.
* Verified that candies can be dragged and swapped correctly.
* Confirmed game board initialization and gameplay functionality after the fix.

---

## 🧪 Testing and Verification

### Local Validation

* [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check

* [x] Tested and verified in **Google Chrome**
* [ ] Tested and verified in **Mozilla Firefox**
* [x] Tested and verified in **Microsoft Edge**

### Responsive & Accessibility Checks

* [x] Verified responsive layout on Mobile viewports (using DevTools)
* [x] Verified responsive layout on Tablet viewports
* [ ] Keyboard navigation and focus outlines checked
* [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording

<img width="1919" height="965" alt="image" src="https://github.com/user-attachments/assets/0b2a9ef5-5800-44f2-8bef-a11e75ccdc81" />


---

## 🤝 Contributor Checklist

* [x] My code follows the code style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] My changes generate no new warnings or console errors.
* [x] There are no unrelated changes or formatter noise in this PR.

DONE UNDER GSSOC'26
