### PR TITLE
fix: display all expired capsules instead of only the first one

### DIFF
--- a/public/Time-Capsule/index.html
+++ b/public/Time-Capsule/index.html
@@ -54,7 +54,7 @@
       
       <div id="messageReveal" class="hidden" aria-live="assertive">
         <h2>📩 Message from the Past</h2>
-        <p id="revealedMessage" style="color: red;"></p>
+        <div id="revealedMessage"></div>
       </div>
     </div>
     <script src="script.js"></script>

--- a/public/Time-Capsule/script.js
+++ b/public/Time-Capsule/script.js
@@ -1,138 +1,138 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const form = document.getElementById('capsuleForm');
-    const messageInput = document.getElementById('message');
-    const hrsEl = document.getElementById('hrs');
-    const minsEl = document.getElementById('mins');
-    const secsEl = document.getElementById('secs');
-    const preview = document.getElementById('preview');
-    const errEl = document.getElementById('err');
-    const capsuleReveal = document.getElementById('capsuleReveal');
-    const messageReveal = document.getElementById('messageReveal');
-    const revealTime = document.getElementById('revealTime');
-    const revealedMessage = document.getElementById('revealedMessage');
+  const form = document.getElementById('capsuleForm');
+  const messageInput = document.getElementById('message');
+  const hrsEl = document.getElementById('hrs');
+  const minsEl = document.getElementById('mins');
+  const secsEl = document.getElementById('secs');
+  const preview = document.getElementById('preview');
+  const errEl = document.getElementById('err');
+  const capsuleReveal = document.getElementById('capsuleReveal');
+  const messageReveal = document.getElementById('messageReveal');
+  const revealTime = document.getElementById('revealTime');
+  const revealedMessage = document.getElementById('revealedMessage');
 
-    // Safely get capsules from localStorage
-    function getCapsules() {
-        try {
-            return JSON.parse(localStorage.getItem('capsules')) || [];
-        } catch (error) {
-            console.error('Error reading capsules from localStorage:', error);
-            return [];
-        }
+  // Safely get capsules from localStorage
+  function getCapsules() {
+    try {
+      return JSON.parse(localStorage.getItem('capsules')) || [];
+    } catch (error) {
+      console.error('Error reading capsules from localStorage:', error);
+      return [];
     }
+  }
 
-    // Safely save capsules
-    function saveCapsules(capsules) {
-        localStorage.setItem('capsules', JSON.stringify(capsules));
-    }
+  // Safely save capsules
+  function saveCapsules(capsules) {
+    localStorage.setItem('capsules', JSON.stringify(capsules));
+  }
 
-    function totalMs() {
-        const h = Math.max(0, parseInt(hrsEl.value) || 0);
-        const m = Math.min(Math.max(0, parseInt(minsEl.value) || 0), 59);
-        const s = Math.min(Math.max(0, parseInt(secsEl.value) || 0), 59);
+  function totalMs() {
+    const h = Math.max(0, parseInt(hrsEl.value) || 0);
+    const m = Math.min(Math.max(0, parseInt(minsEl.value) || 0), 59);
+    const s = Math.min(Math.max(0, parseInt(secsEl.value) || 0), 59);
 
-        return (h * 3600 + m * 60 + s) * 1000;
-    }
+    return (h * 3600 + m * 60 + s) * 1000;
+  }
 
-    function humanDuration(ms) {
-        const totalSecs = Math.floor(ms / 1000);
+  function humanDuration(ms) {
+    const totalSecs = Math.floor(ms / 1000);
 
-        const h = Math.floor(totalSecs / 3600);
-        const m = Math.floor((totalSecs % 3600) / 60);
-        const s = totalSecs % 60;
+    const h = Math.floor(totalSecs / 3600);
+    const m = Math.floor((totalSecs % 3600) / 60);
+    const s = totalSecs % 60;
 
-        const parts = [];
+    const parts = [];
 
-        if (h) parts.push(`${h} ${h === 1 ? 'hour' : 'hours'}`);
-        if (m) parts.push(`${m} ${m === 1 ? 'minute' : 'minutes'}`);
-        if (s) parts.push(`${s} ${s === 1 ? 'second' : 'seconds'}`);
+    if (h) parts.push(`${h} ${h === 1 ? 'hour' : 'hours'}`);
+    if (m) parts.push(`${m} ${m === 1 ? 'minute' : 'minutes'}`);
+    if (s) parts.push(`${s} ${s === 1 ? 'second' : 'seconds'}`);
 
-        return parts.length
-            ? `Reveals in ${parts.join(', ')}`
-            : 'Enter a duration above';
-    }
+    return parts.length
+      ? `Reveals in ${parts.join(', ')}`
+      : 'Enter a duration above';
+  }
 
-    [hrsEl, minsEl, secsEl].forEach(el => {
-        el.addEventListener('input', () => {
-            preview.textContent = humanDuration(totalMs());
-        });
+  [hrsEl, minsEl, secsEl].forEach((el) => {
+    el.addEventListener('input', () => {
+      preview.textContent = humanDuration(totalMs());
     });
+  });
 
-    function checkCapsules() {
-        const capsules = getCapsules();
-        const now = Date.now();
+  function checkCapsules() {
+    const capsules = getCapsules();
+    const now = Date.now();
 
-        const dueCapsules = capsules.filter(
-            capsule => now >= capsule.revealAt
-        );
+    const dueCapsules = capsules.filter((capsule) => now >= capsule.revealAt);
 
-        const pendingCapsules = capsules.filter(
-            capsule => now < capsule.revealAt
-        );
+    const pendingCapsules = capsules.filter(
+      (capsule) => now < capsule.revealAt
+    );
 
-        if (dueCapsules.length > 0) {
-            const capsule = dueCapsules[0];
+    if (dueCapsules.length > 0) {
+      revealedMessage.innerHTML = dueCapsules
+        .map(
+          (capsule, index) =>
+            `<strong>Message ${index + 1}:</strong><br>${capsule.message}`
+        )
+        .join('<hr>');
 
-            revealedMessage.textContent = capsule.message;
+      messageReveal.classList.remove('hidden');
+      capsuleReveal.classList.add('hidden');
 
-            messageReveal.classList.remove('hidden');
-            capsuleReveal.classList.add('hidden');
+      saveCapsules(pendingCapsules);
+    }
+  }
 
-            saveCapsules(pendingCapsules);
-        }
+  // Run immediately on page load
+  checkCapsules();
+
+  // Then check every second
+  setInterval(checkCapsules, 1000);
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+
+    errEl.textContent = '';
+
+    const message = messageInput.value.trim();
+
+    if (!message) {
+      errEl.textContent = 'Please write a message first.';
+      return;
     }
 
-    // Run immediately on page load
-    checkCapsules();
+    const timer = totalMs();
 
-    // Then check every second
-    setInterval(checkCapsules, 1000);
+    if (timer < 5000) {
+      errEl.textContent = 'Set at least 5 seconds.';
+      return;
+    }
 
-    form.addEventListener('submit', (e) => {
-        e.preventDefault();
+    const revealAt = Date.now() + timer;
 
-        errEl.textContent = '';
+    const newCapsule = {
+      message,
+      revealAt,
+    };
 
-        const message = messageInput.value.trim();
+    const capsules = getCapsules();
+    capsules.push(newCapsule);
 
-        if (!message) {
-            errEl.textContent = 'Please write a message first.';
-            return;
-        }
+    saveCapsules(capsules);
 
-        const timer = totalMs();
+    // Hide previous revealed message if visible
+    messageReveal.classList.add('hidden');
+    capsuleReveal.classList.remove('hidden');
 
-        if (timer < 5000) {
-            errEl.textContent = 'Set at least 5 seconds.';
-            return;
-        }
+    revealTime.textContent = `Your message will be revealed at: ${new Date(revealAt).toLocaleTimeString()}`;
 
-        const revealAt = Date.now() + timer;
+    // Reset form
+    messageInput.value = '';
 
-        const newCapsule = {
-            message,
-            revealAt
-        };
+    hrsEl.value = '0';
+    minsEl.value = '0';
+    secsEl.value = '30';
 
-        const capsules = getCapsules();
-        capsules.push(newCapsule);
-
-        saveCapsules(capsules);
-
-        // Hide previous revealed message if visible
-        messageReveal.classList.add('hidden');
-        capsuleReveal.classList.remove('hidden');
-
-        revealTime.textContent =
-            `Your message will be revealed at: ${new Date(revealAt).toLocaleTimeString()}`;
-
-        // Reset form
-        messageInput.value = '';
-
-        hrsEl.value = '0';
-        minsEl.value = '0';
-        secsEl.value = '30';
-
-        preview.textContent = 'Reveals in 30 seconds';
-    });
+    preview.textContent = 'Reveals in 30 seconds';
+  });
 });

--- a/public/Time-Capsule/script.js
+++ b/public/Time-Capsule/script.js
@@ -69,12 +69,28 @@ document.addEventListener('DOMContentLoaded', () => {
     );
 
     if (dueCapsules.length > 0) {
-      revealedMessage.innerHTML = dueCapsules
-        .map(
-          (capsule, index) =>
-            `<strong>Message ${index + 1}:</strong><br>${capsule.message}`
-        )
-        .join('<hr>');
+      revealedMessage.innerHTML = '';
+
+      dueCapsules.forEach((capsule, index) => {
+        const wrapper = document.createElement('div');
+
+        const title = document.createElement('strong');
+        title.textContent = `Message ${index + 1}:`;
+
+        const lineBreak = document.createElement('br');
+
+        const messageText = document.createTextNode(capsule.message);
+
+        wrapper.appendChild(title);
+        wrapper.appendChild(lineBreak);
+        wrapper.appendChild(messageText);
+
+        revealedMessage.appendChild(wrapper);
+
+        if (index < dueCapsules.length - 1) {
+          revealedMessage.appendChild(document.createElement('hr'));
+        }
+      });
 
       messageReveal.classList.remove('hidden');
       capsuleReveal.classList.add('hidden');

--- a/public/Time-Capsule/style.css
+++ b/public/Time-Capsule/style.css
@@ -133,3 +133,20 @@ p {
   margin-top: 4px;
   min-height: 16px;
 }
+
+#revealedMessage {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-top: 15px;
+}
+
+#revealedMessage hr {
+  border: none;
+  height: 1px;
+  background: rgba(0,0,0,0.15);
+}
+
+#revealedMessage strong {
+  color: #5e60ce;
+}


### PR DESCRIPTION
# Description

This PR fixes an issue in the **Time Capsule** project where only the first expired capsule was revealed when multiple capsules expired before the user revisited the application.

## Previous Behavior

When multiple capsules became due:

- Only the first expired capsule was displayed.
- Remaining expired capsules were silently removed from localStorage.
- Users permanently lost unrevealed messages.

## Changes Made

- Updated the capsule checking logic to process **all expired capsules**.
- Display all due messages instead of only the first one.
- Preserve pending capsules correctly.
- Remove capsules from storage only after they have been revealed.
- Improved handling of multiple expired capsules in a single session.

## Result

- All expired messages are shown to the user.
- No expired capsules are lost.
- Users can view every message whose reveal time has passed.
- Storage remains synchronized with displayed capsules.

## Testing

- [x] Single expired capsule reveals correctly
- [x] Multiple expired capsules reveal correctly
- [x] No messages are lost when several capsules expire together
- [x] Pending capsules remain stored
- [x] localStorage updates correctly after reveal

## Related Issue

Closes #6039