### PR TITLE
[A11Y] Missing aria-label on interactive buttons (#5027)

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,7 +318,7 @@
             <option value="typescript">TypeScript</option>
             <option value="tailwindcss">Tailwind CSS</option>
           </select>
-          <button id="clearAllFiltersBtn" class="clear-filters-btn">
+          <button id="clearAllFiltersBtn" class="clear-filters-btn" aria-label="Clear all filters">
             <i class="fas fa-filter-circle-xmark"></i> Clear Filters
           </button>
         </div>


### PR DESCRIPTION
Closes #5027. Added missing aria-labels to buttons in index.html.