### PR TITLE
Security: Remove hardcoded JWT fallback 'secretkey' in loginusingmern (#6215)

### DIFF
--- a/public/loginusingmern/index.js
+++ b/public/loginusingmern/index.js
@@ -27,7 +27,7 @@ app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
 
 app.use(session({
-  secret: process.env.JWT_SECRET || 'secretkey',
+  secret: process.env.JWT_SECRET,
   resave: false,
   saveUninitialized: false,
 }));
@@ -96,7 +96,7 @@ app.get('/auth/google/callback',
   (req, res) => {
     const token = jwt.sign(
       { id: req.user._id, username: req.user.username },
-      process.env.JWT_SECRET || 'secretkey',
+      process.env.JWT_SECRET,
       { expiresIn: '1d' }
     );
 
@@ -160,7 +160,7 @@ app.post('/login', async (req, res) => {
 
     const token = jwt.sign(
       { id: user._id, username: user.username },
-      process.env.JWT_SECRET || 'secretkey',
+      process.env.JWT_SECRET,
       { expiresIn: '1d' }
     );
 
@@ -177,6 +177,12 @@ app.post('/login', async (req, res) => {
     return res.status(500).send('Server error');
   }
 });
+
+// ─── Env guard ─────────────────────────────────────────────────
+if (!process.env.JWT_SECRET) {
+  console.error('\x1b[31m[FATAL] JWT_SECRET environment variable is required.\x1b[0m');
+  process.exit(1);
+}
 
 // ─── Start ─────────────────────────────────────────────────────
 app.listen(port, () => {

--- a/public/loginusingmern/middleware/auth.js
+++ b/public/loginusingmern/middleware/auth.js
@@ -6,7 +6,7 @@ const authMiddleware = (req, res, next) => {
 
     if (!token) return res.redirect('/');
 
-    const verified = jwt.verify(token, process.env.JWT_SECRET || 'secretkey');
+    const verified = jwt.verify(token, process.env.JWT_SECRET);
     req.user = verified;
 
     next();


### PR DESCRIPTION
## Summary
Fixes #6215

### Changes
- **public/loginusingmern/index.js**: Removed all \|| 'secretkey'\ fallbacks from \jwt.sign()\ and session secret calls. Added a startup guard that exits with \[FATAL]\ if \JWT_SECRET\ is unset.
- **public/loginusingmern/middleware/auth.js**: Removed \|| 'secretkey'\ fallback from \jwt.verify()\.

### Impact
Without this fix: an attacker who knows the public fallback \secretkey\ can forge valid JWTs and bypass authentication entirely.