### PR TITLE
fix(event-registration-system): remove hardcoded admin credentials and JWT secret fallback

### DIFF
--- a/public/event-registration-system/.env.example
+++ b/public/event-registration-system/.env.example
@@ -1,0 +1,9 @@
+# Secret used to sign JWT auth tokens. Use a long random string. Required.
+SESSION_SECRET=
+
+# PostgreSQL connection string. Required in production.
+DATABASE_URL=
+
+# Initial admin account, seeded on first boot only if both are set.
+ADMIN_EMAIL=
+ADMIN_PASSWORD=

--- a/public/event-registration-system/README.md
+++ b/public/event-registration-system/README.md
@@ -295,6 +295,8 @@ Create a `.env` file in the project root:
 ```env
 DATABASE_URL=postgresql://user:password@localhost:5432/zenith
 SESSION_SECRET=your_super_secret_jwt_key
+ADMIN_EMAIL=admin@example.com
+ADMIN_PASSWORD=choose_a_strong_password
 ```
 
 ### Push the database schema
@@ -303,7 +305,7 @@ SESSION_SECRET=your_super_secret_jwt_key
 npm run db:push
 ```
 
-This creates the `users` and `registrations` tables. The admin seed user (`adminzen@event.com` / `admin123zen`) is created automatically when the server first starts.
+This creates the `users` and `registrations` tables. The admin user is created automatically on first boot from the `ADMIN_EMAIL` and `ADMIN_PASSWORD` environment variables. If either variable is not set, admin seeding is skipped.
 
 ### Start the development server
 
@@ -315,12 +317,12 @@ This starts both the Express backend (port 5000) and the Vite frontend dev serve
 
 ### Seed admin credentials
 
-The admin user is seeded automatically on startup if it does not already exist:
+The admin user is seeded automatically on startup from environment variables if it does not already exist. Set `ADMIN_EMAIL` and `ADMIN_PASSWORD` before the first boot to choose the credentials. If either is missing, admin seeding is skipped.
 
-| Field | Value |
-|-------|-------|
-| Email | `adminzen@event.com` |
-| Password | `admin123zen` |
+| Variable | Description |
+|----------|-------------|
+| `ADMIN_EMAIL` | Email for the initial admin login |
+| `ADMIN_PASSWORD` | Password for the initial admin login |
 
 ---
 
@@ -346,6 +348,8 @@ The Express server serves the compiled React app as static files and handles all
 |----------|-------------|
 | `DATABASE_URL` | PostgreSQL connection string |
 | `SESSION_SECRET` | Secret key for JWT signing (use a long random string) |
+| `ADMIN_EMAIL` | Email for the initial admin login |
+| `ADMIN_PASSWORD` | Password for the initial admin login |
 | `NODE_ENV` | Set to `production` |
 
 ---
@@ -493,7 +497,7 @@ Import the JSON into Postman and use the token returned from `POST /api/admin/lo
             },
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"email\": \"adminzen@event.com\",\n  \"password\": \"admin123zen\"\n}",
+              "raw": "{\n  \"email\": \"admin@example.com\",\n  \"password\": \"your_admin_password\"\n}",
               "options": {
                 "raw": {
                   "language": "json"

--- a/public/event-registration-system/server/routes.ts
+++ b/public/event-registration-system/server/routes.ts
@@ -6,7 +6,11 @@ import { z } from "zod";
 import jwt from "jsonwebtoken";
 import { scryptSync, randomBytes, timingSafeEqual } from "crypto";
 
-const JWT_SECRET = process.env.SESSION_SECRET || 'fallback_secret_for_dev_only';
+const SESSION_SECRET = process.env.SESSION_SECRET;
+if (!SESSION_SECRET) {
+  throw new Error("SESSION_SECRET environment variable is required to sign authentication tokens");
+}
+const JWT_SECRET: string = SESSION_SECRET;
 
 // Password hashing helpers
 function hashPassword(password: string) {
@@ -42,14 +46,20 @@ export async function registerRoutes(
 ): Promise<Server> {
   // Seed admin user if it doesn't exist
   async function seedAdmin() {
+    const email = process.env.ADMIN_EMAIL;
+    const password = process.env.ADMIN_PASSWORD;
+    if (!email || !password) {
+      console.log('Admin seed skipped: set ADMIN_EMAIL and ADMIN_PASSWORD to create the initial admin user');
+      return;
+    }
     try {
-      const adminExists = await storage.getUserByEmail('adminzen@event.com');
+      const adminExists = await storage.getUserByEmail(email);
       if (!adminExists) {
         await storage.createUser({
-          email: 'adminzen@event.com',
-          password: hashPassword('admin123zen')
+          email,
+          password: hashPassword(password)
         });
-        console.log('Seed admin user created: adminzen@event.com / admin123zen');
+        console.log(`Seed admin user created for ${email}`);
       }
     } catch (err) {
       console.error('Failed to seed admin:', err);


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #6235

### Summary
The Event Registration System sub-project hardcoded its JWT signing secret and its admin credentials, all committed to the public repo and printed to logs. This PR moves all of them to environment variables. Note for existing deployments: `SESSION_SECRET` is now required at startup, and the initial admin is created from `ADMIN_EMAIL` and `ADMIN_PASSWORD`, so those values must be set in the environment.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [x] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `server/routes.ts`: require `SESSION_SECRET` and fail fast at startup if it is missing; removed the hardcoded `'fallback_secret_for_dev_only'` fallback used to sign and verify JWTs.
- `server/routes.ts`: seed the admin user from `ADMIN_EMAIL` and `ADMIN_PASSWORD` only when both are set; removed the hardcoded `adminzen@event.com` / `admin123zen` account and stopped logging credentials.
- `README.md`: removed the published default credentials and documented the new environment variables in the dev env block, the seed section, the production env table, and the Postman example.
- Added `.env.example` documenting `SESSION_SECRET`, `DATABASE_URL`, `ADMIN_EMAIL`, and `ADMIN_PASSWORD`.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: this validator currently fails on `main` independently of this PR because it reads a missing `schema/projects.schema.json` (see #6094 / #5948). This PR does not touch `projects.json`.

What I did verify:
- Confirmed no hardcoded credentials or secret fallback remain anywhere in the sub-project.
- Confirmed `server/routes.ts` transpiles cleanly with esbuild.
- A full `npm run check` (tsc) and runtime boot require installing this sub-project's dependencies and setting the env vars.

### Browser Compatibility Check
- N/A: this is a server-side change with no browser-facing markup.

### Responsive & Accessibility Checks
- N/A: no UI changes.

---

## 📷 Screenshots / Video Recording
N/A. No visual changes.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
