### PR TITLE
Restrict Gmail Nodemailer email requests

### DIFF
--- a/public/gmail_nodemailer/README.md
+++ b/public/gmail_nodemailer/README.md
@@ -118,6 +118,12 @@ PORT=5500
 
 EMAIL_USER=yourgmail@gmail.com
 EMAIL_PASS=your_gmail_app_password
+
+# Optional request controls
+REQUEST_BODY_LIMIT=8kb
+SUBSCRIBER_NAME_MAX_LENGTH=100
+MAIL_RATE_LIMIT_WINDOW_MS=60000
+MAIL_RATE_LIMIT_MAX_REQUESTS=5
 ```
 
 ---

--- a/public/gmail_nodemailer/app.js
+++ b/public/gmail_nodemailer/app.js
@@ -7,10 +7,86 @@ const bodyParser = require('body-parser');
 const path = require('path');
 const nodemailer = require('nodemailer');
 
-const port = 5500;
+const port = process.env.PORT || 5500;
+const REQUEST_BODY_LIMIT = process.env.REQUEST_BODY_LIMIT || '8kb';
+const requestBuckets = new Map();
 
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(express.json());
+function readPositiveInteger(name, fallback) {
+  const parsed = Number.parseInt(process.env[name] || '', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+const MAX_NAME_LENGTH = readPositiveInteger('SUBSCRIBER_NAME_MAX_LENGTH', 100);
+const RATE_LIMIT_WINDOW_MS = readPositiveInteger('MAIL_RATE_LIMIT_WINDOW_MS', 60000);
+const RATE_LIMIT_MAX_REQUESTS = readPositiveInteger('MAIL_RATE_LIMIT_MAX_REQUESTS', 5);
+
+function rateLimitMailRequests(req, res, next) {
+  const now = Date.now();
+  const clientId = req.ip || req.socket.remoteAddress || 'unknown';
+
+  for (const [bucketClientId, bucket] of requestBuckets) {
+    if (now > bucket.resetAt) {
+      requestBuckets.delete(bucketClientId);
+    }
+  }
+
+  const bucket = requestBuckets.get(clientId);
+
+  if (!bucket || now > bucket.resetAt) {
+    requestBuckets.set(clientId, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return next();
+  }
+
+  if (bucket.count >= RATE_LIMIT_MAX_REQUESTS) {
+    const retryAfterSeconds = Math.ceil((bucket.resetAt - now) / 1000);
+    res.set('Retry-After', String(retryAfterSeconds));
+    return res.status(429).send('Too many email requests. Please try again later.');
+  }
+
+  bucket.count += 1;
+  return next();
+}
+
+function validateSubscriber(body) {
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  const email = typeof body.emailid === 'string' ? body.emailid.trim() : '';
+  const localPart = email.split('@')[0];
+  const emailPattern =
+    /^[A-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?(?:\.[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?)+$/i;
+
+  if (!name || name.length > MAX_NAME_LENGTH || /[\u0000-\u001F\u007F]/.test(name)) {
+    return { error: `Name must be between 1 and ${MAX_NAME_LENGTH} characters.` };
+  }
+
+  if (
+    !email ||
+    email.length > 254 ||
+    localPart.length > 64 ||
+    localPart.startsWith('.') ||
+    localPart.endsWith('.') ||
+    localPart.includes('..') ||
+    !emailPattern.test(email)
+  ) {
+    return { error: 'Enter one valid email address.' };
+  }
+
+  return { name, email };
+}
+
+function escapeHtml(value) {
+  const htmlEntities = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;',
+  };
+
+  return value.replace(/[&<>"']/g, (character) => htmlEntities[character]);
+}
+
+app.use(bodyParser.urlencoded({ extended: false, limit: REQUEST_BODY_LIMIT }));
+app.use(express.json({ limit: REQUEST_BODY_LIMIT }));
 
 app.use(express.static(path.join(__dirname, 'public')));
 
@@ -18,7 +94,14 @@ app.get('/', function (req, res) {
   res.sendFile(path.join(__dirname, 'public', 'mail.html'));
 });
 
-app.post('/', function (req, res) {
+app.post('/', rateLimitMailRequests, function (req, res) {
+  const subscriber = validateSubscriber(req.body || {});
+
+  if (subscriber.error) {
+    return res.status(400).send(subscriber.error);
+  }
+
+  const safeName = escapeHtml(subscriber.name);
   const transporter = nodemailer.createTransport({
     service: 'Gmail',
     host: 'smtp.gmail.com',
@@ -33,7 +116,7 @@ app.post('/', function (req, res) {
 
   const mailOptions = {
     from: process.env.EMAIL_USER,
-    to: req.body.emailid,
+    to: subscriber.email,
     subject: 'Welcome to Our Newsletter 🎉',
 
     html: `
@@ -62,7 +145,7 @@ app.post('/', function (req, res) {
             <tr>
               <td style="padding:35px 30px;color:#333333;">
                 <h2 style="margin-top:0;">
-                  Hi ${req.body.name},
+                  Hi ${safeName},
                 </h2>
 
                 <p style="font-size:16px;line-height:1.7;">
@@ -116,6 +199,30 @@ app.post('/', function (req, res) {
   });
 });
 
-app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`);
-});
+function handleRequestErrors(error, req, res, next) {
+  if (error.type === 'entity.too.large') {
+    return res.status(413).send('Request body is too large.');
+  }
+
+  if (error instanceof SyntaxError && 'body' in error) {
+    return res.status(400).send('Invalid JSON request body.');
+  }
+
+  return next(error);
+}
+
+app.use(handleRequestErrors);
+
+if (require.main === module) {
+  app.listen(port, () => {
+    console.log(`Example app listening on port ${port}`);
+  });
+}
+
+module.exports = {
+  app,
+  escapeHtml,
+  handleRequestErrors,
+  rateLimitMailRequests,
+  validateSubscriber,
+};

--- a/public/gmail_nodemailer/app.test.js
+++ b/public/gmail_nodemailer/app.test.js
@@ -1,0 +1,96 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+
+process.env.MAIL_RATE_LIMIT_MAX_REQUESTS = '2';
+process.env.MAIL_RATE_LIMIT_WINDOW_MS = '60000';
+process.env.REQUEST_BODY_LIMIT = '1kb';
+
+const {
+  escapeHtml,
+  handleRequestErrors,
+  rateLimitMailRequests,
+  validateSubscriber,
+} = require('./app');
+
+function createResponse() {
+  return {
+    body: '',
+    headers: {},
+    statusCode: 200,
+    send(body) {
+      this.body = body;
+      return this;
+    },
+    set(name, value) {
+      this.headers[name] = value;
+      return this;
+    },
+    status(statusCode) {
+      this.statusCode = statusCode;
+      return this;
+    },
+  };
+}
+
+test('validates a single subscriber address and bounded name', () => {
+  assert.deepEqual(validateSubscriber({ name: ' Alex ', emailid: 'alex@example.com' }), {
+    name: 'Alex',
+    email: 'alex@example.com',
+  });
+  assert.equal(
+    validateSubscriber({ name: 'Alex', emailid: 'alex@example.com,other@example.com' }).error,
+    'Enter one valid email address.',
+  );
+  assert.equal(
+    validateSubscriber({ name: 'Alex', emailid: '.alex@example.com' }).error,
+    'Enter one valid email address.',
+  );
+  assert.match(validateSubscriber({ name: '\n', emailid: 'alex@example.com' }).error, /^Name must/);
+});
+
+test('escapes subscriber names before HTML rendering', () => {
+  assert.equal(
+    escapeHtml(`<img src="x">'&`),
+    '&lt;img src=&quot;x&quot;&gt;&#39;&amp;',
+  );
+});
+
+test('limits excessive mail requests by client address', () => {
+  const request = { ip: 'test-client' };
+  let nextCalls = 0;
+
+  rateLimitMailRequests(request, createResponse(), () => {
+    nextCalls += 1;
+  });
+  rateLimitMailRequests(request, createResponse(), () => {
+    nextCalls += 1;
+  });
+
+  const limitedResponse = createResponse();
+  rateLimitMailRequests(request, limitedResponse, () => {
+    nextCalls += 1;
+  });
+
+  assert.equal(nextCalls, 2);
+  assert.equal(limitedResponse.statusCode, 429);
+  assert.ok(limitedResponse.headers['Retry-After']);
+});
+
+test('returns clear parser error responses', () => {
+  const oversizedResponse = createResponse();
+  handleRequestErrors(
+    { type: 'entity.too.large' },
+    {},
+    oversizedResponse,
+    assert.fail,
+  );
+  assert.equal(oversizedResponse.statusCode, 413);
+  assert.equal(oversizedResponse.body, 'Request body is too large.');
+
+  const malformedResponse = createResponse();
+  const malformedError = new SyntaxError('Invalid JSON');
+  malformedError.body = '{broken';
+  handleRequestErrors(malformedError, {}, malformedResponse, assert.fail);
+  assert.equal(malformedResponse.statusCode, 400);
+  assert.equal(malformedResponse.body, 'Invalid JSON request body.');
+});

--- a/public/gmail_nodemailer/package.json
+++ b/public/gmail_nodemailer/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test app.test.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #6171

### Summary
This hardens the Gmail Nodemailer subscription endpoint so malformed input and repeated requests are rejected before Nodemailer can send an email. It also escapes the subscriber name before placing it in the HTML email template.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Security enhancement

---

## Changes Made
- Added configurable JSON and URL-encoded request body limits.
- Validates and normalizes the subscriber name and a single recipient email address before creating mail options.
- Escapes the displayed subscriber name before inserting it into the HTML email.
- Added a configurable per-client request limiter with Retry-After on 429 responses.
- Added clear 400 and 413 parser/validation responses.
- Added focused Node tests and documented the optional request-control environment variables.

---

## Testing and Verification

Local checks completed on macOS:
- [x] npm test in public/gmail_nodemailer (4 tests passed)
- [x] node --check public/gmail_nodemailer/app.js
- [x] node --check public/gmail_nodemailer/app.test.js
- [x] git diff --check

Environment note: root npm run lint is currently blocked because the package.json on upstream/Main is malformed near the serve and husky devDependency entries. This PR does not modify the root package.json.

---

## Screenshots / Video Recording
No UI change; this PR updates backend request handling and adds tests.

---

## Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors in the checked files.
- [x] There are no unrelated changes or formatter noise in this PR.

This PR is for GSSoC 2026. Please add the appropriate GSSoC and level labels during review if applicable.