### PR TITLE
perf: compact notes metadata serialization in LocalStorage

### DIFF
--- a/public/notes-app/script.js
+++ b/public/notes-app/script.js
@@ -113,7 +113,16 @@ function normalizeNote(note) {
 }
 
 function saveNotes() {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(state.notes));
+  const compactedNotes = state.notes.map(note => {
+    const compacted = { ...note };
+    if (!compacted.password) delete compacted.password;
+    if (compacted.locked === false) delete compacted.locked;
+    if (compacted.favorite === false) delete compacted.favorite;
+    if (compacted.archived === false) delete compacted.archived;
+    if (compacted.trashed === false) delete compacted.trashed;
+    return compacted;
+  });
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(compactedNotes));
 }
 
 function formatDate(value, options = { month: "short", day: "numeric" }) {


### PR DESCRIPTION
Closes #6117 

# Summary
Implements property pruning on note objects prior to serialization storage. Stripped keys are automatically reconstituted by the existing loading/normalization parser.

# Changes Made
- Updated `saveNotes()` inside `public/notes-app/script.js` to clean falsy states (`password`, `locked`, `favorite`, `archived`, `trashed`) before serializing.

# Testing
- Created notes with varying statuses, verified they prune correctly in storage, and reload with complete states.

# Impact
Improves storage allocation utilization and key loading performance.

# Checklist
- [x] Code follows project standards
- [x] Tested locally
- [x] No unrelated changes included
- [x] Responsive design verified
- [x] Accessibility considered
