### PR TITLE
fix: prevent empty image captcha submissions from consuming attempts

### DIFF
--- a/public/captcha/captcha.js
+++ b/public/captcha/captcha.js
@@ -258,6 +258,13 @@ const verifyCaptcha = () => {
       return;
   }
 
+  if (selectedType === "image" && !selectedImageAnswer) {
+      resultMessage.textContent = "Please select an image before submitting.";
+      resultMessage.classList.add('error');
+      resultMessage.classList.remove('success');
+      return;
+  }
+  
   const userInput = 
   selectedType == "image"
   ? selectedImageAnswer.toLowerCase()


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #6416 

### Summary
This PR fixes an issue in Image Captcha mode where submitting without selecting any image is treated as an incorrect Captcha attempt.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
-Added validation for Image Captcha mode before answer verification.
- Empty submissions now show a clear message: "Please select an image first."
- Empty submissions no longer consume Captcha attempts.
- Existing behavior for incorrect and correct image selections remains unchanged.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x ] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
Before:
<img width="593" height="317" alt="Screenshot 2026-06-04 212245" src="https://github.com/user-attachments/assets/80603712-f386-4bb4-9baa-b749a9105a2d" />

After:
<img width="945" height="540" alt="Screenshot 2026-06-04 212529" src="https://github.com/user-attachments/assets/06a17117-9944-47af-9263-4b7c9072d720" />
R

---

## 🤝 Contributor Checklist
- [ x] My code follows the code style guidelines of this project.
- [x ] I have performed a self-review of my own code.
- [x ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x ] My changes generate no new warnings or console errors.
- [ x] There are no unrelated changes or formatter noise in this PR.
