### PR TITLE
fix: pause Snake Game on tab switch using Page Visibility API

### DIFF
--- a/public/snake_game/script.js
+++ b/public/snake_game/script.js
@@ -11,7 +11,6 @@ const eatSound = document.getElementById('eatSound');
 const gameOverSound = document.getElementById('gameOverSound');
 
 let snake, dir, nextDir, food, score, level, speed, running, paused;
-let lastTickTime = 0; // For smooth modern frame accumulation tracking
 
 let highScore = 0;
 let isGameOver = false;
@@ -21,6 +20,27 @@ let finalScore = 0;
 let rafId        = null;   // requestAnimationFrame handle (main loop)
 let lastTickTime = 0;      // timestamp of last logic tick
 let accumulator  = 0;      // ms accumulated since last tick
+// ──────────────────────────────────────────────────────────────────────────
+
+// ─── Page Visibility API — pause/resume on tab switch ─────────────────────
+document.addEventListener('visibilitychange', () => {
+  if (document.hidden) {
+    // Tab went to background: pause the game silently
+    if (running && !paused) {
+      paused = true;
+      paused_by_visibility = true; // remember we auto-paused
+    }
+  } else {
+    // Tab came back: resume only if WE auto-paused it
+    if (paused_by_visibility) {
+      paused = false;
+      paused_by_visibility = false;
+      lastTickTime = performance.now(); // reset tick time so no catch-up
+      accumulator  = 0;
+    }
+  }
+});
+let paused_by_visibility = false; // tracks auto-pause vs user-pause
 // ──────────────────────────────────────────────────────────────────────────
 
 // ─── Web Audio sound engine ────────────────────────────────────────────────
@@ -249,7 +269,12 @@ function gameEngine(timestamp) {
 
   if (running && !paused) {
     const elapsed = timestamp - lastTickTime;
-    if (elapsed >= speed) {
+
+    // Guard: if the tab was hidden and visibility API didn't fire (edge case),
+    // a huge elapsed value would cause multiple rapid ticks. Cap it to one tick worth.
+    if (elapsed > speed * 3) {
+      lastTickTime = timestamp;
+    } else if (elapsed >= speed) {
       tick();
       lastTickTime = timestamp;
     }


### PR DESCRIPTION
## 📋 Pull Request Description

### Related Issue
Closes #6148

### Summary
The Snake Game (Day 29) continued running in the background when the browser tab was switched or minimized. Upon returning, the snake's position had advanced uncontrollably, causing instant and unfair collisions. This fix implements the Page Visibility API to automatically pause the game when the tab is hidden and resume it cleanly when the tab is focused again. A fallback guard in the game engine also prevents catch-up ticks in browsers where the visibility event may not fire reliably.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📄 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠 Changes Made
- Removed duplicate `let lastTickTime = 0` declaration that existed twice in the original file (would cause issues in strict mode)
- Added `document.addEventListener('visibilitychange', ...)` using the Page Visibility API to detect when the tab is hidden or restored
- Introduced `paused_by_visibility` boolean flag to distinguish between a user-triggered pause (Spacebar) and an auto-pause caused by a tab switch — so both can work independently without conflict
- On tab return: `lastTickTime` and `accumulator` are reset to `performance.now()` so no backlogged ticks fire and the snake resumes exactly where it left off
- Added a fallback guard inside `gameEngine`: if `elapsed > speed * 3`, the tick is skipped and the timer resets — this prevents multi-tick catch-up in browsers that do not reliably fire `visibilitychange`

---

## 🧪 Testing and Verification
- [x] Manually tested: start game → switch tab → wait 5 seconds → return → snake pauses and resumes correctly with no position jump
- [x] Manually tested: Spacebar pause still works independently and is not affected by the visibility auto-pause
- [x] Manually tested: game over, restart, and normal gameplay unaffected
- [x] Tested in Chrome and Edge (Chromium-based)
- [x] Only `public/snake_game/script.js` was modified — no changes to `index.html` or `style.css`