### PR TITLE
fix(precommit): correct validateProjects script reference in lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "stylelint-config-standard": "^40.0.0"
   },
   "lint-staged": {
-    "projects.json": "node scripts/validateProjects.js",
+    "projects.json": "node scripts/validate-metadata.js",
     "*.html": "npx htmlhint"
 
   }


### PR DESCRIPTION
### Related Issue
Closes #5948

### Summary
Fixes the pre-commit hook configuration referencing a non-existent validation script.

The repository's lint-staged configuration attempted to run `scripts/validateProjects.js`, which does not exist. This caused project metadata validation hooks to fail during commits.

### Changes Made
- Updated lint-staged configuration to use:
  - `scripts/validate-metadata.js`
- Removed the broken reference to:
  - `scripts/validateProjects.js`

### Impact
- Restores correct pre-commit validation behavior
- Prevents commit failures caused by missing script references
- Aligns repository tooling with the actual validation script structure

### Testing
- Verified `node scripts/validate-metadata.js` executes successfully
- Confirmed lint-staged now references the correct validation script