### PR TITLE
Security: Add HTML escaping to prevent XSS in nodemailer email template (#6218)

### DIFF
--- a/public/gmail_nodemailer/app.js
+++ b/public/gmail_nodemailer/app.js
@@ -7,6 +7,15 @@ const bodyParser = require('body-parser');
 const path = require('path');
 const nodemailer = require('nodemailer');
 
+function escapeHtml(text) {
+  return String(text || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}
+
 const port = 5500;
 
 app.use(bodyParser.urlencoded({ extended: true }));
@@ -62,7 +71,7 @@ app.post('/', function (req, res) {
             <tr>
               <td style="padding:35px 30px;color:#333333;">
                 <h2 style="margin-top:0;">
-                  Hi ${req.body.name},
+                  Hi ${escapeHtml(req.body.name)},
                 </h2>
 
                 <p style="font-size:16px;line-height:1.7;">


### PR DESCRIPTION
﻿## Summary
Fixes #6218

### Changes
- **public/gmail_nodemailer/app.js**: Added escapeHtml() helper function that escapes &, <, >, ", and '. Applied it to eq.body.name in the HTML email template.

### Impact
Without this fix: a user can set their name to <img src=x onerror=alert(1)>, injecting arbitrary HTML/JS into emails rendered by recipients (stored XSS).
