### PR TITLE
fix(travel-booking): make chatbot API endpoint environment-aware

### DIFF
--- a/public/Travel_booking_website/index.js
+++ b/public/Travel_booking_website/index.js
@@ -172,8 +172,11 @@ async function sendMessage() {
 
   chatMessages.scrollTop = chatMessages.scrollHeight;
 
+  const isLocalhost = window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1";
+  const chatEndpoint = isLocalhost ? "http://localhost:5000/api/chat" : "/api/chat";
+
   try {
-    const response = await fetch("http://localhost:5000/api/chat", {
+    const response = await fetch(chatEndpoint, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #5943

### Summary
Fixes the Travel Booking Website chatbot failing in deployed environments due to a hardcoded localhost API endpoint.

Previously, chatbot requests were always sent to `http://localhost:5000/api/chat`, which only works during local development. This update makes the endpoint environment-aware so the chatbot can function correctly both locally and after deployment.

### Type of Change
- 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 🛠️ Changes Made
- Added environment detection using `window.location.hostname`.
- Configured the chatbot to use:
  - `http://localhost:5000/api/chat` when running locally.
  - `/api/chat` when running in deployed environments.
- Replaced the hardcoded fetch URL with a dynamically resolved endpoint.
- Improved deployment compatibility without affecting existing local development workflows.

---

## 🧪 Testing and Verification

### Browser Testing
- Verified chatbot requests use `http://localhost:5000/api/chat` when running on localhost.
- Verified chatbot requests resolve to `/api/chat` in a simulated production environment.
- Confirmed no regression in chatbot message submission flow.

---


## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.