### PR TITLE
Security: Add rate limiting on authentication endpoints to prevent brute-force (#6217)

### DIFF
--- a/public/Voting_Application_Backend/server/package.json
+++ b/public/Voting_Application_Backend/server/package.json
@@ -21,6 +21,7 @@
     "mongoose": "^8.6.3",
     "nodemon": "^3.1.7",
     "passport": "^0.7.0",
-    "passport-local": "^1.0.0"
+    "passport-local": "^1.0.0",
+    "express-rate-limit": "^7.4.0"
   }
 }

--- a/public/Voting_Application_Backend/server/routes/userRoutes.js
+++ b/public/Voting_Application_Backend/server/routes/userRoutes.js
@@ -1,11 +1,20 @@
 const express = require('express');
 const router = express.Router();
+const rateLimit = require('express-rate-limit');
 
 const User = require('./../models/user');
 const {jwtAuthMiddleware, generateToken} = require('./../jwt');
 
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  message: { error: 'Too many attempts. Try again in 15 minutes.' },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 //POST route to add a person
-router.post('/signup', async(req, res)=>{
+router.post('/signup', authLimiter, async(req, res)=>{
     try{
         const data = req.body
         const adminUser = await User.findOne({ role: 'admin' });
@@ -50,7 +59,7 @@ router.post('/signup', async(req, res)=>{
 })
 
 //login Route
-router.post('/login', async(req, res)=> {
+router.post('/login', authLimiter, async(req, res)=> {
     try {
         //extract username and password from the request body
         const{aadharCardNumber, password} = req.body;

--- a/public/loginusingmern/index.js
+++ b/public/loginusingmern/index.js
@@ -11,8 +11,17 @@ const session = require('express-session');
 const passport = require('passport');
 const GoogleStrategy = require('passport-google-oauth20').Strategy;
 
+const rateLimit = require('express-rate-limit');
 const collection = require('./mongo.js');
 const authMiddleware = require('./middleware/auth');
+
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  message: { error: 'Too many attempts. Try again in 15 minutes.' },
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 const port = process.env.PORT || 3000;
 
@@ -112,7 +121,7 @@ app.get('/auth/google/callback',
 );
 
 // ─── POST /signup ──────────────────────────────────────────────
-app.post('/signup', async (req, res) => {
+app.post('/signup', authLimiter, async (req, res) => {
   try {
     const { username, email, password } = req.body;
 
@@ -140,7 +149,7 @@ app.post('/signup', async (req, res) => {
 });
 
 // ─── POST /login ───────────────────────────────────────────────
-app.post('/login', async (req, res) => {
+app.post('/login', authLimiter, async (req, res) => {
   try {
     const { username, password } = req.body;
 

--- a/public/loginusingmern/package.json
+++ b/public/loginusingmern/package.json
@@ -22,6 +22,7 @@
     "nodemon": "^3.1.14",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",
-    "validator": "^13.15.35"
+    "validator": "^13.15.35",
+    "express-rate-limit": "^7.4.0"
   }
 }


### PR DESCRIPTION
﻿## Summary
Fixes #6217

### Changes
- **public/loginusingmern/index.js**: Added express-rate-limit (10 req / 15 min) on POST /login and POST /signup
- **public/loginusingmern/package.json**: Added express-rate-limit dependency
- **public/Voting_Application_Backend/server/routes/userRoutes.js**: Added same rate limiter on login and signup routes
- **public/Voting_Application_Backend/server/package.json**: Added express-rate-limit dependency

### Impact
Without this fix: attackers can brute-force passwords and Aadhar numbers without throttling across three backends.
