### PR TITLE
Security: Add maxCount on file upload to prevent disk exhaustion DoS (#6214)

### DIFF
--- a/public/file_uploader/index.js
+++ b/public/file_uploader/index.js
@@ -54,7 +54,9 @@ app.get('/file', (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'file_uploader.html'));
 });
 
-app.post("/upload", upload.array("myFile"), (req, res) => {
+const MAX_FILES = 10;
+
+app.post("/upload", upload.array("myFile", MAX_FILES), (req, res) => {
     console.log("Body: ", req.body);
     console.log("Files: ", req.files);
 


### PR DESCRIPTION
﻿## Summary
Fixes #6214

### Changes
- **public/file_uploader/index.js**: Added MAX_FILES = 10 constant and maxCount: 10 to upload.array() call.

### Impact
Without this fix: an attacker can send thousands of 2MB files in a single request, exhausting disk space and causing denial of service.
