### PR TITLE
fix: add like button toggle functionality in LinkedIn Clone Day 79

### DIFF
--- a/public/Linkedin-Clone/style.css
+++ b/public/Linkedin-Clone/style.css
@@ -1096,3 +1096,12 @@ a:hover {
     /* hide sort control on mobile */
     .sort-by { display: none; }
 }
+/* Like Button Liked State */
+.post-activity-link.liked {
+  color: #0a66c2 !important;
+  font-weight: 600 !important;
+}
+
+.post-activity-link.liked span {
+  color: #0a66c2 !important;
+}


### PR DESCRIPTION
### Related Issue
Closes #5616

### Summary
Added like button toggle functionality in LinkedIn Clone (Day 79). 
Clicking Like now toggles liked/unliked state and updates the count.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

### Changes Made
- Added click event listener for `.post-activity-link` like buttons
- Like button toggles blue color and bold on click
- Like count updates on like/unlike
- Works for both existing and newly created posts

### Testing and Verification
- [x] Tested and verified in Google Chrome
- [x] Tested and verified in Mozilla Firefox

### Screenshots
BEFORE :
🔵 Like button color
❌ Before: "Be the first to like"
❌ Before: Gray / normal color
<img width="674" height="673" alt="Screenshot 2026-06-02 181955" src="https://github.com/user-attachments/assets/0c58f2ce-c034-47e9-8c61-9f123eca4d54" />

AFTER :
✅ After: "You and 1 others"
✅ After: Blue + bold
<img width="694" height="693" alt="Screenshot 2026-06-02 182012" src="https://github.com/user-attachments/assets/c0d6ee9d-e436-4708-9987-d4dd8c301410" />

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
