### PR TITLE
Fix Whack-a-Mole: clear intervals on game over and restart fresh on retry

### DIFF
--- a/public/Whack-a-Mole Game/mole.js
+++ b/public/Whack-a-Mole Game/mole.js
@@ -2,6 +2,8 @@ let currMoleTile;
 let currPlantTile;
 let score = 0;
 let gameOver = false;
+let moleInterval = null;  // track mole interval to prevent duplicates
+let plantInterval = null; // track plant interval to prevent duplicates
 
 window.onload = function () {
     setGame();
@@ -20,8 +22,17 @@ function setGame() {
         document.getElementById("board").appendChild(tile);
     }
 
-    setInterval(setMole, 1000);
-    setInterval(setPlant, 2000);
+    // Clear any existing intervals before starting new ones to prevent
+    // concurrent loop accumulation if setGame() is ever called more than once
+    if (moleInterval !== null) {
+        clearInterval(moleInterval);
+    }
+    if (plantInterval !== null) {
+        clearInterval(plantInterval);
+    }
+
+    moleInterval = setInterval(setMole, 1000);
+    plantInterval = setInterval(setPlant, 2000);
 }
 
 function getRandomTile() {
@@ -99,6 +110,16 @@ function selectTile() {
 
         gameOver = true;
 
+        // Stop intervals immediately so moles/plants freeze on game over
+        if (moleInterval !== null) {
+            clearInterval(moleInterval);
+            moleInterval = null;
+        }
+        if (plantInterval !== null) {
+            clearInterval(plantInterval);
+            plantInterval = null;
+        }
+
         // show restart button
         document.getElementById("restart-btn").style.display =
             "inline-block";
@@ -134,4 +155,9 @@ function restartGame() {
 
     currMoleTile = null;
     currPlantTile = null;
+
+    // Restart intervals fresh — previous ones were cleared on game over
+    // so there is no risk of concurrent loop accumulation
+    moleInterval = setInterval(setMole, 1000);
+    plantInterval = setInterval(setPlant, 2000);
 }


### PR DESCRIPTION
Fixes #6290

## Changes
- Added moleInterval and plantInterval module-level variables to store setInterval IDs
- setGame() checks and clears any existing intervals before starting new ones (prevents concurrent loops if called multiple times)
- selectTile() now immediately clears both intervals when the player hits a piranha plant, so moles/plants stop appearing the moment game over triggers
- estartGame() starts fresh intervals so the timing is predictable and no stale callbacks can accumulate

## Before vs After
| | Before | After |
|---|---|---|
| Game over | Moles keep updating on board | Board freezes immediately |
| Restart | Old intervals keep running | Fresh intervals start cleanly |
| Concurrent loops | Possible if setGame() called twice | Impossible — old intervals always cleared first |

## Testing
1. Play Whack-a-Mole → hit a piranha plant → board should freeze immediately
2. Click Restart → game plays at correct 1s/2s speed (not doubled)