### PR TITLE
[Feature]: Add GitHub Profile Finder with Repository Details

### DIFF
--- a/public/github-finder/index.html
+++ b/public/github-finder/index.html
@@ -1,0 +1,98 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GitHub Profile Finder</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app-container">
+      <header class="search-header">
+        <h1>GitHub Profile Finder</h1>
+        <form id="searchForm" class="search-box">
+          <input
+            type="text"
+            id="usernameInput"
+            placeholder="Enter a GitHub username..."
+            autocomplete="off"
+            required
+          />
+          <button type="submit">Search</button>
+        </form>
+      </header>
+
+      <main id="displayDeck">
+        <div id="welcomeState" class="info-card placeholder">
+          <div class="icon-avatar">🔍</div>
+          <h3>Discover Developers</h3>
+          <p>
+            Type any username into the search bar above to fetch real-time
+            profile metrics and public repository indexes directly from GitHub.
+          </p>
+        </div>
+
+        <div id="loadingState" class="info-card hidden">
+          <div class="spinner"></div>
+          <p>Querying GitHub API infrastructure...</p>
+        </div>
+
+        <div id="errorState" class="info-card error-card hidden">
+          <div class="icon-avatar">⚠️</div>
+          <h3>No User Found</h3>
+          <p>
+            We couldn't locate that specific profile. Check your spelling and
+            try searching again.
+          </p>
+        </div>
+
+        <article id="profileResultCard" class="profile-layout hidden">
+          <section class="user-profile-card">
+            <div class="profile-header">
+              <img id="userAvatar" src="" alt="User Avatar Graphic" />
+              <div class="user-meta">
+                <h2 id="userName">Developer Name</h2>
+                <a
+                  id="userLogin"
+                  href=""
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  >@username</a
+                >
+                <p id="userBio" class="bio-text">
+                  This profile has no bio description text logged.
+                </p>
+              </div>
+            </div>
+
+            <div class="stats-row">
+              <div class="stat-box">
+                <span class="stat-val" id="repoCount">0</span>
+                <span class="stat-lbl">Repos</span>
+              </div>
+              <div class="stat-box">
+                <span class="stat-val" id="followerCount">0</span>
+                <span class="stat-lbl">Followers</span>
+              </div>
+              <div class="stat-box">
+                <span class="stat-val" id="followingCount">0</span>
+                <span class="stat-lbl">Following</span>
+              </div>
+            </div>
+
+            <div id="locationWrapper" class="location-tag">
+              <span class="pin-icon">📍</span>
+              <span id="userLocation">Unknown Location</span>
+            </div>
+          </section>
+
+          <section class="repos-section">
+            <h3>Top Public Repositories</h3>
+            <div id="reposGrid" class="repos-grid"></div>
+          </section>
+        </article>
+      </main>
+    </div>
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/public/github-finder/script.js
+++ b/public/github-finder/script.js
@@ -1,0 +1,123 @@
+// Target base GitHub tracking endpoint URLs
+const GITHUB_API_BASE = "https://api.github.com/users";
+
+const searchForm = document.getElementById("searchForm");
+const usernameInput = document.getElementById("usernameInput");
+
+const welcomeState = document.getElementById("welcomeState");
+const loadingState = document.getElementById("loadingState");
+const errorState = document.getElementById("errorState");
+const profileResultCard = document.getElementById("profileResultCard");
+
+// Profile DOM interface binding node pointers
+const userAvatar = document.getElementById("userAvatar");
+const userName = document.getElementById("userName");
+const userLogin = document.getElementById("userLogin");
+const userBio = document.getElementById("userBio");
+const repoCount = document.getElementById("repoCount");
+const followerCount = document.getElementById("followerCount");
+const followingCount = document.getElementById("followingCount");
+const userLocation = document.getElementById("userLocation");
+const locationWrapper = document.getElementById("locationWrapper");
+const reposGrid = document.getElementById("reposGrid");
+
+// Core API Processing Core Async Manager
+async function executeGitHubProfileQuery(username) {
+  // Switch state layouts to engage loading status view blocks
+  welcomeState.classList.add("hidden");
+  errorState.classList.add("hidden");
+  profileResultCard.classList.add("hidden");
+  loadingState.classList.remove("hidden");
+
+  try {
+    // Query the profile metadata row
+    const profileResponse = await fetch(`${GITHUB_API_BASE}/${username}`);
+
+    // Handle 404 Not Found error states gracefully
+    if (profileResponse.status === 404) {
+      showStateCard(errorState);
+      return;
+    }
+    if (!profileResponse.ok) throw new Error("API rejection flag thrown.");
+
+    const profileData = await profileResponse.json();
+
+    // Query repository details sorted by most recently updated public items
+    const reposResponse = await fetch(
+      `${GITHUB_API_BASE}/${username}/repos?sort=updated&per_page=5`,
+    );
+    const reposData = reposResponse.ok ? await reposResponse.json() : [];
+
+    populateProfileInterface(profileData, reposData);
+  } catch (error) {
+    console.error(error);
+    showStateCard(errorState);
+  }
+}
+
+// Map retrieved properties directly onto DOM elements
+function populateProfileInterface(user, repos) {
+  loadingState.classList.add("hidden");
+  profileResultCard.classList.remove("hidden");
+
+  // Bind metric values safely
+  userAvatar.src = user.avatar_url;
+  userName.innerText = user.name || user.login;
+  userLogin.innerText = `@${user.login}`;
+  userLogin.href = user.html_url;
+  userBio.innerText = user.bio || "This user has no profile bio registered.";
+
+  repoCount.innerText = user.public_repos;
+  followerCount.innerText = user.followers;
+  followingCount.innerText = user.following;
+
+  // Evaluate geography badges
+  if (user.location) {
+    userLocation.innerText = user.location;
+    locationWrapper.classList.remove("hidden");
+  } else {
+    locationWrapper.classList.add("hidden");
+  }
+
+  // Refresh and build repository container cards
+  reposGrid.innerHTML = "";
+  if (repos.length === 0) {
+    reposGrid.innerHTML = `<p class="text-secondary" style="grid-column: 1/-1;">No public repositories located inside this user's registry layout.</p>`;
+    return;
+  }
+
+  // Iterate over nested repository arrays to display the top 5 public targets
+  repos.forEach((repo) => {
+    const cardElement = document.createElement("div");
+    cardElement.className = "repo-card";
+    cardElement.innerHTML = `
+            <div class="repo-card-header">
+                <a href="${repo.html_url}" target="_blank" rel="noopener noreferrer">${repo.name}</a>
+                <p class="repo-desc">${repo.description || "No description asset logs submitted."}</p>
+            </div>
+            <div class="repo-footer">
+                <span class="repo-stat">⭐ ${repo.stargazers_count}</span>
+                <span class="repo-stat">🍴 ${repo.forks_count}</span>
+            </div>
+        `;
+    reposGrid.appendChild(cardElement);
+  });
+}
+
+// Utility presentation view toggle
+function showStateCard(targetCard) {
+  loadingState.classList.add("hidden");
+  welcomeState.classList.add("hidden");
+  errorState.classList.add("hidden");
+  profileResultCard.classList.add("hidden");
+  targetCard.classList.remove("hidden");
+}
+
+// Wire form operational submission interceptors
+searchForm.addEventListener("submit", (e) => {
+  e.preventDefault();
+  const targetedUser = usernameInput.value.trim();
+  if (targetedUser) {
+    executeGitHubProfileQuery(targetedUser);
+  }
+});

--- a/public/github-finder/styles.css
+++ b/public/github-finder/styles.css
@@ -1,0 +1,317 @@
+:root {
+  --bg-base: #0d1117;
+  --bg-surface: #161b22;
+  --bg-card: #21262d;
+  --accent-blue: #58a6ff;
+  --accent-green: #2ea44f;
+  --text-primary: #c9d1d9;
+  --text-secondary: #8b949e;
+  --border-color: #30363d;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  background-color: var(--bg-base);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  padding: 3rem 1rem;
+}
+
+.app-container {
+  width: 100%;
+  max-width: 740px;
+}
+
+/* Search Header Bars Control Panel Layout */
+.search-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.search-header h1 {
+  font-size: 1.8rem;
+  font-weight: 600;
+  margin-bottom: 1.25rem;
+  letter-spacing: -0.02em;
+}
+
+.search-box {
+  display: flex;
+  gap: 0.75rem;
+  background-color: var(--bg-surface);
+  padding: 0.5rem;
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+}
+
+.search-box input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text-primary);
+  font-size: 1rem;
+  padding: 0.5rem 0.75rem;
+}
+
+.search-box input::placeholder {
+  color: var(--text-secondary);
+}
+
+.search-box button {
+  background-color: var(--accent-green);
+  color: #ffffff;
+  border: none;
+  outline: none;
+  font-size: 0.95rem;
+  font-weight: 600;
+  padding: 0.5rem 1.25rem;
+  border-radius: 0.35rem;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.search-box button:hover {
+  opacity: 0.9;
+}
+
+/* Informative Context States (Welcome, Loading, Error) */
+.info-card {
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+  padding: 3rem 1.5rem;
+  text-align: center;
+}
+
+.icon-avatar {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+.info-card h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+.info-card p {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  max-width: 440px;
+  margin: 0 auto;
+  line-height: 1.5;
+}
+
+.error-card h3 {
+  color: #ff7b72;
+}
+
+/* CSS Component Load Spinner */
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid rgba(88, 166, 255, 0.1);
+  border-top-color: var(--accent-blue);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  margin: 0 auto 1.25rem auto;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Main Profile Panel Outputs Grid */
+.profile-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  animation: fadeIn 0.3s ease-out;
+}
+
+.user-profile-card {
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+  padding: 2rem;
+}
+
+.profile-header {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+#userAvatar {
+  width: 90px;
+  height: 90px;
+  border-radius: 50%;
+  border: 2px solid var(--border-color);
+  background-color: var(--bg-base);
+}
+
+.user-meta {
+  flex: 1;
+}
+
+.user-meta h2 {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.user-meta a {
+  color: var(--accent-blue);
+  text-decoration: none;
+  font-size: 0.95rem;
+  display: inline-block;
+  margin: 0.2rem 0 0.6rem 0;
+}
+
+.user-meta a:hover {
+  text-decoration: underline;
+}
+
+.bio-text {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
+/* Developer Metrics Arrays layout columns */
+.stats-row {
+  display: flex;
+  gap: 1rem;
+  background-color: var(--bg-base);
+  border: 1px solid var(--border-color);
+  border-radius: 0.35rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.stat-box {
+  flex: 1;
+  text-align: center;
+}
+
+.stat-val {
+  display: block;
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.stat-lbl {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+}
+
+.location-tag {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+/* Top 5 public repository grids cards */
+.repos-section h3 {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.repos-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 1rem;
+}
+
+.repo-card {
+  background-color: var(--bg-surface);
+  border: 1px solid var(--border-color);
+  border-radius: 0.5rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.repo-card-header a {
+  color: var(--accent-blue);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 1rem;
+  word-break: break-all;
+}
+
+.repo-card-header a:hover {
+  text-decoration: underline;
+}
+
+.repo-desc {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  margin: 0.5rem 0 1rem 0;
+  line-height: 1.4;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+}
+
+.repo-footer {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.repo-stat {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.hidden {
+  display: none !important;
+}
+
+/* Viewport Fluid Structural Scale Adaptations */
+@media (max-width: 580px) {
+  .profile-header {
+    flex-direction: column;
+    text-align: center;
+  }
+  .repos-grid {
+    grid-template-columns: 1fr;
+  }
+  .stats-row {
+    flex-wrap: wrap;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(5px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Related Issue

Closes #5886

## Summary

This Pull Request fully implements the interactive GitHub Profile Finder tool within its own dedicated path directory. It references live data points using the native GitHub Users API, populating comprehensive user metric fields alongside a dynamic child grid listing their top 5 public repositories.

## Changes Made

- Profile Analytics Interface: Designed an immersive profile finder UI with precise input fields, card grids, dynamic statistics, and location tracking fields.
- GitHub API Engine: Configured dual fetch processing paths to asynchronously gather profile fields alongside repository objects sorted cleanly by update frequency.
- Resilient Error Framework: Added clean view states to catch and handle invalid searches (`404 Not Found`) securely without halting application processes.
- Styling Optimization: Swept all workspace source layouts with Prettier to uphold repository alignment criteria.

## Testing

- Evaluated live lookups across several valid GitHub profiles to confirm complete element maps
- Tested non-existent account string fields to confirm error layout cards trigger perfectly
- Monitored response data layouts to verify the public repositories list caps cleanly at 5 results   @dhairyagothi kindly review this
