### PR TITLE
fix(travel-chatbot): validate API response format and handle errors gracefully

### DIFF
--- a/public/Travel_booking_website/index.js
+++ b/public/Travel_booking_website/index.js
@@ -190,6 +190,20 @@ async function sendMessage() {
 
     const data = await response.json();
 
+    let reply = "";
+    if (data) {
+      if (data.choices && Array.isArray(data.choices) && data.choices.length > 0 &&
+          data.choices[0].message && typeof data.choices[0].message.content === "string") {
+        reply = data.choices[0].message.content;
+      } else if (typeof data.reply === "string") {
+        reply = data.reply;
+      }
+    }
+
+    if (!reply) {
+      throw new Error("Invalid or empty response format from API");
+    }
+
     loadingMessage.remove();
 
     // BOT RESPONSE
@@ -199,15 +213,15 @@ async function sendMessage() {
     botMessage.classList.add("bot-message");
 
     botMessage.innerHTML = `
-  ${formatResponse(data.choices[0].message.content)}
+  ${formatResponse(reply)}
   <div class="msg-timestamp">${getTime()}</div>
 `;
 
     chatMessages.appendChild(botMessage);
     localStorage.setItem(
-  "travel_chat",
-  chatMessages.innerHTML
-);
+      "travel_chat",
+      chatMessages.innerHTML
+    );
 
     // AUTO SCROLL
 


### PR DESCRIPTION
### Related Issue

Closes #6249

### Summary

Fixes a chatbot bug in the Travel Booking Website where the interface could remain stuck on "Thinking..." when the backend returned an unexpected or malformed response structure.

The chatbot previously assumed a specific response format and accessed nested properties without validating their existence. When the response did not match the expected structure, runtime errors prevented the loading state from being cleared.

### Type of Change

🐛 Bug fix

### Changes Made

* Added validation before accessing nested API response properties.
* Added support for both `reply`-based and `choices`-based response formats.
* Gracefully handles malformed, incomplete, or unexpected responses.
* Ensures the loading indicator is always cleared.
* Displays a user-friendly error message when a valid chatbot response cannot be generated.

### Testing and Verification

* Verified chatbot behavior with valid API responses.
* Verified chatbot behavior with unexpected response structures.
* Confirmed that the interface no longer remains stuck on "Thinking...".
* Confirmed that runtime errors caused by missing nested properties are prevented.

### Impact

Improves chatbot reliability and user experience by preventing unresponsive loading states and handling backend response inconsistencies safely.
