### PR TITLE
DevOps: Add npm caching to CI lint-format-check workflow (#6220)

### DIFF
--- a/.github/workflows/lint-format-check.yml
+++ b/.github/workflows/lint-format-check.yml
@@ -20,13 +20,14 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+          cache: 'npm'
 
       - name: Install Dependencies
         run: |
           if [ -f package-lock.json ]; then
-            npm ci
+            npm ci --prefer-offline
           else
-            npm install
+            npm install --prefer-offline
           fi
 
       - name: Collect changed lint targets


### PR DESCRIPTION
﻿## Summary
Fixes #6220

### Changes
- **.github/workflows/lint-format-check.yml**: Added cache: 'npm' to setup-node step and --prefer-offline flag to npm install/ci commands.

### Impact
Without this fix: every CI run downloads all dependencies from scratch (30-60s), even when package-lock.json hasn't changed — wasted bandwidth and slower feedback.
