### PR TITLE
fix(virtual-piano): prevent console errors from unsupported keyboard inputs

### DIFF
--- a/public/Virtual_Piano/index.js
+++ b/public/Virtual_Piano/index.js
@@ -5,6 +5,7 @@ var recordStart  = null;
 var recording    = [];
 var playbackTimers = [];
 var keysHeld     = {};
+var supportedKeys = ["a", "w", "s", "e", "d", "f", "t", "g", "y", "h", "u", "j", "k", "o", "l", "p", ";"];
 
 // Load saved recording from localStorage on startup
 var saved = localStorage.getItem("pianoRecording");
@@ -17,6 +18,10 @@ if (saved) {
 
 var numOfKeys = $(".key").length;
 function handleKey(note) {
+    if (!note) return;
+    var key = note.toLowerCase();
+    if (!supportedKeys.includes(key)) return;
+
     playNote(note);
     pressAnimation(note);
 
@@ -35,12 +40,16 @@ for(var i=0; i<numOfKeys; i++) {
 }
 
 $(document).keydown(function(event) {
+    var key = event.key.toLowerCase();
+    if (!supportedKeys.includes(key)) return;
     if (keysHeld[event.key]) return; 
     keysHeld[event.key] = true;
     handleKey(event.key);
 });
 
 $(document).keyup(function(event) {
+    var key = event.key.toLowerCase();
+    if (!supportedKeys.includes(key)) return;
     delete keysHeld[event.key];
 });
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #5938

### Summary

Fixes a bug in the Virtual Piano project where pressing unsupported keyboard keys could trigger console errors during key animation handling.

The fix introduces validation for supported piano keys and safely ignores unmapped keyboard inputs before they reach the sound and animation logic.

### Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 🛠️ Changes Made

* Added a `supportedKeys` list containing all valid piano keyboard mappings
* Added validation in keyboard event handlers to ignore unsupported keys
* Added validation inside `handleKey()` to prevent invalid inputs from reaching animation and playback logic
* Prevented selector-related runtime errors caused by special characters such as `.`, `/`, `[`, and `]`

---

## 🧪 Testing and Verification

### Local Validation

* [x] Verified valid piano keys still trigger sound playback
* [x] Verified valid piano keys still trigger visual animations
* [x] Verified unsupported keys are ignored safely
* [x] Verified no console errors occur when pressing unsupported keys

### Browser Compatibility Check

* [x] Tested and verified in Google Chrome

---

## 📷 Screenshots / Video Recording

Console remains error-free when unsupported keys are pressed, while valid piano keys continue to function normally.

---

## 🤝 Contributor Checklist

* [x] My code follows the code style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] My changes generate no new warnings or console errors.
* [x] There are no unrelated changes in this PR.
