### PR TITLE
[Feature]: Add "What to Watch" Random Movie Selector

### DIFF
--- a/public/movie-selector/app.js
+++ b/public/movie-selector/app.js
@@ -1,0 +1,91 @@
+// Access high-rated discover elements utilizing the public fallback tracking pipeline index mapping
+const MOVIE_DISCOVER_API =
+  "https://api.themoviedb.org/3/discover/movie?api_key=8f2467d3e6205844a4b1f4faaa387eb3&sort_by=vote_average.desc&vote_count.gte=500&include_adult=false";
+const IMAGE_RESOURCES_API = "https://image.tmdb.org/t/p/w400";
+
+const genreSelect = document.getElementById("genreSelect");
+const findMovieBtn = document.getElementById("findMovieBtn");
+
+const loadingState = document.getElementById("loadingState");
+const welcomeState = document.getElementById("welcomeState");
+const movieCard = document.getElementById("movieCard");
+
+const moviePoster = document.getElementById("moviePoster");
+const movieTitle = document.getElementById("movieTitle");
+const movieRating = document.getElementById("movieRating");
+const movieReleaseDate = document.getElementById("movieReleaseDate");
+const movieOverview = document.getElementById("movieOverview");
+
+// Asynchronous Selection Engine Orchestrator
+async function rollRandomMovieRecommendation(genreId) {
+  // Toggle active interface card states
+  welcomeState.classList.add("hidden");
+  movieCard.classList.add("hidden");
+  loadingState.classList.remove("hidden");
+
+  try {
+    // Query high-rated films inside the targeted genre matching criteria
+    const targetUrl = `${MOVIE_DISCOVER_API}&with_genres=${genreId}&page=${Math.floor(Math.random() * 3) + 1}`;
+    const response = await fetch(targetUrl);
+    const payload = await response.json();
+
+    if (!payload.results || payload.results.length === 0) {
+      throw new Error(
+        "Empty query array returned from fallback dataset mapping.",
+      );
+    }
+
+    // Pull a random index position parameter array element out from the response row arrays
+    const structuralIndexList = payload.results;
+    const randomElementIndex = Math.floor(
+      Math.random() * structuralIndexList.length,
+    );
+    const selectedMovie = structuralIndexList[randomElementIndex];
+
+    populateMovieCard(selectedMovie);
+  } catch (error) {
+    loadingState.classList.add("hidden");
+    welcomeState.classList.remove("hidden");
+    alert(
+      "Failed to access cinematic collection nodes. Please select another genre filter.",
+    );
+  }
+}
+
+// Map selected array data features safely straight into DOM element hooks
+function populateMovieCard(movie) {
+  loadingState.classList.add("hidden");
+  movieCard.classList.remove("hidden");
+
+  movieTitle.innerText = movie.title;
+  movieRating.innerText = `⭐ ${movie.vote_average.toFixed(1)}`;
+
+  // Parse parsing variables safely to capture the standard release calendar year string
+  const dateString = movie.release_date;
+  movieReleaseDate.innerText = dateString ? dateString.split("-")[0] : "N/A";
+
+  movieOverview.innerText =
+    movie.overview ||
+    "No synopsis description overview logs has been filed for this entry.";
+
+  // Fallback image handling if tracking assets maps return empty
+  if (movie.poster_path) {
+    moviePoster.src = `${IMAGE_RESOURCES_API}${movie.poster_path}`;
+    moviePoster.style.display = "block";
+  } else {
+    moviePoster.src =
+      "https://images.unsplash.com/photo-1594909122845-11baa439b7bf?q=80&w=400&auto=format&fit=crop";
+  }
+}
+
+// Attach operational click handler bindings
+findMovieBtn.addEventListener("click", () => {
+  const activeGenreValue = genreSelect.value;
+  if (!activeGenreValue) {
+    alert(
+      "Please make a genre selection selection first inside the console selection menu row.",
+    );
+    return;
+  }
+  rollRandomMovieRecommendation(activeGenreValue);
+});

--- a/public/movie-selector/index.html
+++ b/public/movie-selector/index.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>"What to Watch" Random Movie Selector</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app-container">
+      <header class="app-header">
+        <h1>"What to Watch"</h1>
+        <p>
+          Can't decide on a film? Pick your favorite genre and let us choose a
+          highly-rated movie for you!
+        </p>
+      </header>
+
+      <section class="control-panel">
+        <div class="select-wrapper">
+          <select id="genreSelect">
+            <option value="" disabled selected>Choose a genre...</option>
+            <option value="28">Action</option>
+            <option value="12">Adventure</option>
+            <option value="16">Animation</option>
+            <option value="35">Comedy</option>
+            <option value="80">Crime</option>
+            <option value="99">Documentary</option>
+            <option value="18">Drama</option>
+            <option value="14">Fantasy</option>
+            <option value="27">Horror</option>
+            <option value="9648">Mystery</option>
+            <option value="878">Sci-Fi</option>
+            <option value="53">Thriller</option>
+          </select>
+        </div>
+        <button id="findMovieBtn">Find Movie</button>
+      </section>
+
+      <main class="display-deck">
+        <div id="loadingState" class="spinner-box hidden">
+          <div class="spinner"></div>
+          <p>Scanning the cinematic vaults...</p>
+        </div>
+
+        <div id="welcomeState" class="placeholder-card">
+          <div class="placeholder-icon">🎬</div>
+          <h3>Your Next Movie Awaits</h3>
+          <p>
+            Select a genre above and click the selector button to pull a
+            top-tier random recommendation card.
+          </p>
+        </div>
+
+        <article id="movieCard" class="movie-card hidden">
+          <div class="poster-frame">
+            <img id="moviePoster" src="" alt="Movie Poster Graphic" />
+          </div>
+          <div class="movie-details">
+            <div class="meta-row">
+              <span id="movieRating" class="rating-badge">0.0</span>
+              <span id="movieReleaseDate" class="release-tag"
+                >Release Year</span
+              >
+            </div>
+            <h2 id="movieTitle">Movie Title</h2>
+            <p id="movieOverview" class="synopsis-text">
+              Movie short summary overview will render here inside this
+              paragraph component layer.
+            </p>
+          </div>
+        </article>
+      </main>
+    </div>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/public/movie-selector/styles.css
+++ b/public/movie-selector/styles.css
@@ -1,0 +1,276 @@
+:root {
+  --bg-base: #090d16;
+  --bg-surface: #121824;
+  --bg-card: #1b2336;
+  --accent-glow: #3b82f6;
+  --accent-gold: #fbbf24;
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --border-line: rgba(255, 255, 255, 0.06);
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    sans-serif;
+  background-color: var(--bg-base);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem 1rem;
+}
+
+.app-container {
+  width: 100%;
+  max-width: 680px;
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-line);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.5);
+}
+
+/* App Header styling blocks */
+.app-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.app-header h1 {
+  font-size: 2.2rem;
+  font-weight: 800;
+  background: linear-gradient(to right, #60a5fa, #a78bfa);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.03em;
+}
+
+.app-header p {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  margin-top: 0.5rem;
+  line-height: 1.5;
+}
+
+/* Operational Console Controls Layout */
+.control-panel {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+.select-wrapper {
+  position: relative;
+  flex: 1;
+}
+
+.control-panel select {
+  width: 100%;
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-line);
+  color: var(--text-primary);
+  padding: 0.85rem 1.25rem;
+  border-radius: 0.75rem;
+  font-size: 1rem;
+  outline: none;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.select-wrapper::after {
+  content: "▼";
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  position: absolute;
+  right: 1.25rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.control-panel button {
+  background-color: var(--accent-glow);
+  color: #ffffff;
+  border: none;
+  padding: 0.85rem 1.75rem;
+  font-size: 1rem;
+  font-weight: 700;
+  border-radius: 0.75rem;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.control-panel button:hover {
+  opacity: 0.9;
+}
+
+/* Movie Deck Panel Presentation Architecture */
+.display-deck {
+  min-height: 320px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* State card layouts (Welcome / Placeholders) */
+.placeholder-card {
+  text-align: center;
+  padding: 3rem 1.5rem;
+  border: 2px dashed rgba(255, 255, 255, 0.04);
+  border-radius: 1rem;
+  width: 100%;
+}
+
+.placeholder-icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+  opacity: 0.7;
+}
+
+.placeholder-card h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.4rem;
+}
+
+.placeholder-card p {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  max-width: 380px;
+  margin: 0 auto;
+  line-height: 1.5;
+}
+
+/* Loading CSS Spinner Blocks */
+.spinner-box {
+  text-align: center;
+}
+
+.spinner {
+  width: 44px;
+  height: 44px;
+  border: 3px solid rgba(59, 130, 246, 0.1);
+  border-top-color: var(--accent-glow);
+  border-radius: 50%;
+  animation: rotate 0.8s linear infinite;
+  margin: 0 auto 1rem auto;
+}
+
+@keyframes rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Main Movie Result Card */
+.movie-card {
+  display: flex;
+  gap: 2rem;
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-line);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  width: 100%;
+  animation: scaleUp 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.poster-frame {
+  width: 180px;
+  flex-shrink: 0;
+  background-color: var(--bg-base);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.3);
+}
+
+.poster-frame img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.movie-details {
+  display: flex;
+  flex-direction: column;
+}
+
+.meta-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.rating-badge {
+  background-color: rgba(251, 191, 36, 0.1);
+  color: var(--accent-gold);
+  font-weight: 700;
+  font-size: 0.85rem;
+  padding: 0.2rem 0.5rem;
+  border-radius: 0.25rem;
+}
+
+.release-tag {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.movie-details h2 {
+  font-size: 1.6rem;
+  font-weight: 800;
+  line-height: 1.25;
+  margin-bottom: 1rem;
+  letter-spacing: -0.01em;
+}
+
+.synopsis-text {
+  color: #cbd5e1;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+.hidden {
+  display: none !important;
+}
+
+/* Viewport Adjustments for Mobile and Tablets */
+@media (max-width: 560px) {
+  .movie-card {
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+  .poster-frame {
+    width: 140px;
+  }
+  .meta-row {
+    justify-content: center;
+  }
+  .control-panel {
+    flex-direction: column;
+  }
+}
+
+@keyframes scaleUp {
+  from {
+    transform: scale(0.97);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}


### PR DESCRIPTION
## Related Issue

Closes #5883

## Summary

This Pull Request fully implements a standalone "What to Watch" Random Movie Selector web tool inside the public folder framework. It features drop-down filter menus to poll TMDB endpoint arrays, isolating randomized highly-rated recommended film assets, displaying movie poster imagery, rating badges, calendar release rows, and synopses cleanly.

## Changes Made

- Interactive Select Dashboard: Styled a container workspace layout complete with dropdown selectors, dynamic state loaders, and fluid responsive result cards.
- Random Selection Matrix Engine: Programmed logic computing random page and result offsets over returned payload rows to vary selections across each selection trigger click event.
- Visual Fallbacks: Configured error handling cards and poster fallback mappings to preserve design consistency across irregular layout queries.
- Clean Syntax Controls: Ran code files through internal Prettier sweeps to enforce project styling metrics uniformly.

## Testing

- Audited random generation queries to verify uniform index item returns across varied genre settings
- Tested error loading layouts by mocking connection drops or empty payload returns
- Verified responsive CSS reflow layouts scale safely across both tablet, mobile, and wide viewport monitor windows   @dhairyagothi kindly review this
