### PR TITLE
Remove dark mode button styles

### DIFF
--- a/public/digital_clock/digitalclock.css
+++ b/public/digital_clock/digitalclock.css
@@ -85,23 +85,7 @@ body.light-mode .info-box {
   color: #111827;
 }
 
-.dark-mode-btn {
-  margin-top: 2px;
-  padding: 20px 34px;
-  border-radius: 9px;
-  border: 2px solid var(--primary);
-  background: transparent;
-  color: var(--primary);
-  font-family: "Poppins", sans-serif;
-  font-weight: 600;
-  cursor: pointer;
-  transition: all 0.3s;
-}
 
-.dark-mode-btn:hover {
-  background: var(--primary);
-  color: #000;
-}
 body {
   min-height: 100vh;
   font-family: var(--font-sans);
@@ -1468,3 +1452,14 @@ input:checked + .toggle-slider:before {
   text-align: center;
   margin-top: 12px;
 }
+
+
+
+.dashboard-grid {
+  align-items: start;
+}
+
+.card {
+  height: fit-content;
+}
+


### PR DESCRIPTION
Removed dark mode button styles from digitalclock.css.

## 📝 Pull Request Description

### Related Issue
Closes #ISSUE_NUMBER

### Summary
Provide a short, reviewer-friendly summary of what changed and why.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Detailed description of change 1
- Detailed description of change 2

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [ ] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
*Please attach screenshots or screen recordings showing before vs after behavior if this PR includes visual changes.*

---

## 🤝 Contributor Checklist
- [ ] My code follows the code style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [ ] My changes generate no new warnings or console errors.
- [ ] There are no unrelated changes or formatter noise in this PR.
