### PR TITLE
fix(chatbot): add missing Hugging Face API key visibility toggle

### DIFF
--- a/public/AI ChatBot/script.js
+++ b/public/AI ChatBot/script.js
@@ -165,6 +165,11 @@ function toggleObKey() {
   inp.type = inp.type === "password" ? "text" : "password";
 }
 
+function toggleObHfKey() {
+  const inp = $("ob-hf-input");
+  inp.type = inp.type === "password" ? "text" : "password";
+}
+
 function finishOnboarding() {
   const val = $("ob-api-input").value.trim();
   const errEl = $("ob-key-error");


### PR DESCRIPTION
## Summary

Fixes a JavaScript ReferenceError in the AI ChatBot onboarding flow.

The Hugging Face API key visibility button on Step 4 referenced `toggleObHfKey()`, but the function was not defined in `script.js`. Clicking the eye icon resulted in a console error and prevented the visibility toggle from working.

## Changes Made

* Added the missing `toggleObHfKey()` function.
* Implemented password/text visibility toggling for the onboarding Hugging Face API key field (`ob-hf-input`).
* Kept the implementation consistent with the existing onboarding API key toggle behavior.

## Issue Fixed

Closes #5669

## Testing

### Reproduction Before Fix

1. Open AI ChatBot onboarding.
2. Navigate to Step 4 (Image Generation).
3. Click the eye icon beside the Hugging Face API key field.
4. Observe `ReferenceError: toggleObHfKey is not defined` in the console.

### Verification After Fix

1. Open AI ChatBot onboarding.
2. Navigate to Step 4 (Image Generation).
3. Click the eye icon beside the Hugging Face API key field.
4. Confirm the field toggles between hidden and visible states.
5. Confirm no console errors are generated.
6. Confirm onboarding continues normally.
