### PR TITLE
Improved the responsiveness of travel booking website

### DIFF
--- a/public/Travel_booking_website/style.css
+++ b/public/Travel_booking_website/style.css
@@ -24,7 +24,7 @@ body {
 .section_container {
     max-width: var(--max-width);
     margin: auto;
-    padding: 5rem 1rem;
+    padding: 2rem 2rem;
 }
 
 .section_header {
@@ -162,7 +162,7 @@ nav {
 .header_container {
     max-width: 900px;
     margin-inline: auto;
-    margin-bottom: 3rem;
+    margin-bottom: 1rem;
     color: var(--white);
     text-align: center;
 }
@@ -174,10 +174,13 @@ nav {
     color: var(--white);
     text-align: center;
 }
+.header_container p{
+    margin-bottom: 20px;
+}
 
 .booking {
     max-width: 900px;
-    margin: auto;
+    margin: 20px 20px;
     padding: 1.25rem 1.5rem;
     display: grid;
     gap: 0.75rem;
@@ -190,13 +193,16 @@ nav {
 }
 
 .booking_type {
-    width: fit-content;
+    margin: 10px 10px;
+    width: 90%;
     padding: 4px;
     display: grid;
     grid-template-columns: max-content max-content max-content;
     align-items: center;
     background-color: rgba(255, 255, 255, 0.2);
     border-radius: calc(var(--radius) - 2px);
+    justify-content: space-evenly;
+    justify-self: center;
 }
 
 .booking_type>div {
@@ -220,6 +226,7 @@ nav {
     grid-template-columns: repeat(3, 1fr) auto;
     gap: 1rem;
     align-items: end;
+    margin:10px 10px;
 }
 
 .booking_input {
@@ -757,8 +764,97 @@ nav {
 }
 
 
+@media(width<550px){
+    .booking_form{
+        margin: 0px;
+    }
+    .booking_type{
 
-@media (min-width: 576px) {
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 0px;
+    }
+    .booking_input{
+        display: flex;
+        flex-direction: column;
+        margin-bottom: 10px;
+    }
+    #book-now-btn{
+        display: flex;
+        flex-direction: column;
+
+    }
+    .service_grid {
+        display: flex;
+        flex-direction: column;
+    }
+
+
+}
+
+
+@media (width<768px) {
+    .nav{
+        width: 100%;
+    }
+
+    .nav_bar{
+        width: 100%;
+        height: 120px;
+        align-items: center;
+        padding: 1rem;
+    }
+
+    .nav_links{
+        width: 100%;
+        left: 0;
+        padding: 1rem;
+    }
+
+    .header_container h1{
+        margin-top: 125px;
+    }
+    .header_container p{
+        margin-bottom: 20px;
+    }
+    .booking{
+        width: auto;
+        display:flex;
+        flex-direction: column;
+    }
+    .booking_type{
+        justify-content: space-evenly;
+        width: auto;
+        margin:20px;
+        justify-self: center;
+    }
+    .booking_form{
+        display: table-column;
+        justify-self: center;
+        width:auto;
+        
+    }
+    .booking_input{
+        display: flex;
+        align-items: center;
+        gap: 5px;
+        padding: 6px;
+
+    }
+    .booking_input label{
+        width: 170px;
+    }
+    .booking_input input{
+        flex: 1;
+        min-width: 0;
+    }
+    #book-now-btn{
+        margin:20px 20px;
+        
+    }
+    .service_container {
+        margin: 0px;
+    }
     .service_grid {
         grid-template-columns: repeat(2, 1fr);
     }
@@ -768,6 +864,7 @@ nav {
         align-items: center;
         justify-content: space-between;
     }
+   
 }
 
 @media (min-width: 768px) {
@@ -810,6 +907,10 @@ nav {
         grid-template-columns: repeat(3, 1fr);
         align-items: end;
     }
+    .service_grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+
 
     .offer_grid {
         grid-template-columns: repeat(3, 1fr);
@@ -830,6 +931,7 @@ nav {
 }
 
 @media (min-width: 1024px) {
+    
     .service_grid {
         grid-template-columns: repeat(3, 1fr);
     }


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #5062 

### Summary
Improved the responsiveness of the Travel Booking Website for mobile and tablet devices. Updated layouts and component sizing to ensure a better user experience across different screen sizes.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [X] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added responsive media queries for mobile and tablet viewports.
- Enhanced overall mobile user experience and layout consistency.

---

## 🧪 Testing and Verification

### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [X] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [X] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [X] Verified responsive layout on Mobile viewports (using DevTools)
- [X] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
*Please attach screenshots or screen recordings showing before vs after behavior if this PR includes visual changes.*
<img width="1150" height="1004" alt="image" src="https://github.com/user-attachments/assets/efc1f218-0d2b-4427-9754-7a02d4039f5f" />
<img width="1104" height="618" alt="image" src="https://github.com/user-attachments/assets/eacf0923-1cb1-47f6-9fec-88ce88ea3230" />

<img width="790" height="998" alt="image" src="https://github.com/user-attachments/assets/b9e411ae-6c30-4543-bf0f-bef1499107bc" />


---

## 🤝 Contributor Checklist
- [X] My code follows the code style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [X] My changes generate no new warnings or console errors.
- [X] There are no unrelated changes or formatter noise in this PR.
