### PR TITLE
Add Dark Mode Toggle with Persistent Theme Support to Number Guessing Game

### DIFF
--- a/public/Number Guessing Game/GuessNumber.js
+++ b/public/Number Guessing Game/GuessNumber.js
@@ -88,3 +88,31 @@ function newGame(){
         playGame = true;
     })
 }
+
+const toggleBtn = document.getElementById("theme-toggle");
+
+const savedTheme = localStorage.getItem("theme");
+
+if (savedTheme === "dark") {
+    document.body.classList.add("dark");
+    toggleBtn.textContent = "☀️";
+}
+
+toggleBtn.addEventListener("click", () => {
+    document.body.classList.toggle("dark");
+
+    if (document.body.classList.contains("dark")) {
+        localStorage.setItem("theme", "dark");
+        toggleBtn.textContent = "☀️";
+    } else {
+        localStorage.setItem("theme", "light");
+        toggleBtn.textContent = "🌙";
+    }
+});
+
+if (
+    !localStorage.getItem("theme") &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches
+) {
+    document.body.classList.add("dark");
+}

--- a/public/Number Guessing Game/index.html
+++ b/public/Number Guessing Game/index.html
@@ -26,6 +26,10 @@
             <p class="lowOrHi"></p>
         </div>
     </div>
+
+    <button id="theme-toggle" class="theme-toggle">
+    🌙
+</button>
     <script src="GuessNumber.js"></script>
 </body>
 

--- a/public/Number Guessing Game/style.css
+++ b/public/Number Guessing Game/style.css
@@ -1,10 +1,26 @@
+:root {
+    --bg-color: #ffe4e1;
+    --container-color: #ffffff;
+    --text-color: #333333;
+    --button-color: #ff7f7f;
+    --button-text: #ffffff;
+}
+
+body.dark {
+    --bg-color: #121212;
+    --container-color: #1e1e1e;
+    --text-color: #f5f5f5;
+    --button-color: #444444;
+    --button-text: #ffffff;
+}
 *{
     margin: 0;
     padding: 0;
 }
 
 body {
-    background-color: linen;
+    background: var(--bg-color);
+    color: var(--text-color);
 }
 
 h1{
@@ -65,4 +81,28 @@ p{
 
 #guessField:hover{
     background-color: linen;
+}
+
+.container {
+    background: var(--container-color);
+}
+
+button {
+    background: var(--button-color);
+    color: var(--button-text);
+}
+
+.theme-toggle {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    font-size: 1.2rem;
+    padding: 10px;
+    border: none;
+    border-radius: 50%;
+    cursor: pointer;
+}
+
+body {
+    position: relative;
 }


### PR DESCRIPTION
## Description

This PR adds a Dark Mode feature to the Number Guessing Game, allowing users to switch between light and dark themes using a theme toggle button.

### Changes Made

* Added a Dark Mode toggle button (🌙/☀️) to the game interface.
* Implemented theme switching using CSS variables for easier theme management.
* Created a dark theme color palette for improved usability in low-light environments.
* Added JavaScript logic to toggle themes dynamically.
* Stored the user's theme preference in localStorage so the selected theme persists after page refreshes.
* Updated styling to ensure a consistent appearance across both themes.

### Problem Solved

The Number Guessing Game previously supported only a light theme, which could cause eye strain during prolonged use or in low-light conditions. This feature improves accessibility and user comfort by providing a dark mode option while preserving the existing design and functionality.

### Testing

* Verified theme toggle functionality.
* Confirmed theme preference persists after page refresh.
* Tested both light and dark themes across different screen sizes.
* Ensured existing game functionality remains unaffected.
