### PR TITLE
Security: Restrict socket.io CORS from wildcard to allow-list (#6213)

### DIFF
--- a/public/AI ChatBot/server.js
+++ b/public/AI ChatBot/server.js
@@ -7,11 +7,15 @@ const path = require('path');
 const app = express();
 const server = http.createServer(app);
 
-// Initialize Socket.io and allow connections from your frontend development server
+const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS || 'http://localhost:5000,http://localhost:3000')
+  .split(',')
+  .map(s => s.trim());
+
 const io = new Server(server, {
   cors: {
-    origin: "*", // Adjust this in production to match your frontend URL
-    methods: ["GET", "POST"]
+    origin: ALLOWED_ORIGINS,
+    methods: ["GET", "POST"],
+    credentials: true
   }
 });
 


### PR DESCRIPTION
﻿## Summary
Fixes #6213

### Changes
- **public/AI ChatBot/server.js**: Replaced origin: "*" with an allow-list parsed from ALLOWED_ORIGINS env var (defaults to localhost:5000,localhost:3000).

### Impact
Without this fix: any website can open WebSocket connections to the chat server, enabling cross-site WebSocket hijacking (CSWSH) and sensitive data leakage.
