### PR TITLE
fix: update sepia theme text contrast and stats strip colors

### DIFF
--- a/style.css
+++ b/style.css
@@ -66,18 +66,18 @@ body.light-mode {
   --bg-surface: #eee8d5;
 
   --text-primary: #433422;
-  --text-secondary: rgba(67, 52, 34, 0.7);
-  --text-muted: rgba(67, 52, 34, 0.5);
+  --text-secondary: #5c4a37;                   /* darker for visibility */
+  --text-muted: rgba(67, 52, 34, 0.6);
   --accent-color: #cb4b16;
   --accent: #b58900;
-  --accent-dim: rgba(181, 137, 0, 0.1);
+  --accent-dim: rgba(181, 137, 0, 0.15);
   --accent-hover: #d33682;
-  --border: rgba(67, 52, 34, 0.15);
-  --border-hover: rgba(67, 52, 34, 0.25);
-  --border-accent: rgba(181, 137, 0, 0.35);
-  --accent-glow: rgba(203, 75, 22, 0.15);
-  --glass-bg: rgba(67, 52, 34, 0.03);
-  --glass-border: rgba(67, 52, 34, 0.08);
+  --border: rgba(67, 52, 34, 0.2);            /* Increased opacity */
+  --border-hover: rgba(67, 52, 34, 0.35);
+  --border-accent: rgba(181, 137, 0, 0.45);
+  --accent-glow: rgba(203, 75, 22, 0.2);
+  --glass-bg: rgba(253, 246, 227, 0.85);      /* High-contrast background for navbar */
+  --glass-border: rgba(67, 52, 34, 0.15);
   --gradient-1: linear-gradient(135deg, #cb4b16, #b58900);
 }
 
@@ -3264,4 +3264,95 @@ body.custom-cursor-active .cursor-ring {
 
 body.custom-cursor-active .cursor-ring.is-visible {
   opacity: 1;
+}
+/* ============================================================
+   SEPIA CONTRAST PATCH 
+   ============================================================ */
+:root[data-theme="sepia"] body {
+  background-color: var(--bg-primary) !important;
+  color: var(--text-primary) !important;
+}
+
+/* Fix Navbar background transparency */
+:root[data-theme="sepia"] .navbar {
+  background: rgba(244, 236, 216, 0.94) !important;
+  border-bottom: 1px solid var(--border) !important;
+}
+
+/*all link items, headers, and hero subtitles pop out */
+:root[data-theme="sepia"] .hero-sub,
+:root[data-theme="sepia"] .hero-extra,
+:root[data-theme="sepia"] .projects-section p,
+:root[data-theme="sepia"] .welcome-text {
+  color: var(--text-secondary) !important;
+}
+
+/* Fix navbar items text colors */
+:root[data-theme="sepia"] .navbar a,
+:root[data-theme="sepia"] .brand-copy strong,
+:root[data-theme="sepia"] .btn-ghost {
+  color: var(--text-primary) !important;
+}
+
+/* Brighten terminal card frames for readability */
+:root[data-theme="sepia"] .hero-terminal-shell {
+  background: var(--bg-elevated) !important;
+  border-color: var(--border) !important;
+}
+:root[data-theme="sepia"] .hero-terminal-text {
+  color: var(--text-primary) !important;
+}
+/* ============================================================
+   ADDITIONAL SEPIA FIXES (Stats Strip, Subheaders & Cards)
+   ============================================================ */
+:root[data-theme="sepia"] {
+  --text-muted-sepia: #73624e; 
+}
+:root[data-theme="sepia"] .stats-strip {
+  background: #433422 !important;       /* sepia brown */
+  border-color: #5c4a37 !important;     /* lighter brown border */
+  box-shadow: 0 12px 40px rgba(67, 52, 34, 0.15) !important;
+}
+
+:root[data-theme="sepia"] .stat-item,
+:root[data-theme="sepia"] .stat-item strong,
+:root[data-theme="sepia"] .stat-divider {
+  color: #fdf6e3 !important;           
+}
+
+/* 2. Lighten the font color for  "100 Days · 100 Web Projects" */
+:root[data-theme="sepia"] .hero-overline {
+  color: var(--text-muted-sepia) !important;
+  font-weight: 500;
+}
+
+/* 3. Make the Hero descriptions and paragraph text legible */
+:root[data-theme="sepia"] .hero-sub,
+:root[data-theme="sepia"] .hero-extra,
+:root[data-theme="sepia"] .projects-header p,
+:root[data-theme="sepia"] p {
+  color: #5c4a37 !important; 
+}
+
+/* 4. Fix the lower section blocks  */
+:root[data-theme="sepia"] h3,
+:root[data-theme="sepia"] .section-title,
+:root[data-theme="sepia"] .mobile-menu-title {
+  color: var(--text-primary) !important;
+}
+
+/* 5. Fix the bottom grid details & lists (Browse all projects, Meet contributors, tags) */
+:root[data-theme="sepia"] .nav-buttons.mobile-drawer-layer a.btn,
+:root[data-theme="sepia"] .explore-links a,
+:root[data-theme="sepia"] .connect-links,
+:root[data-theme="sepia"] .badge,
+:root[data-theme="sepia"] span {
+  color: #433422 !important;
+}
+
+/* 6. Footer adjustment */
+:root[data-theme="sepia"] footer,
+:root[data-theme="sepia"] footer text,
+:root[data-theme="sepia"] [class*="footer"] {
+  color: var(--text-muted-sepia) !important;
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #6142 

### Summary
Fixed a accessibility issue on the main repository landing page where switching to the "Sepia" theme had paragraph elements, subheaders, and navigation links completely invisible due to a lack of color contrast against the warm background. Additionally, updated the top stats banner to a high-contrast inverted color scheme for better visuals.

### Type of Change
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [X] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- **Enhanced Sepia Theme Variables:** Adjusted `--text-secondary`, `--text-muted`, and border properties inside the `:root[data-theme="sepia"]` block to provide readable dark brown values instead of transparent dark-mode variables.
- **Inverted Stats Strip Colorway:** Reversed the design of `.stats-strip` in sepia mode to sepia brown background (`#433422`) with  cream text (`#fdf6e3`) .
- **Global Typography Fallbacks:** Appended specific scoping overrides targeting `.hero-sub`, `.hero-extra`, `.hero-overline`, navbar anchor links, headers, and generic paragraph elements to ensure 100% text legibility when the sepia data-attribute is active.


## 🧪 Testing and Verification

### Local Validation
- [X] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [X] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [X] Verified responsive layout on Mobile viewports (using DevTools)
- [X] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
Before
<img width="1909" height="870" alt="Screenshot 2026-06-03 214546" src="https://github.com/user-attachments/assets/31fd3400-f282-41c0-b82d-217ecafca1e4" />
<img width="1911" height="860" alt="Screenshot 2026-06-03 214602" src="https://github.com/user-attachments/assets/d8c2a97d-62ca-419a-8f76-c71704c9a6bf" />
After
<img width="1890" height="911" alt="Screenshot 2026-06-04 190555" src="https://github.com/user-attachments/assets/f0147f00-807a-4af8-8cdf-4404b33162f3" />
<img width="1896" height="914" alt="Screenshot 2026-06-04 190539" src="https://github.com/user-attachments/assets/830432cc-f0bd-47c2-ae71-61f22be5ad05" />


---

## 🤝 Contributor Checklist
- [X] My code follows the code style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation / README files accordingly.
- [X] My changes generate no new warnings or console errors.
- [X] There are no unrelated changes or formatter noise in this PR.
