### PR TITLE
ci: restore projects schema and fix validation path

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -1686,7 +1686,7 @@
     "projectDesc": "A browser-native media sequencer featuring multi-track composition, real-time clip trimming, transform controls, and high-performance canvas rendering.",
     "techStack": ["tool", "html", "css", "javascript"],
     "difficulty": "advanced",
-    "projectPath": "./public/canvas_multitrack_sequencer/index.html"
+    "projectPath": "./public/Breakout-game/canvas_multitrack_sequencer/index.html"
   },
   {
     "projectNo": 187,

--- a/schema/projects.schema.json
+++ b/schema/projects.schema.json
@@ -1,0 +1,37 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": [
+      "projectNo",
+      "projectName",
+      "projectPath",
+      "techStack",
+      "difficulty",
+      "projectDesc"
+    ],
+    "properties": {
+      "projectNo": {
+        "type": "number"
+      },
+      "projectName": {
+        "type": "string"
+      },
+      "projectPath": {
+        "type": "string"
+      },
+      "techStack": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "difficulty": {
+        "type": "string"
+      },
+      "projectDesc": {
+        "type": "string"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #6094 


# Summary
Restores the missing JSON schema file required by the project validation scripts, and fixes a broken file path for project Day 186.

# Changes Made
- Created `schema/projects.schema.json` containing the official project metadata schema structure.
- Updated Day 186 `projectPath` to point to its actual location `./public/Breakout-game/canvas_multitrack_sequencer/index.html`.

# Testing
Validated locally via:
```bash
node scripts/validateProjects.js
