### PR TITLE
feat: add text highlighting with remove and clear all to EchoNotes

### DIFF
--- a/public/EchoNotes/index.html
+++ b/public/EchoNotes/index.html
@@ -292,6 +292,20 @@
         </div>
 
         <div class="toolbar-group">
+          <span class="toolbar-label">Highlight</span>
+          <div style="display:flex; gap:4px; align-items:center;">
+            <button onclick="applyHighlight('#ffff99')" title="Yellow" style="width:18px;height:18px;border-radius:50%;background:rgba(255,255,100,0.5);border:1px solid #ccc;cursor:pointer;"></button>
+            <button onclick="applyHighlight('#99ffcc')" title="Green" style="width:18px;height:18px;border-radius:50%;background:rgba(100,255,180,0.5);border:1px solid #ccc;cursor:pointer;"></button>
+            <button onclick="applyHighlight('#99ccff')" title="Blue" style="width:18px;height:18px;border-radius:50%;background:rgba(100,180,255,0.5);border:1px solid #ccc;cursor:pointer;"></button>
+            <button onclick="applyHighlight('#ffb3de')" title="Pink" style="width:18px;height:18px;border-radius:50%;background:rgba(255,150,220,0.5);border:1px solid #ccc;cursor:pointer;"></button>
+            <button onclick="applyHighlight('#ffcc99')" title="Orange" style="width:18px;height:18px;border-radius:50%;background:rgba(255,180,100,0.5);border:1px solid #ccc;cursor:pointer;"></button>
+            <button onclick="applyHighlight('#cc99ff')" title="Purple" style="width:18px;height:18px;border-radius:50%;background:rgba(180,100,255,0.5);border:1px solid #ccc;cursor:pointer;"></button>
+            <button onclick="removeHighlight()" title="Remove highlight (Ctrl+Shift+H)" style="width:22px;height:18px;border-radius:4px;background:var(--bg-card);border:1px solid var(--border);cursor:pointer;font-size:10px;color:var(--text-secondary);">✕</button>
+            <button onclick="clearAllHighlights()" title="Clear all highlights (Ctrl+Shift+C)" style="width:22px;height:18px;border-radius:4px;background:var(--bg-card);border:1px solid var(--border);cursor:pointer;font-size:10px;color:var(--text-secondary);">🗑</button>
+          </div>
+        </div>
+
+        <div class="toolbar-group">
           <span class="toolbar-label">Size</span>
           <select class="size-select" id="fontSizeSelect" onchange="applyFontSize(this.value)" title="Global Font Size">
             <option value="13">Small</option>

--- a/public/EchoNotes/script.js
+++ b/public/EchoNotes/script.js
@@ -609,6 +609,215 @@ function applyFontSize(s) {
 }
 
 // ==========================================================================
+// HIGHLIGHT FUNCTIONS (Cross-browser compatible)
+// ==========================================================================
+
+// Apply highlight to selected text (works in Chrome, Firefox, Safari, Edge)
+function applyHighlight(color) {
+  const r = parseInt(color.slice(1,3), 16);
+  const g = parseInt(color.slice(3,5), 16);
+  const b = parseInt(color.slice(5,7), 16);
+  const rgba = `rgba(${r},${g},${b},0.5)`;
+  
+  const selection = window.getSelection();
+  
+  // Check if text is selected
+  if (!selection.rangeCount || selection.isCollapsed) {
+    showToast('⚠️', 'Select some text first', 'error');
+    return;
+  }
+  
+  const range = selection.getRangeAt(0);
+  
+  // Don't highlight if nothing selected
+  if (range.collapsed) {
+    showToast('⚠️', 'Select some text first', 'error');
+    return;
+  }
+  
+  try {
+    // Modern method: wrap selected text in a span with background color
+    const span = document.createElement('span');
+    span.style.backgroundColor = rgba;
+    span.style.transition = 'background-color 0.2s ease';
+    span.style.cursor = 'pointer';
+    
+    // Add data attribute to identify highlights
+    span.setAttribute('data-highlight', 'true');
+    
+    range.surroundContents(span);
+    selection.removeAllRanges();
+    markUnsaved();
+    showToast('✨', 'Text highlighted', 'success');
+  } catch (e) {
+    // Fallback for edge cases (selection spans across multiple elements)
+    try {
+      if (document.queryCommandSupported('hiliteColor')) {
+        document.execCommand('hiliteColor', false, rgba);
+        markUnsaved();
+        showToast('✨', 'Text highlighted', 'success');
+      } else {
+        showToast('⚠️', 'Highlight not supported in this browser', 'error');
+      }
+    } catch (err) {
+      showToast('⚠️', 'Could not highlight selection', 'error');
+    }
+  }
+}
+
+// Remove highlight from currently selected text
+function removeHighlight() {
+  const selection = window.getSelection();
+  
+  if (!selection.rangeCount || selection.isCollapsed) {
+    showToast('⚠️', 'Select highlighted text first', 'error');
+    return;
+  }
+  
+  const range = selection.getRangeAt(0);
+  let removed = false;
+  
+  try {
+    // Check if the selected node is inside a highlight span
+    let node = range.commonAncestorContainer;
+    if (node.nodeType === Node.TEXT_NODE) {
+      node = node.parentNode;
+    }
+    
+    // If directly on a highlight span, remove it
+    if (node && node.tagName === 'SPAN' && node.hasAttribute('data-highlight')) {
+      const parent = node.parentNode;
+      while (node.firstChild) {
+        parent.insertBefore(node.firstChild, node);
+      }
+      parent.removeChild(node);
+      removed = true;
+    } else {
+      // Find all highlight spans within the selection
+      const highlightedSpans = range.cloneContents().querySelectorAll('span[data-highlight]');
+      if (highlightedSpans.length > 0) {
+        // Create a document fragment to work with
+        const fragment = range.extractContents();
+        const tempDiv = document.createElement('div');
+        tempDiv.appendChild(fragment);
+        
+        // Remove all highlight spans
+        tempDiv.querySelectorAll('span[data-highlight]').forEach(span => {
+          const parent = span.parentNode;
+          while (span.firstChild) {
+            parent.insertBefore(span.firstChild, span);
+          }
+          parent.removeChild(span);
+        });
+        
+        // Insert back the cleaned content
+        while (tempDiv.firstChild) {
+          range.insertNode(tempDiv.firstChild);
+        }
+        removed = true;
+      }
+    }
+    
+    if (removed) {
+      selection.removeAllRanges();
+      markUnsaved();
+      showToast('✨', 'Highlight removed', 'success');
+    } else {
+      // Try execCommand fallback
+      if (document.queryCommandSupported('removeFormat')) {
+        document.execCommand('removeFormat', false, null);
+        markUnsaved();
+        showToast('✨', 'Highlight removed', 'success');
+      } else {
+        showToast('⚠️', 'No highlight found in selection', 'error');
+      }
+    }
+  } catch (e) {
+    // Fallback to execCommand
+    if (document.queryCommandSupported('removeFormat')) {
+      document.execCommand('removeFormat', false, null);
+      markUnsaved();
+      showToast('✨', 'Highlight removed', 'success');
+    } else {
+      showToast('⚠️', 'Could not remove highlight', 'error');
+    }
+  }
+}
+
+// Clear ALL highlights from the current note
+function clearAllHighlights() {
+  const editor = document.getElementById('note-content');
+  if (!editor) {
+    showToast('⚠️', 'No note open', 'error');
+    return;
+  }
+  
+  // Find all highlighted spans (using data attribute or background style)
+  let highlighted = editor.querySelectorAll('span[data-highlight]');
+  
+  // Also find elements with background color (for execCommand highlights)
+  const bgHighlighted = editor.querySelectorAll('[style*="background-color"]');
+  
+  // Combine both
+  if (bgHighlighted.length > 0) {
+    const existingIds = new Set();
+    highlighted.forEach(h => existingIds.add(h));
+    bgHighlighted.forEach(h => {
+      if (!existingIds.has(h)) existingIds.add(h);
+    });
+    highlighted = Array.from(existingIds);
+  }
+  
+  if (highlighted.length === 0) {
+    showToast('ℹ️', 'No highlights to clear', 'info');
+    return;
+  }
+  
+  openModal('Clear All Highlights', `Remove ${highlighted.length} highlight(s) from this note?`, () => {
+    highlighted.forEach(el => {
+      // If it's a span with our data attribute, remove it
+      if (el.tagName === 'SPAN' && (el.hasAttribute('data-highlight') || el.style.backgroundColor)) {
+        const parent = el.parentNode;
+        while (el.firstChild) {
+          parent.insertBefore(el.firstChild, el);
+        }
+        parent.removeChild(el);
+      } else {
+        // Just remove background color style
+        el.style.backgroundColor = '';
+        if (el.style.background) el.style.background = '';
+      }
+    });
+    
+    // Clean up any empty spans left behind
+    editor.querySelectorAll('span:empty').forEach(span => {
+      if (!span.hasAttributes() || span.attributes.length === 0) {
+        span.remove();
+      }
+    });
+    
+    markUnsaved();
+    showToast('✨', `Cleared ${highlighted.length} highlight(s)`, 'success');
+  });
+}
+
+// Optional: Keyboard shortcut for removing highlight (Ctrl+Shift+H)
+document.addEventListener('keydown', (e) => {
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'H') {
+    e.preventDefault();
+    if (activeId) {
+      removeHighlight();
+    }
+  }
+  // Ctrl+Shift+C for clear all highlights
+  if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key === 'C') {
+    e.preventDefault();
+    if (activeId) {
+      clearAllHighlights();
+    }
+  }
+});
+// ==========================================================================
 // PDF EXPORT
 // ==========================================================================
 function exportPDF() {


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #1137 

### Summary
Added text highlighting functionality to EchoNotes with 6 color options, ability to remove single highlights, clear all highlights with confirmation modal, and keyboard shortcuts.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [X] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added 6 highlight color buttons (Yellow, Green, Blue, Pink, Orange, Purple)
- Added remove highlight button (✕) to remove highlight from selected text
- Added clear all highlights button (🗑) with confirmation modal
- Added keyboard shortcuts: Ctrl+Shift+H (remove), Ctrl+Shift+C (clear all)
- Cross-browser compatible
---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [X] Tested and verified in **Google Chrome**
- [X] Tested and verified in **Mozilla Firefox**
- [X] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [X] Keyboard navigation and focus outlines checked
- [X] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
<img width="1119" height="870" alt="1" src="https://github.com/user-attachments/assets/e074142e-1431-4320-8bd5-e3a88c86d6ac" />
<img width="1117" height="868" alt="2" src="https://github.com/user-attachments/assets/0b3e80b4-7d84-4da6-9ed7-a77975f1476a" />
<img width="1600" height="874" alt="3" src="https://github.com/user-attachments/assets/25e1a3f3-a54b-4720-a665-6c9e4b7e765d" />
<img width="1589" height="938" alt="4" src="https://github.com/user-attachments/assets/0500dddd-5a87-48fb-b235-c324dd5e318b" />

---



## 🤝 Contributor Checklist
- [X] My code follows the code style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [X] My changes generate no new warnings or console errors.
- [X] There are no unrelated changes or formatter noise in this PR.
