### PR TITLE
Harden NPM Package Search rendering

### DIFF
--- a/public/NPM Package Search/script.js
+++ b/public/NPM Package Search/script.js
@@ -1,35 +1,99 @@
 const resultsDiv = document.getElementById('results');
+const searchInput = document.getElementById('search-input');
+const searchButton = document.getElementById('search-button');
+let activeSearchId = 0;
+
 resultsDiv.style.display = 'none';
 
-document.getElementById('search-button').addEventListener('click', function() {
-    const query = document.getElementById('search-input').value;
-    fetch(`https://registry.npmjs.org/-/v1/search?text=${query}&size=10`)
-        .then(response => {
-            if (response.status === 429) {
-                throw new Error('Rate limit exceeded. Please try again later.');
-            }
-            return response.json();
-        })
-        .then(data => {
-            resultsDiv.style.display = 'block';
-            resultsDiv.innerHTML = '';
-            if (data.objects.length === 0) {
-                resultsDiv.innerHTML = '<p>No packages found.</p>';
-            } else {
-                data.objects.forEach(pkg => {
-                    const pkgElement = document.createElement('div');
-                    pkgElement.classList.add('package');
-                    pkgElement.innerHTML = `
-                        <h3><a href="https://www.npmjs.com/package/${pkg.package.name}" target="_blank">${pkg.package.name}</a></h3>
-                        <p>${pkg.package.description}</p>
-                    `;
-                    resultsDiv.appendChild(pkgElement);
-                });
-            }
-        })
-        .catch(error => {
-            const resultsDiv = document.getElementById('results');
-            resultsDiv.innerHTML = `<p>Error: ${error.message}</p>`;
-            console.error('Error fetching packages:', error);
+function clearResults() {
+    resultsDiv.textContent = '';
+}
+
+function showMessage(message) {
+    clearResults();
+    const messageElement = document.createElement('p');
+    messageElement.textContent = message;
+    resultsDiv.appendChild(messageElement);
+    resultsDiv.style.display = 'block';
+}
+
+function createPackageElement(packageData) {
+    const packageName = packageData.name || 'Unnamed package';
+    const pkgElement = document.createElement('div');
+    const title = document.createElement('h3');
+    const link = document.createElement('a');
+    const description = document.createElement('p');
+
+    pkgElement.classList.add('package');
+    const packagePath = packageName.split('/').map(encodeURIComponent).join('/');
+
+    link.href = `https://www.npmjs.com/package/${packagePath}`;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = packageName;
+    description.textContent = packageData.description || 'No description provided.';
+
+    title.appendChild(link);
+    pkgElement.appendChild(title);
+    pkgElement.appendChild(description);
+
+    return pkgElement;
+}
+
+searchButton.addEventListener('click', async function() {
+    const query = searchInput.value.trim();
+    const searchId = ++activeSearchId;
+
+    if (!query) {
+        showMessage('Enter a package name to search.');
+        return;
+    }
+
+    const url = new URL('https://registry.npmjs.org/-/v1/search');
+    url.search = new URLSearchParams({
+        text: query,
+        size: '10'
+    });
+
+    searchButton.disabled = true;
+    showMessage('Searching packages...');
+
+    try {
+        const response = await fetch(url.toString());
+
+        if (searchId !== activeSearchId) return;
+
+        if (response.status === 429) {
+            throw new Error('Rate limit exceeded. Please try again later.');
+        }
+
+        if (!response.ok) {
+            throw new Error(`Search failed with status ${response.status}.`);
+        }
+
+        const data = await response.json();
+
+        if (searchId !== activeSearchId) return;
+
+        clearResults();
+        resultsDiv.style.display = 'block';
+
+        if (!data.objects || data.objects.length === 0) {
+            showMessage('No packages found.');
+            return;
+        }
+
+        data.objects.forEach(pkg => {
+            resultsDiv.appendChild(createPackageElement(pkg.package || {}));
         });
+    } catch (error) {
+        if (searchId !== activeSearchId) return;
+
+        showMessage(`Error: ${error.message}`);
+        console.error('Error fetching packages:', error);
+    } finally {
+        if (searchId === activeSearchId) {
+            searchButton.disabled = false;
+        }
+    }
 });


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #5779

### Summary
This hardens the NPM Package Search flow so user input and registry metadata are no longer interpolated directly into request URLs or result HTML. It also adds clearer request states so repeated searches do not leave stale or unsafe output in the results panel.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## Changes Made
- Builds the registry search URL with URL and URLSearchParams so the package query is encoded correctly.
- Replaces result-card innerHTML rendering with DOM nodes and textContent for package names/descriptions.
- Adds empty-query, no-results, rate-limit, and non-OK response messages without injecting error text as HTML.
- Disables the search button during the active request and keeps a latest-request guard before rendering results.

---

## Testing and Verification

Local checks completed:
- [x] node --check public/NPM Package Search/script.js
- [x] npm run lint

Additional note: node scripts/validate-projects.js currently fails on existing projects.json entries unrelated to this PR: missing paths for Multi-Track Video and Audio Editor, Flipkart Clone, Theme-Toggler, plus duplicate projectNo 196. I left those unrelated registry issues untouched.

Browser/responsive note: no layout or HTML structure was changed; this PR only updates the JavaScript search flow and result rendering.

---

## Screenshots / Video Recording
No layout change; this is a JavaScript safety and error-handling fix for the search flow.

---

## Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.

This PR is for GSSoC 2026. Please add the appropriate GSSoC and level labels during review if applicable.