### PR TITLE
feat: Add the note page in the Student Command Center

### DIFF
--- a/public/StudentCommandCenter/index.html
+++ b/public/StudentCommandCenter/index.html
@@ -24,7 +24,7 @@
             <ul>
                 <li class="active">Dashboard</li>
                 <li><a href="tasks.html">Tasks</a></li>
-                <li>Notes</li>
+                <li><a href="notes.html">Notes</a></li>
                 <li>Focus Mode</li>
                 <li>Settings</li>
             </ul>

--- a/public/StudentCommandCenter/notes.html
+++ b/public/StudentCommandCenter/notes.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Notes - Student Command Center</title>
+    <link rel="stylesheet" href="style.css" />
+</head>
+
+<body>
+
+    <!-- BACK BUTTON -->
+    <a href="index.html"
+       style="position:fixed;left:18px;top:18px;padding:8px 12px;
+       border-radius:8px;background:white;text-decoration:none;
+       z-index:9999;font-weight:700;">
+       ← Back to Dashboard
+    </a>
+
+    <div class="container">
+
+        <!-- NOTES SECTION -->
+        <section class="notes-section">
+
+            <h2>Quick Notes</h2>
+            <textarea id="notesArea" placeholder="Write notes here..."></textarea>
+            <button id="saveNotesBtn">Save Note</button>
+
+            <h3>Saved Notes</h3>
+            <ul id="notesList"></ul>
+
+        </section>
+
+    </div>
+    <script src="notes.js"></script>
+</body>
+</html>

--- a/public/StudentCommandCenter/notes.js
+++ b/public/StudentCommandCenter/notes.js
@@ -1,0 +1,62 @@
+const notesArea = document.getElementById("notesArea");
+const saveNotesBtn = document.getElementById("saveNotesBtn");
+const notesList = document.getElementById("notesList");
+
+// Load notes safely
+let notes = JSON.parse(localStorage.getItem("notes")) || [];
+
+// Render notes
+function renderNotes() {
+
+    if (!notesList) return; // prevents crash if page doesn't have notes UI
+
+    notesList.innerHTML = "";
+
+    notes.forEach((note, index) => {
+
+        const li = document.createElement("li");
+
+        li.innerHTML = `
+            <li class="note-card">
+                ${note}
+                <button class="deleteBtn" onclick="deleteNote(${index})">Delete</button>
+            </li>
+        `;
+
+        notesList.appendChild(li);
+    });
+}
+
+// Save note
+if (saveNotesBtn) {
+    saveNotesBtn.addEventListener("click", () => {
+
+        const note = notesArea.value.trim();
+
+        if (!note) {
+            alert("Please enter a note");
+            return;
+        }
+
+        notes.push(note);
+
+        localStorage.setItem("notes", JSON.stringify(notes));
+
+        notesArea.value = "";
+
+        renderNotes();
+    });
+}
+
+// Delete note
+function deleteNote(index) {
+
+    notes.splice(index, 1);
+
+    localStorage.setItem("notes", JSON.stringify(notes));
+
+    renderNotes();
+}
+
+// Initial render
+renderNotes();

--- a/public/StudentCommandCenter/script.js
+++ b/public/StudentCommandCenter/script.js
@@ -79,46 +79,67 @@ if(savedTasks) {
 }
 
 // NOTES
-const notesArea = document.getElementById("notesArea");
 const saveNotesBtn = document.getElementById("saveNotesBtn");
+const notesArea = document.getElementById("notesArea");
 const notesList = document.getElementById("notesList");
 
-// Load notes
-let notes = JSON.parse(localStorage.getItem("notes")) || [];
+let notes = [];
 
-// Render notes
+try {
+    notes = JSON.parse(localStorage.getItem("notes")) || [];
+} catch (error) {
+    console.error("Invalid notes data in localStorage:", error);
+    localStorage.removeItem("notes");
+    notes = [];
+}
+
 function renderNotes() {
+
+    if (!notesList) return;
+
     notesList.innerHTML = "";
 
     notes.forEach((note, index) => {
+
         const li = document.createElement("li");
 
-        li.innerHTML = `${note}`;
+        li.innerHTML = `
+            ${note}
+            <button class="deleteBtn" onclick="deleteNote(${index})">Delete</button>
+        `;
 
         notesList.appendChild(li);
     });
 }
 
-// Save note
 saveNotesBtn.addEventListener("click", () => {
 
     const note = notesArea.value.trim();
 
-    if (!note) {
-        alert("Please enter a note");
+    if (note === "") {
+        alert("Enter a note");
         return;
     }
 
     notes.push(note);
 
-    localStorage.setItem("notes", JSON.stringify(notes));
-
     notesArea.value = "";
 
     renderNotes();
+
+    localStorage.setItem("notes", JSON.stringify(notes));
 });
 
-// Initial render
+function deleteNote(index) {
+
+    notes.splice(index, 1);
+
+    renderNotes();
+
+    localStorage.setItem("notes", JSON.stringify(notes));
+}
+
+// LOAD NOTES
 renderNotes();
 
 // POMODORO TIMER

--- a/public/StudentCommandCenter/style.css
+++ b/public/StudentCommandCenter/style.css
@@ -282,6 +282,22 @@ body {
     border-radius: 10px;
 }
 
+/* STICKY NOTE STYLE */
+.note-card {
+    background: #fffa87;
+    padding: 10px;
+    min-height: 100px;
+    width: 25%;
+    display:flex;
+    justify-content: space-between;
+    align-items: center;
+    color: #333;
+    border-radius: 10px;
+    position: relative;
+    box-shadow: 0 4px 10px rgba(0,0,0,0.2);
+    word-wrap: break-word;
+}
+
 /* RESPONSIVE */
 @media(max-width: 900px) {
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #5971 

### Summary
This PR adds a notes page to the Student Command Center to help users navigate through the saved notes and save it in another page to avoid cluster in the main page.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [x] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added a notes.html for the notes section and connected route to the main page
- Added a notes.js for functionality 
- Fixed styling and functions in the index.html

---

## 📷 Screenshots / Video Recording
<img width="1914" height="610" alt="Screenshot 2026-06-03 171224" src="https://github.com/user-attachments/assets/910ed6cf-bc4d-4c49-b558-9978d8278d76" />


---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
