### PR TITLE
ci: allow release and hotfix branches in naming validation workflow

### DIFF
--- a/.github/workflows/branch-name-validator.yml
+++ b/.github/workflows/branch-name-validator.yml
@@ -23,7 +23,8 @@ jobs:
             const allowedPrefixes = [
               'feat/', 'fix/', 'docs/', 'refactor/',
               'perf/', 'accessibility/', 'ci/',
-              'enhancement/', 'bugfix/', 'chore/', 'test/'
+              'enhancement/', 'bugfix/', 'chore/', 'test/',
+              'hotfix/', 'release/'
             ];
 
             const isValid = allowedPrefixes.some(p => branchName.startsWith(p));


### PR DESCRIPTION
Closes #6111 

# Summary
Allows standard workflow prefixes `release/` and `hotfix/` to pass naming validator checks in Github Actions.

# Changes Made
- Appended `'hotfix/'` and `'release/'` to `allowedPrefixes` array inside `.github/workflows/branch-name-validator.yml`.

# Testing
- Validated YAML syntax validation correctness.

# Impact
Enables developers and maintainers to raise PRs from `release/` and `hotfix/` branches smoothly without CI pipeline naming convention blocks.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
