### PR TITLE
fix: restored layout alignment and responsive spacing for Solar System carousel

### DIFF
--- a/public/Solar System Explorer in CSS only haml/style.css
+++ b/public/Solar System Explorer in CSS only haml/style.css
@@ -1,2511 +1,404 @@
-@import url("https://fonts.googleapis.com/css?family=Montserrat:300,400,700");
-.solar_systm {
-  transform-style: preserve-3d;
-  pointer-events: none;
-  height: 100%;
-  position: absolute;
-  left: 0;
-  right: 0;
-}
-
+/* ============================================================
+   GLOBAL DARK GRAPHICS & CONTAINER CONFIGURATIONS
+   ============================================================ */
 * {
-  -webkit-user-select: none; /* Chrome all / Safari all */
-  -moz-user-select: none; /* Firefox all */
-  -ms-user-select: none; /* IE 10+ */
-  user-select: none; /* Likely future */
-}
-
-body .solar_systm .planet, body input[type=radio][name=planet]::after, body .overlay, body input[type=radio][name=planet]::after {
-  position: absolute;
-  left: 0;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  margin: auto;
-}
-
-body .solar_systm .planet.neptune .trajectory.ner, body .solar_systm .planet.neptune .trajectory.pro, body .solar_systm .planet.neptune .trajectory.tri, body .solar_systm .planet.uranus .trajectory.umb, body .solar_systm .planet.uranus .trajectory.ari, body .solar_systm .planet.uranus .trajectory.mir, body .solar_systm .planet.saturn .trajectory.enc, body .solar_systm .planet.saturn .trajectory.di, body .solar_systm .planet.saturn .trajectory.ti, body .solar_systm .planet.jupiter .trajectory.ga, body .solar_systm .planet.jupiter .trajectory.eu, body .solar_systm .planet.jupiter .trajectory.lop, body .solar_systm .planet.mars .trajectory.p, body .solar_systm .planet.mars .trajectory.d, body .solar_systm .planet.earth .trajectory.m {
-  border: 2px dashed white;
-  position: absolute;
-  border-radius: 3400px;
-  background: none !important;
-  z-index: -2;
-}
-
-body .solar_systm .planet {
-  height: 1200px;
-  width: 1200px;
-  border-radius: 600px;
-  background: red;
-  transition: transform 2.8s 0.23s cubic-bezier(0.33, 0, 0, 1), opacity 2s 0.8s, box-shadow 0s 0s;
-  background-size: 1140px 910px !important;
-  top: auto;
-  bottom: -920px;
-}
-body .solar_systm .planet .moon {
-  height: 200px;
-  width: 200px;
-  border-radius: 600px;
-  background: red;
-  position: absolute;
-  text-align: center;
-  color: white;
-  text-transform: uppercase;
-  opacity: 0;
-  transition: all 0.6s 0.2s;
-}
-body .solar_systm .planet .moon h2 {
-  font-weight: 100;
-  font-size: 40px;
-  letter-spacing: 5px;
   margin: 0;
-  position: relative;
-  top: -120px;
-}
-body .solar_systm .planet .moon h3 {
-  font-weight: 100;
-  font-size: 20px;
-  letter-spacing: 5px;
-  color: #fea082;
-  margin: 0;
-  position: relative;
-  top: -120px;
-}
-@keyframes planet {
-  from {
-    background-position-y: 0px;
-  }
-  to {
-    background-position-y: -1000px;
-  }
-}
-
-body .solar {
-  position: absolute;
-  transform: rotatex(-20deg);
-  perspective: 800px;
-  width: 100%;
-  height: 100%;
-  transform-style: preserve-3d;
-}
-
-body input[type=radio][name=planet]::after {
-  width: 220px;
-  height: 220px;
-  border-radius: 550px;
-  appearance: none;
-  outline: none;
-  cursor: pointer;
-  z-index: 12;
-  left: 18px;
-  bottom: 282px;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 body {
-  overflow: hidden;
-  background: black;
-  height: 100vh;
-  font-family: "Montserrat", sans-serif;
-}
-body .logo {
-  color: white;
-  position: absolute;
-  top: 40px;
-  left: 0;
-  right: 0;
-  margin: auto;
-  text-align: center;
-  font-size: 14px;
-  text-transform: uppercase;
-  font-weight: 100;
-  letter-spacing: 4px;
-}
-body .logo span {
-  font-size: 12px;
-  color: #f39041;
-  display: block;
-}
-body label {
-  cursor: pointer;
-}
-body label.sun > .preview {
-  background: url("https://www.solarsystemscope.com/images/textures/full/2k_sun.jpg") !important;
-}
-body label.mercury > .preview {
-  background: url("https://www.solarsystemscope.com/images/textures/full/2k_makemake_fictional.jpg") !important;
-}
-body label.venus > .preview {
-  background: url("https://nasa3d.arc.nasa.gov/shared_assets/images/ven0aaa2/ven0aaa2-copy-428-321.jpg") !important;
-}
-body label.earth > .preview {
-  background: url("https://img00.deviantart.net/04ef/i/2009/114/3/e/new_earth_texture_map_by_lightondesigns.jpg") !important;
-}
-body label.mars > .preview {
-  background: url("https://s3-us-west-2.amazonaws.com/s.cdpn.io/217233/mars_texture.jpg") !important;
-}
-body label.jupiter > .preview {
-  background: url("https://www.jpl.nasa.gov/spaceimages/images/largesize/PIA07782_hires.jpg") !important;
-}
-body label.saturn > .preview {
-  background: url("https://www.solarsystemscope.com/images/textures/full/2k_saturn.jpg") !important;
-}
-body label.uranus > .preview {
-  background: url("https://img00.deviantart.net/957c/i/2017/165/4/9/uranus_texture_map_by_jcpag2010-db7yjwb.png") !important;
-}
-body label.neptune > .preview {
-  background: url("https://img00.deviantart.net/f068/i/2017/165/b/c/neptune_texture_map_by_jcpag2010-dbcjcv5.png") !important;
-}
-body label.pluto > .preview {
-  background: url("https://pre00.deviantart.net/4677/th/pre/f/2015/314/4/e/pluto_map__2015_nov_10__by_snowfall_the_cat-d918tlb.png") !important;
-}
-body label.menu {
-  color: white;
-  display: block;
-  position: absolute;
-  cursor: pointer;
-  left: 90px;
-  z-index: 2;
-}
-body label.menu:after {
-  display: block;
-  width: 12px;
-  height: 12px;
-  border: 2px solid white;
-  border-radius: 60px;
-  content: "";
-  z-index: 2;
-  position: absolute;
-  top: -4px;
-  left: -4px;
-}
-body label.menu:hover h2, body label.menu:hover h3 {
-  opacity: 1;
-}
-body label.menu.sun h2 .pip {
-  background: #ffcc00;
-}
-body label.menu.mercury h2 .pip {
-  background: #E8927C;
-}
-body label.menu.venus h2 .pip {
-  background: #b45d15;
-}
-body label.menu.earth h2 .pip {
-  background: #26daaa;
-}
-body label.menu.mars h2 .pip {
-  background: #e55f45;
-}
-body label.menu.jupiter h2 .pip {
-  background: orange;
-}
-body label.menu.saturn h2 .pip {
-  background: #b29d81;
-}
-body label.menu.uranus h2 .pip {
-  background: #8dcdd8;
-}
-body label.menu.neptune h2 .pip {
-  background: #4f83e2;
-}
-body label.menu.pluto h2 .pip {
-  background: #FF8732;
-}
-body label.menu .preview {
-  width: 30px;
-  height: 30px;
-  background: yellow;
-  float: left;
-  background-size: auto 100% !important;
-  position: absolute;
-  border-radius: 100px;
-  box-shadow: 0 -13px 10px 2px black inset;
-}
-body label.menu .info {
-  position: relative;
-  left: 50px;
-  top: 1px;
-}
-body label.menu h2,
-body label.menu h3 {
-  text-transform: uppercase;
-  margin: 0;
-  font-weight: 100;
-  letter-spacing: 2px;
-}
-body label.menu h2 {
-  font-size: 11px;
-  opacity: 0.4;
-  margin-bottom: 4px;
-}
-body label.menu h2 .pip {
-  width: 0;
-  height: 9px;
-  background: #fea082;
-  float: left;
-  position: relative;
-  top: 3px;
-  transition: all 0.3s;
-  margin-right: 0px;
-}
-body label.menu h3 {
-  font-size: 8px;
-  letter-spacing: 1px;
-  transition: all 0.3s;
-  opacity: 0.3;
-}
-body label.menu:nth-of-type(1) {
-  top: calc(50vh + 100px + (14px + 34px) * 1 + 0px - 410px);
-}
-body label.menu:nth-of-type(2) {
-  top: calc(50vh + 100px + (14px + 34px) * 2 + 0px - 410px);
-}
-body label.menu:nth-of-type(3) {
-  top: calc(50vh + 100px + (14px + 34px) * 3 + 0px - 410px);
-}
-body label.menu:nth-of-type(4) {
-  top: calc(50vh + 100px + (14px + 34px) * 4 + 0px - 410px);
-}
-body label.menu:nth-of-type(5) {
-  top: calc(50vh + 100px + (14px + 34px) * 5 + 0px - 410px);
-}
-body label.menu:nth-of-type(6) {
-  top: calc(50vh + 100px + (14px + 34px) * 6 + 0px - 410px);
-}
-body label.menu:nth-of-type(7) {
-  top: calc(50vh + 100px + (14px + 34px) * 7 + 0px - 410px);
-}
-body label.menu:nth-of-type(8) {
-  top: calc(50vh + 100px + (14px + 34px) * 8 + 0px - 410px);
-}
-body label.menu:nth-of-type(9) {
-  top: calc(50vh + 100px + (14px + 34px) * 9 + 0px - 410px);
-}
-body label.menu:nth-of-type(10) {
-  top: calc(50vh + 100px + (14px + 34px) * 10 + 0px - 410px);
-}
-body input.read {
-  display: none;
-}
-body .read:checked + label + input + .panel {
-  right: 0;
-}
-body .read:checked + label {
-  width: calc(100% - 420px);
-}
-body .read:checked + label::after {
-  opacity: 1;
-  left: 0;
-}
-body .read:checked + label + label {
-  transition: all 0.3s 0.6s;
-  opacity: 1;
-}
-body .read:not(:checked) + label + label {
-  transition: all 0.3s 0s;
-  opacity: 0;
-}
-body label.close {
-  position: absolute;
-  right: 60px;
-  opacity: 0;
-  transition: all 0.3s 0.4s;
-  z-index: 3;
-  top: 65px;
-}
-body label.closeBig {
-  position: absolute;
-  top: 0;
-  left: 0;
-  z-index: 3;
-  height: 100vh;
-  transition: all 0.2s;
-  z-index: 10;
-  width: 0;
-  background: rgba(56, 37, 99, 0.38);
-}
-body label.closeBig::after {
-  content: "Back";
-  text-align: center;
-  font-size: 30px;
-  color: white;
-  position: absolute;
-  left: -140px;
-  opacity: 0;
-  right: 0;
-  top: 50%;
-  transform: translateY(-50%);
-}
-body .overlay {
-  border-bottom: 1020px solid black;
-  width: 1800px;
-  height: 620px;
-  top: auto;
-  -webkit-transform: none;
-  transform: none;
-  top: -240px;
-  left: -303px;
-  opacity: 1;
-  border-radius: 100%;
-  z-index: 0;
-  box-shadow: 0px -190px 215px 110px black inset;
-}
-body input[type=radio][name=planet] {
-  appearance: none;
-}
-body input[type=radio][name=planet]::after {
-  content: "";
-}
-body input[type=radio][name=planet].planet1:checked::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet1:checked + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(1) {
-  pointer-events: all;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(1) .planet {
-  transform: translateZ(0px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 2;
-  animation: planet 60s 3.9s infinite linear;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(1) .planet_description {
-  opacity: 1;
-  transition: all 0.6s 2.6s;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(1) .planet_description h2,
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(1) .planet_description h1 {
-  position: relative;
-  top: 0px;
-  transition: all 0.5s 3s;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(1) .planet_description p,
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(1) .planet_description a {
-  transition: all 1s 3.5s, padding 0.3s 0s;
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(1) .planet .moon {
-  opacity: 1;
-  transition: all 1s 3.2s;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(1) .planet .trajectory {
-  opacity: 0.2;
-  transition: all 0.6s 2.9s;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(1) .planet .overlay {
-  opacity: 1;
-  top: -240px;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(2) .planet {
-  transform: translateZ(-2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(3) .planet {
-  transform: translateZ(-4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 0;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(4) .planet {
-  transform: translateZ(-6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -1;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(5) .planet {
-  transform: translateZ(-9200px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -2;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(6) .planet {
-  transform: translateZ(-11500px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -3;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(7) .planet {
-  transform: translateZ(-13800px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -4;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(8) .planet {
-  transform: translateZ(-16100px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -5;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(9) .planet {
-  transform: translateZ(-18400px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -6;
-}
-body input[type=radio][name=planet].planet1:checked + label + div .solar_systm:nth-of-type(10) .planet {
-  transform: translateZ(-20700px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -7;
-}
-body input[type=radio][name=planet].planet1:checked + label.sun > .info h3 {
-  color: #ffcc00;
-}
-body input[type=radio][name=planet].planet1:checked + label.mercury > .info h3 {
-  color: #E8927C;
-}
-body input[type=radio][name=planet].planet1:checked + label.venus > .info h3 {
-  color: #b45d15;
-}
-body input[type=radio][name=planet].planet1:checked + label.earth > .info h3 {
-  color: #26daaa;
-}
-body input[type=radio][name=planet].planet1:checked + label.mars > .info h3 {
-  color: #e55f45;
-}
-body input[type=radio][name=planet].planet1:checked + label.jupiter > .info h3 {
-  color: orange;
-}
-body input[type=radio][name=planet].planet1:checked + label.saturn > .info h3 {
-  color: #b29d81;
-}
-body input[type=radio][name=planet].planet1:checked + label.uranus > .info h3 {
-  color: #8dcdd8;
-}
-body input[type=radio][name=planet].planet1:checked + label.neptune > .info h3 {
-  color: #4f83e2;
-}
-body input[type=radio][name=planet].planet1:checked + label.pluto > .info h3 {
-  color: #FF8732;
-}
-body input[type=radio][name=planet].planet1:checked + label {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet1:checked + label:before {
-  display: block;
-  width: 4px;
-  height: 4px;
-  position: absolute;
-  left: 2px;
-  top: 2px;
-  z-index: 2;
-  background: white;
-  border-radius: 4px;
-  content: "";
-}
-body input[type=radio][name=planet].planet1:checked + label > .info h2 {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet1:checked + label > .info h2 .pip {
-  width: 30px;
-  margin-right: 6px;
-}
-body input[type=radio][name=planet].planet1:checked + label > .info h3 {
-  opacity: 1;
-  color: #fea082;
-}
-body input[type=radio][name=planet] {
-  appearance: none;
-}
-body input[type=radio][name=planet]::after {
-  content: "";
-}
-body input[type=radio][name=planet].planet2:checked::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet2:checked + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(2) {
-  pointer-events: all;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(1) .planet {
-  transform: translateZ(2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 3;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(2) .planet {
-  transform: translateZ(0px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 2;
-  animation: planet 60s 3.9s infinite linear;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(2) .planet_description {
-  opacity: 1;
-  transition: all 0.6s 2.6s;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(2) .planet_description h2,
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(2) .planet_description h1 {
-  position: relative;
-  top: 0px;
-  transition: all 0.5s 3s;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(2) .planet_description p,
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(2) .planet_description a {
-  transition: all 1s 3.5s, padding 0.3s 0s;
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(2) .planet .moon {
-  opacity: 1;
-  transition: all 1s 3.2s;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(2) .planet .trajectory {
-  opacity: 0.2;
-  transition: all 0.6s 2.9s;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(2) .planet .overlay {
-  opacity: 1;
-  top: -240px;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(3) .planet {
-  transform: translateZ(-2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(4) .planet {
-  transform: translateZ(-4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 0;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(5) .planet {
-  transform: translateZ(-6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -1;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(6) .planet {
-  transform: translateZ(-9200px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -2;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(7) .planet {
-  transform: translateZ(-11500px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -3;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(8) .planet {
-  transform: translateZ(-13800px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -4;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(9) .planet {
-  transform: translateZ(-16100px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -5;
-}
-body input[type=radio][name=planet].planet2:checked + label + input + label + div .solar_systm:nth-of-type(10) .planet {
-  transform: translateZ(-18400px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -6;
-}
-body input[type=radio][name=planet].planet2:checked + label.sun > .info h3 {
-  color: #ffcc00;
-}
-body input[type=radio][name=planet].planet2:checked + label.mercury > .info h3 {
-  color: #E8927C;
-}
-body input[type=radio][name=planet].planet2:checked + label.venus > .info h3 {
-  color: #b45d15;
-}
-body input[type=radio][name=planet].planet2:checked + label.earth > .info h3 {
-  color: #26daaa;
-}
-body input[type=radio][name=planet].planet2:checked + label.mars > .info h3 {
-  color: #e55f45;
-}
-body input[type=radio][name=planet].planet2:checked + label.jupiter > .info h3 {
-  color: orange;
-}
-body input[type=radio][name=planet].planet2:checked + label.saturn > .info h3 {
-  color: #b29d81;
-}
-body input[type=radio][name=planet].planet2:checked + label.uranus > .info h3 {
-  color: #8dcdd8;
-}
-body input[type=radio][name=planet].planet2:checked + label.neptune > .info h3 {
-  color: #4f83e2;
-}
-body input[type=radio][name=planet].planet2:checked + label.pluto > .info h3 {
-  color: #FF8732;
-}
-body input[type=radio][name=planet].planet2:checked + label {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet2:checked + label:before {
-  display: block;
-  width: 4px;
-  height: 4px;
-  position: absolute;
-  left: 2px;
-  top: 2px;
-  z-index: 2;
-  background: white;
-  border-radius: 4px;
-  content: "";
-}
-body input[type=radio][name=planet].planet2:checked + label > .info h2 {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet2:checked + label > .info h2 .pip {
-  width: 30px;
-  margin-right: 6px;
-}
-body input[type=radio][name=planet].planet2:checked + label > .info h3 {
-  opacity: 1;
-  color: #fea082;
-}
-body input[type=radio][name=planet] {
-  appearance: none;
-}
-body input[type=radio][name=planet]::after {
-  content: "";
-}
-body input[type=radio][name=planet].planet3:checked::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet3:checked + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(3) {
-  pointer-events: all;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(1) .planet {
-  transform: translateZ(4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 4;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(2) .planet {
-  transform: translateZ(2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 3;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet {
-  transform: translateZ(0px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 2;
-  animation: planet 60s 3.9s infinite linear;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet_description {
-  opacity: 1;
-  transition: all 0.6s 2.6s;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet_description h2,
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet_description h1 {
-  position: relative;
-  top: 0px;
-  transition: all 0.5s 3s;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet_description p,
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet_description a {
-  transition: all 1s 3.5s, padding 0.3s 0s;
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet .moon {
-  opacity: 1;
-  transition: all 1s 3.2s;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet .trajectory {
-  opacity: 0.2;
-  transition: all 0.6s 2.9s;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet .overlay {
-  opacity: 1;
-  top: -240px;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet {
-  transform: translateZ(-2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet {
-  transform: translateZ(-4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 0;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet {
-  transform: translateZ(-6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -1;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet {
-  transform: translateZ(-9200px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -2;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet {
-  transform: translateZ(-11500px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -3;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet {
-  transform: translateZ(-13800px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -4;
-}
-body input[type=radio][name=planet].planet3:checked + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet {
-  transform: translateZ(-16100px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -5;
-}
-body input[type=radio][name=planet].planet3:checked + label.sun > .info h3 {
-  color: #ffcc00;
-}
-body input[type=radio][name=planet].planet3:checked + label.mercury > .info h3 {
-  color: #E8927C;
-}
-body input[type=radio][name=planet].planet3:checked + label.venus > .info h3 {
-  color: #b45d15;
-}
-body input[type=radio][name=planet].planet3:checked + label.earth > .info h3 {
-  color: #26daaa;
-}
-body input[type=radio][name=planet].planet3:checked + label.mars > .info h3 {
-  color: #e55f45;
-}
-body input[type=radio][name=planet].planet3:checked + label.jupiter > .info h3 {
-  color: orange;
-}
-body input[type=radio][name=planet].planet3:checked + label.saturn > .info h3 {
-  color: #b29d81;
-}
-body input[type=radio][name=planet].planet3:checked + label.uranus > .info h3 {
-  color: #8dcdd8;
-}
-body input[type=radio][name=planet].planet3:checked + label.neptune > .info h3 {
-  color: #4f83e2;
-}
-body input[type=radio][name=planet].planet3:checked + label.pluto > .info h3 {
-  color: #FF8732;
-}
-body input[type=radio][name=planet].planet3:checked + label {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet3:checked + label:before {
-  display: block;
-  width: 4px;
-  height: 4px;
-  position: absolute;
-  left: 2px;
-  top: 2px;
-  z-index: 2;
-  background: white;
-  border-radius: 4px;
-  content: "";
-}
-body input[type=radio][name=planet].planet3:checked + label > .info h2 {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet3:checked + label > .info h2 .pip {
-  width: 30px;
-  margin-right: 6px;
-}
-body input[type=radio][name=planet].planet3:checked + label > .info h3 {
-  opacity: 1;
-  color: #fea082;
-}
-body input[type=radio][name=planet] {
-  appearance: none;
-}
-body input[type=radio][name=planet]::after {
-  content: "";
-}
-body input[type=radio][name=planet].planet4:checked::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet4:checked + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) {
-  pointer-events: all;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(1) .planet {
-  transform: translateZ(6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 5;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(2) .planet {
-  transform: translateZ(4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 4;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet {
-  transform: translateZ(2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 3;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet {
-  transform: translateZ(0px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 2;
-  animation: planet 60s 3.9s infinite linear;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet_description {
-  opacity: 1;
-  transition: all 0.6s 2.6s;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet_description h2,
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet_description h1 {
-  position: relative;
-  top: 0px;
-  transition: all 0.5s 3s;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet_description p,
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet_description a {
-  transition: all 1s 3.5s, padding 0.3s 0s;
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet .moon {
-  opacity: 1;
-  transition: all 1s 3.2s;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet .trajectory {
-  opacity: 0.2;
-  transition: all 0.6s 2.9s;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet .overlay {
-  opacity: 1;
-  top: -240px;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet {
-  transform: translateZ(-2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet {
-  transform: translateZ(-4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 0;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet {
-  transform: translateZ(-6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -1;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet {
-  transform: translateZ(-9200px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -2;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet {
-  transform: translateZ(-11500px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -3;
-}
-body input[type=radio][name=planet].planet4:checked + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet {
-  transform: translateZ(-13800px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -4;
-}
-body input[type=radio][name=planet].planet4:checked + label.sun > .info h3 {
-  color: #ffcc00;
-}
-body input[type=radio][name=planet].planet4:checked + label.mercury > .info h3 {
-  color: #E8927C;
-}
-body input[type=radio][name=planet].planet4:checked + label.venus > .info h3 {
-  color: #b45d15;
-}
-body input[type=radio][name=planet].planet4:checked + label.earth > .info h3 {
-  color: #26daaa;
-}
-body input[type=radio][name=planet].planet4:checked + label.mars > .info h3 {
-  color: #e55f45;
-}
-body input[type=radio][name=planet].planet4:checked + label.jupiter > .info h3 {
-  color: orange;
-}
-body input[type=radio][name=planet].planet4:checked + label.saturn > .info h3 {
-  color: #b29d81;
-}
-body input[type=radio][name=planet].planet4:checked + label.uranus > .info h3 {
-  color: #8dcdd8;
-}
-body input[type=radio][name=planet].planet4:checked + label.neptune > .info h3 {
-  color: #4f83e2;
-}
-body input[type=radio][name=planet].planet4:checked + label.pluto > .info h3 {
-  color: #FF8732;
-}
-body input[type=radio][name=planet].planet4:checked + label {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet4:checked + label:before {
-  display: block;
-  width: 4px;
-  height: 4px;
-  position: absolute;
-  left: 2px;
-  top: 2px;
-  z-index: 2;
-  background: white;
-  border-radius: 4px;
-  content: "";
-}
-body input[type=radio][name=planet].planet4:checked + label > .info h2 {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet4:checked + label > .info h2 .pip {
-  width: 30px;
-  margin-right: 6px;
-}
-body input[type=radio][name=planet].planet4:checked + label > .info h3 {
-  opacity: 1;
-  color: #fea082;
-}
-body input[type=radio][name=planet] {
-  appearance: none;
-}
-body input[type=radio][name=planet]::after {
-  content: "";
-}
-body input[type=radio][name=planet].planet5:checked::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet5:checked + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) {
-  pointer-events: all;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(1) .planet {
-  transform: translateZ(9200px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 6;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(2) .planet {
-  transform: translateZ(6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 5;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet {
-  transform: translateZ(4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 4;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet {
-  transform: translateZ(2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 3;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet {
-  transform: translateZ(0px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 2;
-  animation: planet 60s 3.9s infinite linear;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet_description {
-  opacity: 1;
-  transition: all 0.6s 2.6s;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet_description h2,
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet_description h1 {
-  position: relative;
-  top: 0px;
-  transition: all 0.5s 3s;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet_description p,
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet_description a {
-  transition: all 1s 3.5s, padding 0.3s 0s;
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet .moon {
-  opacity: 1;
-  transition: all 1s 3.2s;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet .trajectory {
-  opacity: 0.2;
-  transition: all 0.6s 2.9s;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet .overlay {
-  opacity: 1;
-  top: -240px;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet {
-  transform: translateZ(-2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet {
-  transform: translateZ(-4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 0;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet {
-  transform: translateZ(-6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -1;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet {
-  transform: translateZ(-9200px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -2;
-}
-body input[type=radio][name=planet].planet5:checked + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet {
-  transform: translateZ(-11500px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -3;
-}
-body input[type=radio][name=planet].planet5:checked + label.sun > .info h3 {
-  color: #ffcc00;
-}
-body input[type=radio][name=planet].planet5:checked + label.mercury > .info h3 {
-  color: #E8927C;
-}
-body input[type=radio][name=planet].planet5:checked + label.venus > .info h3 {
-  color: #b45d15;
-}
-body input[type=radio][name=planet].planet5:checked + label.earth > .info h3 {
-  color: #26daaa;
-}
-body input[type=radio][name=planet].planet5:checked + label.mars > .info h3 {
-  color: #e55f45;
-}
-body input[type=radio][name=planet].planet5:checked + label.jupiter > .info h3 {
-  color: orange;
-}
-body input[type=radio][name=planet].planet5:checked + label.saturn > .info h3 {
-  color: #b29d81;
-}
-body input[type=radio][name=planet].planet5:checked + label.uranus > .info h3 {
-  color: #8dcdd8;
-}
-body input[type=radio][name=planet].planet5:checked + label.neptune > .info h3 {
-  color: #4f83e2;
-}
-body input[type=radio][name=planet].planet5:checked + label.pluto > .info h3 {
-  color: #FF8732;
-}
-body input[type=radio][name=planet].planet5:checked + label {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet5:checked + label:before {
-  display: block;
-  width: 4px;
-  height: 4px;
-  position: absolute;
-  left: 2px;
-  top: 2px;
-  z-index: 2;
-  background: white;
-  border-radius: 4px;
-  content: "";
-}
-body input[type=radio][name=planet].planet5:checked + label > .info h2 {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet5:checked + label > .info h2 .pip {
-  width: 30px;
-  margin-right: 6px;
-}
-body input[type=radio][name=planet].planet5:checked + label > .info h3 {
-  opacity: 1;
-  color: #fea082;
-}
-body input[type=radio][name=planet] {
-  appearance: none;
-}
-body input[type=radio][name=planet]::after {
-  content: "";
-}
-body input[type=radio][name=planet].planet6:checked::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet6:checked + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) {
-  pointer-events: all;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(1) .planet {
-  transform: translateZ(11500px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 7;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(2) .planet {
-  transform: translateZ(9200px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 6;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet {
-  transform: translateZ(6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 5;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet {
-  transform: translateZ(4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 4;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet {
-  transform: translateZ(2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 3;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet {
-  transform: translateZ(0px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 2;
-  animation: planet 60s 3.9s infinite linear;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet_description {
-  opacity: 1;
-  transition: all 0.6s 2.6s;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet_description h2,
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet_description h1 {
-  position: relative;
-  top: 0px;
-  transition: all 0.5s 3s;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet_description p,
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet_description a {
-  transition: all 1s 3.5s, padding 0.3s 0s;
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet .moon {
-  opacity: 1;
-  transition: all 1s 3.2s;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet .trajectory {
-  opacity: 0.2;
-  transition: all 0.6s 2.9s;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet .overlay {
-  opacity: 1;
-  top: -240px;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet {
-  transform: translateZ(-2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet {
-  transform: translateZ(-4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 0;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet {
-  transform: translateZ(-6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -1;
-}
-body input[type=radio][name=planet].planet6:checked + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet {
-  transform: translateZ(-9200px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -2;
-}
-body input[type=radio][name=planet].planet6:checked + label.sun > .info h3 {
-  color: #ffcc00;
-}
-body input[type=radio][name=planet].planet6:checked + label.mercury > .info h3 {
-  color: #E8927C;
-}
-body input[type=radio][name=planet].planet6:checked + label.venus > .info h3 {
-  color: #b45d15;
-}
-body input[type=radio][name=planet].planet6:checked + label.earth > .info h3 {
-  color: #26daaa;
-}
-body input[type=radio][name=planet].planet6:checked + label.mars > .info h3 {
-  color: #e55f45;
-}
-body input[type=radio][name=planet].planet6:checked + label.jupiter > .info h3 {
-  color: orange;
-}
-body input[type=radio][name=planet].planet6:checked + label.saturn > .info h3 {
-  color: #b29d81;
-}
-body input[type=radio][name=planet].planet6:checked + label.uranus > .info h3 {
-  color: #8dcdd8;
-}
-body input[type=radio][name=planet].planet6:checked + label.neptune > .info h3 {
-  color: #4f83e2;
-}
-body input[type=radio][name=planet].planet6:checked + label.pluto > .info h3 {
-  color: #FF8732;
-}
-body input[type=radio][name=planet].planet6:checked + label {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet6:checked + label:before {
-  display: block;
-  width: 4px;
-  height: 4px;
-  position: absolute;
-  left: 2px;
-  top: 2px;
-  z-index: 2;
-  background: white;
-  border-radius: 4px;
-  content: "";
-}
-body input[type=radio][name=planet].planet6:checked + label > .info h2 {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet6:checked + label > .info h2 .pip {
-  width: 30px;
-  margin-right: 6px;
-}
-body input[type=radio][name=planet].planet6:checked + label > .info h3 {
-  opacity: 1;
-  color: #fea082;
-}
-body input[type=radio][name=planet] {
-  appearance: none;
-}
-body input[type=radio][name=planet]::after {
-  content: "";
-}
-body input[type=radio][name=planet].planet7:checked::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet7:checked + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) {
-  pointer-events: all;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(1) .planet {
-  transform: translateZ(13800px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 8;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(2) .planet {
-  transform: translateZ(11500px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 7;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet {
-  transform: translateZ(9200px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 6;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet {
-  transform: translateZ(6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 5;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet {
-  transform: translateZ(4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 4;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet {
-  transform: translateZ(2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 3;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet {
-  transform: translateZ(0px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 2;
-  animation: planet 60s 3.9s infinite linear;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet_description {
-  opacity: 1;
-  transition: all 0.6s 2.6s;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet_description h2,
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet_description h1 {
-  position: relative;
-  top: 0px;
-  transition: all 0.5s 3s;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet_description p,
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet_description a {
-  transition: all 1s 3.5s, padding 0.3s 0s;
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet .moon {
-  opacity: 1;
-  transition: all 1s 3.2s;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet .trajectory {
-  opacity: 0.2;
-  transition: all 0.6s 2.9s;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet .overlay {
-  opacity: 1;
-  top: -240px;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet {
-  transform: translateZ(-2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet {
-  transform: translateZ(-4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 0;
-}
-body input[type=radio][name=planet].planet7:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet {
-  transform: translateZ(-6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: -1;
-}
-body input[type=radio][name=planet].planet7:checked + label.sun > .info h3 {
-  color: #ffcc00;
-}
-body input[type=radio][name=planet].planet7:checked + label.mercury > .info h3 {
-  color: #E8927C;
-}
-body input[type=radio][name=planet].planet7:checked + label.venus > .info h3 {
-  color: #b45d15;
-}
-body input[type=radio][name=planet].planet7:checked + label.earth > .info h3 {
-  color: #26daaa;
-}
-body input[type=radio][name=planet].planet7:checked + label.mars > .info h3 {
-  color: #e55f45;
-}
-body input[type=radio][name=planet].planet7:checked + label.jupiter > .info h3 {
-  color: orange;
-}
-body input[type=radio][name=planet].planet7:checked + label.saturn > .info h3 {
-  color: #b29d81;
-}
-body input[type=radio][name=planet].planet7:checked + label.uranus > .info h3 {
-  color: #8dcdd8;
-}
-body input[type=radio][name=planet].planet7:checked + label.neptune > .info h3 {
-  color: #4f83e2;
-}
-body input[type=radio][name=planet].planet7:checked + label.pluto > .info h3 {
-  color: #FF8732;
-}
-body input[type=radio][name=planet].planet7:checked + label {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet7:checked + label:before {
-  display: block;
-  width: 4px;
-  height: 4px;
-  position: absolute;
-  left: 2px;
-  top: 2px;
-  z-index: 2;
-  background: white;
-  border-radius: 4px;
-  content: "";
-}
-body input[type=radio][name=planet].planet7:checked + label > .info h2 {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet7:checked + label > .info h2 .pip {
-  width: 30px;
-  margin-right: 6px;
-}
-body input[type=radio][name=planet].planet7:checked + label > .info h3 {
-  opacity: 1;
-  color: #fea082;
-}
-body input[type=radio][name=planet] {
-  appearance: none;
-}
-body input[type=radio][name=planet]::after {
-  content: "";
-}
-body input[type=radio][name=planet].planet8:checked::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet8:checked + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) {
-  pointer-events: all;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(1) .planet {
-  transform: translateZ(16100px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 9;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(2) .planet {
-  transform: translateZ(13800px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 8;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet {
-  transform: translateZ(11500px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 7;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet {
-  transform: translateZ(9200px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 6;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet {
-  transform: translateZ(6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 5;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet {
-  transform: translateZ(4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 4;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet {
-  transform: translateZ(2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 3;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet {
-  transform: translateZ(0px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 2;
-  animation: planet 60s 3.9s infinite linear;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet_description {
-  opacity: 1;
-  transition: all 0.6s 2.6s;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet_description h2,
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet_description h1 {
-  position: relative;
-  top: 0px;
-  transition: all 0.5s 3s;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet_description p,
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet_description a {
-  transition: all 1s 3.5s, padding 0.3s 0s;
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet .moon {
-  opacity: 1;
-  transition: all 1s 3.2s;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet .trajectory {
-  opacity: 0.2;
-  transition: all 0.6s 2.9s;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet .overlay {
-  opacity: 1;
-  top: -240px;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet {
-  transform: translateZ(-2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet8:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet {
-  transform: translateZ(-4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 0;
-}
-body input[type=radio][name=planet].planet8:checked + label.sun > .info h3 {
-  color: #ffcc00;
-}
-body input[type=radio][name=planet].planet8:checked + label.mercury > .info h3 {
-  color: #E8927C;
-}
-body input[type=radio][name=planet].planet8:checked + label.venus > .info h3 {
-  color: #b45d15;
-}
-body input[type=radio][name=planet].planet8:checked + label.earth > .info h3 {
-  color: #26daaa;
-}
-body input[type=radio][name=planet].planet8:checked + label.mars > .info h3 {
-  color: #e55f45;
-}
-body input[type=radio][name=planet].planet8:checked + label.jupiter > .info h3 {
-  color: orange;
-}
-body input[type=radio][name=planet].planet8:checked + label.saturn > .info h3 {
-  color: #b29d81;
-}
-body input[type=radio][name=planet].planet8:checked + label.uranus > .info h3 {
-  color: #8dcdd8;
-}
-body input[type=radio][name=planet].planet8:checked + label.neptune > .info h3 {
-  color: #4f83e2;
-}
-body input[type=radio][name=planet].planet8:checked + label.pluto > .info h3 {
-  color: #FF8732;
-}
-body input[type=radio][name=planet].planet8:checked + label {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet8:checked + label:before {
-  display: block;
-  width: 4px;
-  height: 4px;
-  position: absolute;
-  left: 2px;
-  top: 2px;
-  z-index: 2;
-  background: white;
-  border-radius: 4px;
-  content: "";
-}
-body input[type=radio][name=planet].planet8:checked + label > .info h2 {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet8:checked + label > .info h2 .pip {
-  width: 30px;
-  margin-right: 6px;
-}
-body input[type=radio][name=planet].planet8:checked + label > .info h3 {
-  opacity: 1;
-  color: #fea082;
-}
-body input[type=radio][name=planet] {
-  appearance: none;
-}
-body input[type=radio][name=planet]::after {
-  content: "";
-}
-body input[type=radio][name=planet].planet9:checked::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet9:checked + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) {
-  pointer-events: all;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(1) .planet {
-  transform: translateZ(18400px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 10;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(2) .planet {
-  transform: translateZ(16100px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 9;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet {
-  transform: translateZ(13800px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 8;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet {
-  transform: translateZ(11500px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 7;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet {
-  transform: translateZ(9200px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 6;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet {
-  transform: translateZ(6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 5;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet {
-  transform: translateZ(4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 4;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet {
-  transform: translateZ(2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 3;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet {
-  transform: translateZ(0px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 2;
-  animation: planet 60s 3.9s infinite linear;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet_description {
-  opacity: 1;
-  transition: all 0.6s 2.6s;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet_description h2,
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet_description h1 {
-  position: relative;
-  top: 0px;
-  transition: all 0.5s 3s;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet_description p,
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet_description a {
-  transition: all 1s 3.5s, padding 0.3s 0s;
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet .moon {
-  opacity: 1;
-  transition: all 1s 3.2s;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet .trajectory {
-  opacity: 0.2;
-  transition: all 0.6s 2.9s;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet .overlay {
-  opacity: 1;
-  top: -240px;
-}
-body input[type=radio][name=planet].planet9:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet {
-  transform: translateZ(-2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet9:checked + label.sun > .info h3 {
-  color: #ffcc00;
-}
-body input[type=radio][name=planet].planet9:checked + label.mercury > .info h3 {
-  color: #E8927C;
-}
-body input[type=radio][name=planet].planet9:checked + label.venus > .info h3 {
-  color: #b45d15;
-}
-body input[type=radio][name=planet].planet9:checked + label.earth > .info h3 {
-  color: #26daaa;
-}
-body input[type=radio][name=planet].planet9:checked + label.mars > .info h3 {
-  color: #e55f45;
-}
-body input[type=radio][name=planet].planet9:checked + label.jupiter > .info h3 {
-  color: orange;
-}
-body input[type=radio][name=planet].planet9:checked + label.saturn > .info h3 {
-  color: #b29d81;
-}
-body input[type=radio][name=planet].planet9:checked + label.uranus > .info h3 {
-  color: #8dcdd8;
-}
-body input[type=radio][name=planet].planet9:checked + label.neptune > .info h3 {
-  color: #4f83e2;
-}
-body input[type=radio][name=planet].planet9:checked + label.pluto > .info h3 {
-  color: #FF8732;
-}
-body input[type=radio][name=planet].planet9:checked + label {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet9:checked + label:before {
-  display: block;
-  width: 4px;
-  height: 4px;
-  position: absolute;
-  left: 2px;
-  top: 2px;
-  z-index: 2;
-  background: white;
-  border-radius: 4px;
-  content: "";
-}
-body input[type=radio][name=planet].planet9:checked + label > .info h2 {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet9:checked + label > .info h2 .pip {
-  width: 30px;
-  margin-right: 6px;
-}
-body input[type=radio][name=planet].planet9:checked + label > .info h3 {
-  opacity: 1;
-  color: #fea082;
-}
-body input[type=radio][name=planet] {
-  appearance: none;
-}
-body input[type=radio][name=planet]::after {
-  content: "";
-}
-body input[type=radio][name=planet].planet10:checked::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet10:checked + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input::after {
-  display: none;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) {
-  pointer-events: all;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(1) .planet {
-  transform: translateZ(20700px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 11;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(2) .planet {
-  transform: translateZ(18400px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 10;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(3) .planet {
-  transform: translateZ(16100px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 9;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(4) .planet {
-  transform: translateZ(13800px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 8;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(5) .planet {
-  transform: translateZ(11500px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 7;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(6) .planet {
-  transform: translateZ(9200px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 6;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(7) .planet {
-  transform: translateZ(6900px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 5;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(8) .planet {
-  transform: translateZ(4600px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 4;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(9) .planet {
-  transform: translateZ(2300px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 3;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet {
-  transform: translateZ(0px) translateY(0) rotatex(4deg) scaleX(0.89);
-  opacity: 2;
-  animation: planet 60s 3.9s infinite linear;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet_description {
-  opacity: 1;
-  transition: all 0.6s 2.6s;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet_description h2,
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet_description h1 {
-  position: relative;
-  top: 0px;
-  transition: all 0.5s 3s;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet_description p,
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet_description a {
-  transition: all 1s 3.5s, padding 0.3s 0s;
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet .moon {
-  opacity: 1;
-  transition: all 1s 3.2s;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet .trajectory {
-  opacity: 0.2;
-  transition: all 0.6s 2.9s;
-}
-body input[type=radio][name=planet].planet10:checked + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + input + label + div .solar_systm:nth-of-type(10) .planet .overlay {
-  opacity: 1;
-  top: -240px;
-}
-body input[type=radio][name=planet].planet10:checked + label.sun > .info h3 {
-  color: #ffcc00;
-}
-body input[type=radio][name=planet].planet10:checked + label.mercury > .info h3 {
-  color: #E8927C;
-}
-body input[type=radio][name=planet].planet10:checked + label.venus > .info h3 {
-  color: #b45d15;
-}
-body input[type=radio][name=planet].planet10:checked + label.earth > .info h3 {
-  color: #26daaa;
-}
-body input[type=radio][name=planet].planet10:checked + label.mars > .info h3 {
-  color: #e55f45;
-}
-body input[type=radio][name=planet].planet10:checked + label.jupiter > .info h3 {
-  color: orange;
-}
-body input[type=radio][name=planet].planet10:checked + label.saturn > .info h3 {
-  color: #b29d81;
-}
-body input[type=radio][name=planet].planet10:checked + label.uranus > .info h3 {
-  color: #8dcdd8;
-}
-body input[type=radio][name=planet].planet10:checked + label.neptune > .info h3 {
-  color: #4f83e2;
-}
-body input[type=radio][name=planet].planet10:checked + label.pluto > .info h3 {
-  color: #FF8732;
-}
-body input[type=radio][name=planet].planet10:checked + label {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet10:checked + label:before {
-  display: block;
-  width: 4px;
-  height: 4px;
-  position: absolute;
-  left: 2px;
-  top: 2px;
-  z-index: 2;
-  background: white;
-  border-radius: 4px;
-  content: "";
-}
-body input[type=radio][name=planet].planet10:checked + label > .info h2 {
-  opacity: 1;
-}
-body input[type=radio][name=planet].planet10:checked + label > .info h2 .pip {
-  width: 30px;
-  margin-right: 6px;
-}
-body input[type=radio][name=planet].planet10:checked + label > .info h3 {
-  opacity: 1;
-  color: #fea082;
-}
-body .solar_systm:nth-of-type(1) .planet {
-  transform: translateZ(0px) translateY(0) rotatex(4deg) scalex(0.89);
-  opacity: 2;
-}
-body .solar_systm:nth-of-type(1) .planet_description {
-  opacity: 1;
-}
-body .solar_systm:nth-of-type(1) .planet_description p,
-body .solar_systm:nth-of-type(1) .planet_description a {
-  opacity: 0;
-}
-body .solar_systm:nth-of-type(1) .planet_description h1,
-body .solar_systm:nth-of-type(1) .planet_description h2 {
-  position: relative;
-  top: -330px;
-  transition: all 0.5s 0s;
-}
-body .solar_systm:nth-of-type(2) .planet {
-  transform: translateZ(-2300px) translateY(0) rotatex(4deg) scalex(0.89);
-  opacity: 1;
-}
-body .solar_systm:nth-of-type(2) .planet_description {
-  opacity: 1;
-}
-body .solar_systm:nth-of-type(2) .planet_description p,
-body .solar_systm:nth-of-type(2) .planet_description a {
-  opacity: 0;
-}
-body .solar_systm:nth-of-type(2) .planet_description h1,
-body .solar_systm:nth-of-type(2) .planet_description h2 {
-  position: relative;
-  top: -330px;
-  transition: all 0.5s 0s;
-}
-body .solar_systm:nth-of-type(3) .planet {
-  transform: translateZ(-4600px) translateY(0) rotatex(4deg) scalex(0.89);
-  opacity: 0;
-}
-body .solar_systm:nth-of-type(3) .planet_description {
-  opacity: 1;
-}
-body .solar_systm:nth-of-type(3) .planet_description p,
-body .solar_systm:nth-of-type(3) .planet_description a {
-  opacity: 0;
-}
-body .solar_systm:nth-of-type(3) .planet_description h1,
-body .solar_systm:nth-of-type(3) .planet_description h2 {
-  position: relative;
-  top: -330px;
-  transition: all 0.5s 0s;
-}
-body .solar_systm:nth-of-type(4) .planet {
-  transform: translateZ(-6900px) translateY(0) rotatex(4deg) scalex(0.89);
-  opacity: -1;
-}
-body .solar_systm:nth-of-type(4) .planet_description {
-  opacity: 1;
-}
-body .solar_systm:nth-of-type(4) .planet_description p,
-body .solar_systm:nth-of-type(4) .planet_description a {
-  opacity: 0;
-}
-body .solar_systm:nth-of-type(4) .planet_description h1,
-body .solar_systm:nth-of-type(4) .planet_description h2 {
-  position: relative;
-  top: -330px;
-  transition: all 0.5s 0s;
-}
-body .solar_systm:nth-of-type(5) .planet {
-  transform: translateZ(-9200px) translateY(0) rotatex(4deg) scalex(0.89);
-  opacity: -2;
-}
-body .solar_systm:nth-of-type(5) .planet_description {
-  opacity: 1;
-}
-body .solar_systm:nth-of-type(5) .planet_description p,
-body .solar_systm:nth-of-type(5) .planet_description a {
-  opacity: 0;
-}
-body .solar_systm:nth-of-type(5) .planet_description h1,
-body .solar_systm:nth-of-type(5) .planet_description h2 {
-  position: relative;
-  top: -330px;
-  transition: all 0.5s 0s;
-}
-body .solar_systm:nth-of-type(6) .planet {
-  transform: translateZ(-11500px) translateY(0) rotatex(4deg) scalex(0.89);
-  opacity: -3;
-}
-body .solar_systm:nth-of-type(6) .planet_description {
-  opacity: 1;
-}
-body .solar_systm:nth-of-type(6) .planet_description p,
-body .solar_systm:nth-of-type(6) .planet_description a {
-  opacity: 0;
-}
-body .solar_systm:nth-of-type(6) .planet_description h1,
-body .solar_systm:nth-of-type(6) .planet_description h2 {
-  position: relative;
-  top: -330px;
-  transition: all 0.5s 0s;
-}
-body .solar_systm:nth-of-type(7) .planet {
-  transform: translateZ(-13800px) translateY(0) rotatex(4deg) scalex(0.89);
-  opacity: -4;
-}
-body .solar_systm:nth-of-type(7) .planet_description {
-  opacity: 1;
-}
-body .solar_systm:nth-of-type(7) .planet_description p,
-body .solar_systm:nth-of-type(7) .planet_description a {
-  opacity: 0;
-}
-body .solar_systm:nth-of-type(7) .planet_description h1,
-body .solar_systm:nth-of-type(7) .planet_description h2 {
-  position: relative;
-  top: -330px;
-  transition: all 0.5s 0s;
-}
-body .solar_systm:nth-of-type(8) .planet {
-  transform: translateZ(-16100px) translateY(0) rotatex(4deg) scalex(0.89);
-  opacity: -5;
-}
-body .solar_systm:nth-of-type(8) .planet_description {
-  opacity: 1;
-}
-body .solar_systm:nth-of-type(8) .planet_description p,
-body .solar_systm:nth-of-type(8) .planet_description a {
-  opacity: 0;
-}
-body .solar_systm:nth-of-type(8) .planet_description h1,
-body .solar_systm:nth-of-type(8) .planet_description h2 {
-  position: relative;
-  top: -330px;
-  transition: all 0.5s 0s;
-}
-body .solar_systm:nth-of-type(9) .planet {
-  transform: translateZ(-18400px) translateY(0) rotatex(4deg) scalex(0.89);
-  opacity: -6;
-}
-body .solar_systm:nth-of-type(9) .planet_description {
-  opacity: 1;
-}
-body .solar_systm:nth-of-type(9) .planet_description p,
-body .solar_systm:nth-of-type(9) .planet_description a {
-  opacity: 0;
-}
-body .solar_systm:nth-of-type(9) .planet_description h1,
-body .solar_systm:nth-of-type(9) .planet_description h2 {
-  position: relative;
-  top: -330px;
-  transition: all 0.5s 0s;
-}
-body .solar_systm:nth-of-type(10) .planet {
-  transform: translateZ(-20700px) translateY(0) rotatex(4deg) scalex(0.89);
-  opacity: -7;
-}
-body .solar_systm:nth-of-type(10) .planet_description {
-  opacity: 1;
-}
-body .solar_systm:nth-of-type(10) .planet_description p,
-body .solar_systm:nth-of-type(10) .planet_description a {
-  opacity: 0;
-}
-body .solar_systm:nth-of-type(10) .planet_description h1,
-body .solar_systm:nth-of-type(10) .planet_description h2 {
-  position: relative;
-  top: -330px;
-  transition: all 0.5s 0s;
-}
-body .solar_systm .planet .trajectory {
-  transition: all 0.6s 0s;
-  opacity: 0;
-}
-body .solar_systm .planet.sun {
-  background: url("https://www.solarsystemscope.com/images/textures/full/2k_sun.jpg");
-  box-shadow: 0 -590px 150px black inset, 0 0px 130px 40px rgba(255, 150, 0, 0.8) inset, 0 0px 23px 4px rgba(255, 150, 0, 0.8) inset, 0 -10px 130px rgba(255, 200, 0, 0.6);
-}
-body .solar_systm .planet.sun .overlay {
-  display: none;
-}
-body .solar_systm .planet.mercury {
-  background: url("https://www.solarsystemscope.com/images/textures/full/2k_makemake_fictional.jpg");
-  box-shadow: 0 -590px 150px black inset, 0 0px 130px 40px rgba(234, 205, 199, 0.6) inset, 0 0px 23px 4px rgba(234, 205, 199, 0.6) inset, 0 -10px 130px rgba(188, 143, 127, 0.6);
-}
-body .solar_systm .planet.venus {
-  background: url("https://nasa3d.arc.nasa.gov/shared_assets/images/ven0aaa2/ven0aaa2-copy-428-321.jpg");
-  box-shadow: 0 -590px 150px black inset, 0 0px 130px 40px #ffcb9c inset, 0 0px 23px 4px #ffcb9c inset, 0 -10px 130px #b85a07;
-}
-body .solar_systm .planet.earth {
-  background: url("https://img00.deviantart.net/04ef/i/2009/114/3/e/new_earth_texture_map_by_lightondesigns.jpg");
-  box-shadow: 0 -590px 150px black inset, 0 0px 130px 40px #8cbaff inset, 0 0px 23px 4px #8cbaff inset, 0 -10px 130px #7894a9;
-}
-body .solar_systm .planet.earth .trajectory.m {
-  width: 1500px;
-  height: 1500px;
-  left: -150px;
-  top: -110px;
-}
-body .solar_systm .planet.earth .moon {
-  left: 800px;
-  top: -160px;
-  transform: scale(0.45);
-  background: url("https://img2.cgtrader.com/items/702173/682fad2a11/92k-moon-color-map-3d-model.jpg");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.earth .moon h3 {
-  color: #26daaa;
-}
-body .solar_systm .planet.mars {
-  background: url("https://s3-us-west-2.amazonaws.com/s.cdpn.io/217233/mars_texture.jpg");
-  box-shadow: 0 -590px 150px black inset, 0 0px 130px 40px #e86363 inset, 0 0px 23px 4px #e86363 inset, 0 -10px 130px #6b261a;
-}
-body .solar_systm .planet.mars .moon h3 {
-  color: #e55f45;
-}
-body .solar_systm .planet.mars .deimos {
-  left: 900px;
-  top: -100px;
-  transform: scale(0.45);
-  background: url("https://www.jpl.nasa.gov/spaceimages/images/largesize/PIA07782_hires.jpg");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.mars .trajectory.d {
-  width: 1770px;
-  height: 1770px;
-  left: -317px;
-  top: -110px;
-}
-body .solar_systm .planet.mars .trajectory.p {
-  width: 1600px;
-  height: 1600px;
-  left: -200px;
-  top: -160px;
-}
-body .solar_systm .planet.mars .phoebos {
-  left: 100px;
-  top: -160px;
-  transform: scale(0.5);
-  background: url("https://www.jpl.nasa.gov/spaceimages/images/largesize/PIA07782_hires.jpg");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.jupiter .moon h3 {
-  color: orange;
-}
-body .solar_systm .planet.jupiter .trajectory.lop {
-  width: 1500px;
-  height: 1500px;
-  left: -210px;
-  top: -189px;
-}
-body .solar_systm .planet.jupiter .trajectory.eu {
-  width: 1530px;
-  height: 1530px;
-  left: -165px;
-  top: -130px;
-}
-body .solar_systm .planet.jupiter .trajectory.ga {
-  width: 1760px;
-  height: 1760px;
-  left: -360px;
-  top: -114px;
-}
-body .solar_systm .planet.jupiter {
-  background: url("https://www.jpl.nasa.gov/spaceimages/images/largesize/PIA07782_hires.jpg");
-  box-shadow: 0 -590px 150px black inset, 0 0px 130px 40px rgba(234, 205, 199, 0.6) inset, 0 0px 23px 4px rgba(234, 205, 199, 0.6) inset, 0 -10px 130px rgba(188, 143, 127, 0.6);
-}
-body .solar_systm .planet.jupiter .lo {
-  left: 100px;
-  top: -100px;
-  transform: scale(0.4);
-  background: url("http://stevealbers.net/albers/sos/jupiter/io/io_rgb_cyl.jpg");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.jupiter .europa {
-  left: 400px;
-  top: -210px;
-  transform: scale(0.45);
-  background: url("http://i.imgur.com/ZZBiHOH.jpg");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.jupiter .ganymede {
-  left: 900px;
-  top: -70px;
-  transform: scale(0.4);
-  background: url("https://vignette.wikia.nocookie.net/planet-texture-maps/images/1/14/Ganymede.jpg/revision/latest?cb=20180104001948");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.saturn .moon h3 {
-  color: #b29d81;
-}
-body .solar_systm .planet.saturn {
-  background: url("https://www.solarsystemscope.com/images/textures/full/2k_saturn.jpg");
-  box-shadow: 0 -590px 150px black inset, 0 0px 130px 40px rgba(234, 205, 199, 0.6) inset, 0 0px 23px 4px rgba(234, 205, 199, 0.6) inset, 0 -10px 130px rgba(188, 143, 127, 0.6);
-}
-body .solar_systm .planet.saturn .trajectory.ti {
-  width: 1500px;
-  height: 1500px;
-  left: -210px;
-  top: -189px;
-}
-body .solar_systm .planet.saturn .trajectory.di {
-  width: 1530px;
-  height: 1530px;
-  left: -165px;
-  top: -130px;
-}
-body .solar_systm .planet.saturn .trajectory.enc {
-  width: 1760px;
-  height: 1760px;
-  left: -360px;
-  top: -114px;
-}
-body .solar_systm .planet.saturn .titan {
-  left: 100px;
-  top: -100px;
-  transform: scale(0.4);
-  background: url("https://pre00.deviantart.net/bea3/th/pre/i/2017/057/7/f/titan_texture_map_8k_by_fargetanik-db0f8m0.png");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.saturn .dione {
-  left: 400px;
-  top: -210px;
-  transform: scale(0.45);
-  background: url("https://www.jpl.nasa.gov/spaceimages/images/wallpaper/PIA12577-640x350.jpg");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.saturn .enceladus {
-  left: 900px;
-  top: -70px;
-  transform: scale(0.4);
-  background: url("https://img.purch.com/w/660/aHR0cDovL3d3dy5zcGFjZS5jb20vaW1hZ2VzL2kvMDAwLzA0NC8yMzkvb3JpZ2luYWwvZW5jZWxhZHVzLW1hcC1jYXNzaW5pLmpwZw==");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.uranus .moon h3 {
-  color: #8dcdd8;
-}
-body .solar_systm .planet.uranus .trajectory.mir {
-  width: 1500px;
-  height: 1500px;
-  left: -210px;
-  top: -189px;
-}
-body .solar_systm .planet.uranus .trajectory.ari {
-  width: 1530px;
-  height: 1530px;
-  left: -165px;
-  top: -130px;
-}
-body .solar_systm .planet.uranus .trajectory.umb {
-  width: 1760px;
-  height: 1760px;
-  left: -360px;
-  top: -114px;
-}
-body .solar_systm .planet.uranus .miranda {
-  left: 100px;
-  top: -100px;
-  transform: scale(0.4);
-  background: url("http://celestia.simulatorlabbs.com/CelSL/textures/medres/miranda.jpg");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.uranus .ariel {
-  left: 400px;
-  top: -210px;
-  transform: scale(0.45);
-  background: url("http://celestia.freedoors.org/Celestia-Doors/textures/medres/ariel.jpg");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.uranus .umbriel {
-  left: 900px;
-  top: -70px;
-  transform: scale(0.4);
-  background: url("http://celestia.freedoors.org/Celestia-Doors/textures/medres/titania.jpg");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.uranus {
-  background: url("https://img00.deviantart.net/957c/i/2017/165/4/9/uranus_texture_map_by_jcpag2010-db7yjwb.png");
-  box-shadow: 0 -590px 150px black inset, 0 0px 130px 40px rgba(234, 205, 199, 0.6) inset, 0 0px 23px 4px rgba(234, 205, 199, 0.6) inset, 0 -10px 130px rgba(127, 188, 171, 0.6);
-}
-body .solar_systm .planet.neptune .moon h3 {
-  color: #4f83e2;
-}
-body .solar_systm .planet.neptune .trajectory.tri {
-  width: 1500px;
-  height: 1500px;
-  left: -210px;
-  top: -189px;
-}
-body .solar_systm .planet.neptune .trajectory.pro {
-  width: 1530px;
-  height: 1530px;
-  left: -165px;
-  top: -130px;
-}
-body .solar_systm .planet.neptune .trajectory.ner {
-  width: 1760px;
-  height: 1760px;
-  left: -360px;
-  top: -114px;
-}
-body .solar_systm .planet.neptune .triton {
-  left: 100px;
-  top: -100px;
-  transform: scale(0.4);
-  background: url("https://img00.deviantart.net/b934/i/2016/198/b/0/triton_texture_map_14k_by_fargetanik-daac9tm.png");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.neptune .proteus {
-  left: 400px;
-  top: -210px;
-  transform: scale(0.45);
-  background: url("http://2.bp.blogspot.com/-NrsDNbSk8TU/VKmLHdOgw0I/AAAAAAAAHvY/dod1Kqv2Ta8/s1600/NereidTxt2.jpg");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.neptune .nereid {
-  left: 900px;
-  top: -70px;
-  transform: scale(0.4);
-  background: url("http://4.bp.blogspot.com/-3eyaVs4az74/VKmMpLo6FYI/AAAAAAAAHvs/zK5NTllQYnk/s1600/NereidTxt.jpg");
-  z-index: -1;
-  box-shadow: 0px -30px 30px 10px black inset;
-}
-body .solar_systm .planet.neptune {
-  background: url("https://www.solarsystemscope.com/images/textures/full/2k_neptune.jpg");
-  box-shadow: 0 -590px 150px black inset, 0 0px 130px 40px rgba(234, 205, 199, 0.6) inset, 0 0px 23px 4px rgba(234, 205, 199, 0.6) inset, 0 -10px 130px rgb(45, 65, 83);
-}
-body .solar_systm .planet.pluto {
-  background: url("https://pre00.deviantart.net/4677/th/pre/f/2015/314/4/e/pluto_map__2015_nov_10__by_snowfall_the_cat-d918tlb.png");
-  box-shadow: 0 -590px 150px black inset, 0 0px 130px 40px rgba(234, 205, 199, 0.6) inset, 0 0px 23px 4px rgba(234, 205, 199, 0.6) inset, 0 -10px 130px rgb(45, 65, 83);
-}
-body .solar_systm .planet_description {
-  width: 620px;
-  text-align: center;
-  position: absolute;
-  margin: auto;
-  left: 0;
-  z-index: 2;
-  right: 0;
-  color: white;
-  font-weight: 100;
-  transition: all 0.4s 0s;
-  text-transform: uppercase;
-  z-index: 1;
-}
-body .solar_systm .planet_description.mercury a {
-  color: #E8927C;
-}
-body .solar_systm .planet_description.mercury h2 {
-  color: rgb(247.2337662338, 218.1948051948, 210.7662337662);
-}
-body .solar_systm .planet_description.venus a {
-  color: #b45d15;
-}
-body .solar_systm .planet_description.venus h2 {
-  color: rgb(233.3731343284, 143.776119403, 69.6268656716);
-}
-body .solar_systm .planet_description.earth a {
-  color: #26daaa;
-}
-body .solar_systm .planet_description.earth h2 {
-  color: rgb(125.1417322835, 232.8582677165, 204.1338582677);
-}
-body .solar_systm .planet_description.mars a {
-  color: #e55f45;
-}
-body .solar_systm .planet_description.mars h2 {
-  color: rgb(241.5094339623, 171.9811320755, 158.4905660377);
-}
-body .solar_systm .planet_description.jupiter a {
-  color: orange;
-}
-body .solar_systm .planet_description.jupiter h2 {
-  color: #ffc966;
-}
-body .solar_systm .planet_description.saturn a {
-  color: #b29d81;
-}
-body .solar_systm .planet_description.saturn h2 {
-  color: rgb(216.6896551724, 206.2413793103, 192.3103448276);
-}
-body .solar_systm .planet_description.uranus a {
-  color: #8dcdd8;
-}
-body .solar_systm .planet_description.uranus h2 {
-  color: rgb(217, 238.3333333333, 242);
-}
-body .solar_systm .planet_description.neptune a {
-  color: #4f83e2;
-}
-body .solar_systm .planet_description.neptune h2 {
-  color: rgb(166.5707317073, 192.6975609756, 240.4292682927);
-}
-body .solar_systm .planet_description.pluto a {
-  color: #FF8732;
-}
-body .solar_systm .planet_description.pluto h2 {
-  color: rgb(255, 194.7073170732, 152);
-}
-body .solar_systm .planet_description h1,
-body .solar_systm .planet_description h2,
-body .solar_systm .planet_description p,
-body .solar_systm .planet_description a {
-  font-weight: 100;
-  font-size: 10px;
-  letter-spacing: 5px;
-  margin: 0;
-}
-body .solar_systm .planet_description h1 {
-  letter-spacing: 16px;
-  font-size: 34px;
-}
-body .solar_systm .planet_description h2,
-body .solar_systm .planet_description a {
-  color: #fabfad;
-}
-body .solar_systm .planet_description h2 {
-  margin-top: 60px;
-  margin-bottom: 6px;
-}
-body .solar_systm .planet_description p {
-  line-height: 26px;
-  margin-top: 14px;
-  oapcity: 0.9;
-  margin-bottom: 10px;
-}
-body .solar_systm .planet_description a {
-  color: #fea082;
-  font-size: 11px;
-  font-weight: 500;
-  padding: 0 2px 5px 0px;
-  border-bottom: 2px solid;
-  transition: all 0.2s;
-  position: relative;
-  left: 0;
-}
-body .solar_systm .planet_description a:hover {
-  padding: 0 10px 5px 10px;
-  left: -1px;
-}
-body .solar_systm .planet_description a span {
-  letter-spacing: 0;
-  margin-left: -5px;
-}
-body .panel {
-  position: absolute;
-  right: -520px;
-  width: 300px;
-  top: 0;
-  height: 100vh;
-  transition: all 0.2s;
-  color: black;
-  background: white;
-  padding: 10px 60px 0px 60px;
-  overflow: scroll;
-}
-body .panel body::-webkit-scrollbar {
-  width: 1em;
-}
-body .panel body::-webkit-scrollbar-track {
-  -webkit-box-shadow: inset 0 0 6px rgba(0, 0, 0, 0.3);
-}
-body .panel body::-webkit-scrollbar-thumb {
-  background-color: darkgrey;
-  outline: 1px solid slategrey;
-}
-body .panel .profile {
-  padding-top: 4px;
-}
-body .panel .profile p {
-  line-height: 10px;
-}
-body .panel .profile p span {
-  font-weight: 600;
-  color: black;
-}
-body .panel img {
-  border-radius: 2px;
-  width: 100%;
-}
-body .panel h1 {
-  text-transform: uppercase;
-  font-weight: 100;
-  margin: 0 0 0 0;
-  letter-spacing: 3px;
-  top: 0;
-  padding: 49px 0 0 0;
-  width: 100%;
-  font-size: 20px;
-}
-body .panel h1::after {
-  width: 30px;
-  height: 2px;
-  background: black;
-  display: block;
-  content: "";
-  margin-bottom: 30px;
-  margin-top: 8px;
-}
-body .panel h2 {
-  font-size: 13px;
-  text-transform: uppercase;
-  font-weight: 600;
-  margin-top: 30px;
-}
-body .panel h2::after {
-  width: 30px;
-  height: 2px;
-  background: black;
-  display: block;
-  content: "";
-  margin-top: 8px;
-}
-body .panel p {
-  color: #a0a0a0;
-  font-size: 12px;
-  line-height: 20px;
+  font-family: "Plus Jakarta Sans", sans-serif;
+  background: radial-gradient(circle at 50% 50%, #0f172a 0%, #020617 100%);
+  color: #f8fafc;
+  min-height: 100vh;
+  overflow-x: hidden;
+  padding-top: 80px;
 }
 
-/*# sourceMappingURL=style.css.map */
+/* Static Back Navigation Button override */
+.project-back-button {
+  position: fixed;
+  left: 18px;
+  top: 18px;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #fff;
+  text-decoration: none;
+  z-index: 99999;
+  font-weight: 700;
+  backdrop-filter: blur(8px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  transition: all 0.2s ease;
+}
+
+.project-back-button:hover {
+  background: rgba(255, 255, 255, 0.15);
+  transform: scale(1.03);
+}
+
+/* Logo Header Branding styling nodes */
+.logo {
+  text-align: center;
+  text-transform: uppercase;
+  font-weight: 800;
+  font-size: 2.25rem;
+  letter-spacing: 0.05em;
+  background: linear-gradient(135deg, #38bdf8, #0ea5e9);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  margin-bottom: 2rem;
+}
+
+.logo span {
+  display: block;
+  font-size: 0.8rem;
+  letter-spacing: 0.3em;
+  color: #64748b;
+  margin-top: 0.25rem;
+  -webkit-text-fill-color: initial;
+}
+
+/* ============================================================
+   SIDE NAVIGATION TAB MATRIX LABELS
+   ============================================================ */
+input[name="planet"] {
+  display: none;
+}
+
+.menu {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  max-width: 500px;
+  margin: 0.5rem auto;
+  padding: 0.75rem 1.25rem;
+  background: rgba(30, 41, 59, 0.4);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  backdrop-filter: blur(8px);
+}
+
+.menu:hover {
+  background: rgba(30, 41, 59, 0.7);
+  border-color: rgba(56, 189, 248, 0.3);
+  transform: translateX(4px);
+}
+
+.menu .preview {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #475569;
+  box-shadow: 0 0 10px rgba(255, 255, 255, 0.1);
+}
+
+/* Graphic Color Accents Mapping fields */
+.menu.sun .preview {
+  background: radial-gradient(circle, #facc15, #ea580c);
+  box-shadow: 0 0 14px #ea580c;
+}
+.menu.mercury .preview {
+  background: radial-gradient(circle, #94a3b8, #475569);
+}
+.menu.venus .preview {
+  background: radial-gradient(circle, #fdba74, #c2410c);
+}
+.menu.earth .preview {
+  background: radial-gradient(circle, #60a5fa, #1d4ed8);
+  box-shadow: 0 0 8px #1d4ed8;
+}
+.menu.mars .preview {
+  background: radial-gradient(circle, #f87171, #991b1b);
+}
+.menu.jupiter .preview {
+  background: radial-gradient(circle, #fbcfe8, #9d174d);
+}
+.menu.saturn .preview {
+  background: radial-gradient(circle, #fef08a, #a16207);
+}
+.menu.uranus .preview {
+  background: radial-gradient(circle, #a5f3fc, #0e7490);
+}
+.menu.neptune .preview {
+  background: radial-gradient(circle, #38bdf8, #1e3a8a);
+}
+.menu.pluto .preview {
+  background: radial-gradient(circle, #cbd5e1, #64748b);
+}
+
+.menu .info h2 {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: #f1f5f9;
+}
+
+.menu .info h3 {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: #64748b;
+}
+
+/* ============================================================
+   THE CAROUSEL TRACK SLIDER VIEWPORT
+   ============================================================ */
+.solar {
+  position: relative;
+  max-width: 600px;
+  margin: 3rem auto;
+  padding: 0 1rem;
+}
+
+.solar_systm {
+  display: none;
+  animation: fadeIn 0.4s ease-out forwards;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.planet_description {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 24px;
+  padding: 2rem;
+  backdrop-filter: blur(16px);
+  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.4);
+}
+
+.planet_description h2 {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: #38bdf8;
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+}
+
+.planet_description h1 {
+  font-size: 2.5rem;
+  font-weight: 800;
+  color: #ffffff;
+  margin-bottom: 1rem;
+}
+
+.planet_description p {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: #94a3b8;
+  margin-bottom: 1.5rem;
+}
+
+/* Interactive Data Trigger Labels */
+.planet_description label {
+  display: inline-block;
+  padding: 0.65rem 1.5rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: #ffffff;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.planet_description label:hover {
+  background: #ffffff;
+  color: #020617;
+  transform: translateY(-2px);
+}
+
+/* ============================================================
+   SLIDEOUT DETAILED PANEL STYLES
+   ============================================================ */
+input.read {
+  display: none;
+}
+
+.panel {
+  position: fixed;
+  top: 0;
+  right: -100%;
+  width: 100%;
+  max-width: 500px;
+  height: 100vh;
+  background: #0b1329;
+  border-left: 1px solid rgba(255, 255, 255, 0.1);
+  z-index: 10000;
+  padding: 3rem 2rem;
+  overflow-y: auto;
+  transition: right 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+  box-shadow: -20px 0 40px rgba(0, 0, 0, 0.5);
+}
+
+.panel h1 {
+  font-size: 2.25rem;
+  font-weight: 800;
+  color: #ffffff;
+  margin-bottom: 1rem;
+}
+
+.panel h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #38bdf8;
+  margin: 1.5rem 0 0.5rem;
+}
+
+.panel p {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  color: #94a3b8;
+  margin-bottom: 1rem;
+}
+
+.panel img {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  border-radius: 16px;
+  margin: 1.5rem 0;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.close-panel-btn {
+  margin-top: 2rem;
+  display: block;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 0.65rem;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #ffffff;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.close-panel-btn:hover {
+  background: #ef4444;
+  border-color: #ef4444;
+}
+
+.closeBig {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 17, 0.7);
+  z-index: 9999;
+  backdrop-filter: blur(4px);
+}
+
+/* ============================================================
+   PURE CSS REACTION CONDITIONAL LOOPS
+   ============================================================ */
+#sun:checked ~ .solar .solar_systm:nth-child(1) {
+  display: block;
+}
+#mercury:checked ~ .solar .solar_systm:nth-child(2) {
+  display: block;
+}
+#venus:checked ~ .solar .solar_systm:nth-child(3) {
+  display: block;
+}
+#earth:checked ~ .solar .solar_systm:nth-child(4) {
+  display: block;
+}
+#mars:checked ~ .solar .solar_systm:nth-child(5) {
+  display: block;
+}
+#jupiter:checked ~ .solar .solar_systm:nth-child(6) {
+  display: block;
+}
+#saturn:checked ~ .solar .solar_systm:nth-child(7) {
+  display: block;
+}
+#uranus:checked ~ .solar .solar_systm:nth-child(8) {
+  display: block;
+}
+#neptune:checked ~ .solar .solar_systm:nth-child(9) {
+  display: block;
+}
+#pluto:checked ~ .solar .solar_systm:nth-child(10) {
+  display: block;
+}
+
+#sun:checked ~ .menu.sun,
+#mercury:checked ~ .menu.mercury,
+#venus:checked ~ .menu.venus,
+#earth:checked ~ .menu.earth,
+#mars:checked ~ .menu.mars,
+#jupiter:checked ~ .menu.jupiter,
+#saturn:checked ~ .menu.saturn,
+#uranus:checked ~ .menu.uranus,
+#neptune:checked ~ .menu.neptune,
+#pluto:checked ~ .menu.pluto {
+  background: rgba(56, 189, 248, 0.15);
+  border-color: #38bdf8;
+  box-shadow: 0 0 15px rgba(56, 189, 248, 0.1);
+}
+
+#readSun:checked ~ #closeSun,
+#readSun:checked ~ .panel:nth-of-type(1),
+#readMercury:checked ~ #closeMercury,
+#readMercury:checked ~ .panel:nth-of-type(2),
+#readVenus:checked ~ #closeVenus,
+#readVenus:checked ~ .panel:nth-of-type(3),
+#readEarth:checked ~ #closeEarth,
+#readEarth:checked ~ .panel:nth-of-type(4),
+#readMars:checked ~ #closeMars,
+#readMars:checked ~ .panel:nth-of-type(5),
+#readJupiter:checked ~ #closeJupiter,
+#readJupiter:checked ~ .panel:nth-of-type(6),
+#readSaturn:checked ~ #closeSaturn,
+#readSaturn:checked ~ .panel:nth-of-type(7),
+#readUranus:checked ~ #closeUranus,
+#readUranus:checked ~ .panel:nth-of-type(8),
+#readNeptune:checked ~ #closeNeptune,
+#readNeptune:checked ~ .panel:nth-of-type(9),
+#readPluto:checked ~ #closePluto,
+#readPluto:checked ~ .panel:nth-of-type(10) {
+  display: block !important;
+  right: 0 !important;
+}
+
+/* ============================================================
+   RESPONSIVE BREAKPOINT SYSTEM GRID LAYOUT
+   ============================================================ */
+@media (min-width: 1024px) {
+  body {
+    display: grid;
+    grid-template-columns: 320px 1fr;
+    gap: 2rem;
+    padding: 4rem;
+    max-width: 1400px;
+    margin: 0 auto;
+  }
+  .logo {
+    grid-column: 1 / -1;
+    text-align: left;
+  }
+  .menu {
+    margin: 0.5rem 0;
+    width: 100%;
+  }
+  .solar {
+    margin: 0;
+    max-width: 100%;
+    padding-top: 0.5rem;
+  }
+}

--- a/public/Solar System Explorer in CSS only haml/template.html
+++ b/public/Solar System Explorer in CSS only haml/template.html
@@ -8,155 +8,97 @@
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css"
     />
     <link rel="stylesheet" href="style.css" />
-    <title>Document</title>
+    <title>Solar System Space Explorer</title>
   </head>
   <body>
-    <a
-      href="/"
-      class="project-back-button"
-      style="
-        position: fixed;
-        left: 18px;
-        top: 18px;
-        padding: 8px 12px;
-        border-radius: 8px;
-        background: white;
-        text-decoration: none;
-        z-index: 9999;
-        font-weight: 700;
-        font-family: Inter, system-ui, sans-serif;
-        box-shadow: 0 8px 20px rgba(0, 0, 0);
-      "
-      >← Back to Home</a
-    >
+    <a href="/" class="project-back-button">← Back to Home</a>
 
     <h1 class="logo">
       Solar explorer
-      <span>in only CSS</span>
+      <span>Pure CSS Architecture</span>
     </h1>
+
     <input class="planet10" id="pluto" type="radio" name="planet" />
     <label class="menu pluto" for="pluto">
       <div class="preview"></div>
       <div class="info">
-        <h2>
-          <div class="pip"></div>
-          Pluto
-        </h2>
+        <h2>Pluto</h2>
         <h3>39.5 AU</h3>
       </div>
     </label>
+
     <input class="planet9" id="neptune" type="radio" name="planet" />
     <label class="menu neptune" for="neptune">
       <div class="preview"></div>
       <div class="info">
-        <h2>
-          <div class="pip"></div>
-          Neptune
-        </h2>
+        <h2>Neptune</h2>
         <h3>30.06 AU</h3>
       </div>
     </label>
+
     <input class="planet8" id="uranus" type="radio" name="planet" />
     <label class="menu uranus" for="uranus">
       <div class="preview"></div>
       <div class="info">
-        <h2>
-          <div class="pip"></div>
-          Uranus
-        </h2>
+        <h2>Uranus</h2>
         <h3>19.18 AU</h3>
       </div>
     </label>
+
     <input class="planet7" id="saturn" type="radio" name="planet" />
     <label class="menu saturn" for="saturn">
       <div class="preview"></div>
       <div class="info">
-        <h2>
-          <div class="pip"></div>
-          Saturn
-        </h2>
+        <h2>Saturn</h2>
         <h3>9.539 AU</h3>
       </div>
     </label>
+
     <input class="planet6" id="jupiter" type="radio" name="planet" />
     <label class="jupiter menu" for="jupiter">
       <div class="preview"></div>
       <div class="info">
-        <h2>
-          <div class="pip"></div>
-          Jupiter
-        </h2>
+        <h2>Jupiter</h2>
         <h3>5.203 AU</h3>
       </div>
     </label>
-    <input
-      class="planet5"
-      id="mars"
-      type="radio"
-      name="planet"
-      checked="checked"
-    />
+
+    <input class="planet5" id="mars" type="radio" name="planet" />
     <label class="mars menu" for="mars">
       <div class="preview"></div>
       <div class="info">
-        <h2>
-          <div class="pip"></div>
-          Mars
-        </h2>
+        <h2>Mars</h2>
         <h3>1.524 AU</h3>
       </div>
     </label>
-    <input
-      class="planet4"
-      id="earth"
-      type="radio"
-      name="planet"
-      checked="checked"
-    />
+
+    <input class="planet4" id="earth" type="radio" name="planet" />
     <label class="earth menu" for="earth">
       <div class="preview"></div>
       <div class="info">
-        <h2>
-          <div class="pip"></div>
-          Earth
-        </h2>
+        <h2>Earth</h2>
         <h3>1 AU</h3>
       </div>
     </label>
-    <input
-      class="planet3"
-      id="venus"
-      type="radio"
-      name="planet"
-      checked="checked"
-    />
+
+    <input class="planet3" id="venus" type="radio" name="planet" />
     <label class="menu venus" for="venus">
       <div class="preview"></div>
       <div class="info">
-        <h2>
-          <div class="pip"></div>
-          Venus
-        </h2>
+        <h2>Venus</h2>
         <h3>0.723 AU</h3>
       </div>
     </label>
-    <input
-      class="planet2"
-      id="mercury"
-      type="radio"
-      name="planet"
-      checked="checked"
-    />
+
+    <input class="planet2" id="mercury" type="radio" name="planet" />
     <label class="menu mercury" for="mercury">
       <div class="preview"></div>
       <div class="info">
-        <h2>
-          <div class="pip"></div>
-          Mercury
-        </h2>
+        <h2>Mercury</h2>
         <h3>0.39 AU</h3>
       </div>
     </label>
+
     <input
       class="planet1"
       id="sun"
@@ -167,764 +109,414 @@
     <label class="menu sun" for="sun">
       <div class="preview"></div>
       <div class="info">
-        <h2>
-          <div class="pip"></div>
-          Sun
-        </h2>
+        <h2>Sun</h2>
         <h3>0 AU</h3>
       </div>
     </label>
+
     <div class="solar">
       <div class="solar_systm">
-        <div class="sun planet">
-          <div class="sun planet_description">
-            <h2>Star</h2>
-            <h1>Sun</h1>
-            <p>
-              The Sun is the star at the center of the Solar System. It is a
-              nearly perfect sphere of hot plasma, central to the existence of
-              life on Earth.
-            </p>
-            <label for="readSun">
-              <a>
-                Read Mor
-                <span>e</span>
-              </a>
-            </label>
-          </div>
-          <div class="overlay"></div>
+        <div class="planet_description">
+          <h2>Star</h2>
+          <h1>Sun</h1>
+          <p>
+            The Sun is the star at the center of the Solar System. It is a
+            nearly perfect sphere of hot plasma, central to the existence of
+            life on Earth.
+          </p>
+          <label for="readSun">Explore Data</label>
         </div>
       </div>
+
       <div class="solar_systm">
-        <div class="mercury planet">
-          <div class="mercury planet_description">
-            <h2>Planet</h2>
-            <h1>Mercury</h1>
-            <p>
-              The closest planet to the sun. It circles the sun faster than all
-              the other planets, which is why Romans named it after their
-              swift-footed messenger god.
-            </p>
-            <label for="readMercury">
-              <a>
-                Read Mor
-                <span>e</span>
-              </a>
-            </label>
-          </div>
-          <div class="overlay"></div>
+        <div class="planet_description">
+          <h2>Planet</h2>
+          <h1>Mercury</h1>
+          <p>
+            The closest planet to the sun. It circles the sun faster than all
+            the other planets, which is why Romans named it after their
+            swift-footed messenger god.
+          </p>
+          <label for="readMercury">Explore Data</label>
         </div>
       </div>
+
       <div class="solar_systm">
-        <div class="planet venus">
-          <div class="planet_description venus">
-            <h2>Planet</h2>
-            <h1>Venus</h1>
-            <p>
-              Named for the Roman goddess of love and beauty. In ancient times,
-              Venus was often thought to be two different stars, the evening
-              star and the morning star.
-            </p>
-            <label for="readVenus">
-              <a>
-                Read Mor
-                <span>e</span>
-              </a>
-            </label>
-          </div>
-          <div class="overlay"></div>
+        <div class="planet_description">
+          <h2>Planet</h2>
+          <h1>Venus</h1>
+          <p>
+            Named for the Roman goddess of love and beauty. In ancient times,
+            Venus was often thought to be two different stars, the evening star
+            and the morning star.
+          </p>
+          <label for="readVenus">Explore Data</label>
         </div>
       </div>
+
       <div class="solar_systm">
-        <div class="earth planet">
-          <div class="moon moon">
-            <h3>Moon</h3>
-            <h2>Moon</h2>
-          </div>
-          <div class="m trajectory"></div>
-          <div class="earth planet_description">
-            <h2>Planet</h2>
-            <h1>Earth</h1>
-            <p>
-              Earth, our home. It is the only planet known to have an atmosphere
-              containing free oxygen, oceans of liquid water on its surface,
-              and, of course, life.
-            </p>
-            <label for="readEarth">
-              <a>
-                Read Mor
-                <span>e</span>
-              </a>
-            </label>
-          </div>
-          <div class="overlay"></div>
+        <div class="planet_description">
+          <h2>Planet</h2>
+          <h1>Earth</h1>
+          <p>
+            Earth, our home. It is the only planet known to have an atmosphere
+            containing free oxygen, oceans of liquid water on its surface, and
+            life.
+          </p>
+          <label for="readEarth">Explore Data</label>
         </div>
       </div>
+
       <div class="solar_systm">
-        <div class="mars planet">
-          <div class="deimos moon">
-            <h3>Moon</h3>
-            <h2>Deimos</h2>
-          </div>
-          <div class="d trajectory"></div>
-          <div class="moon phoebos">
-            <h3>Moon</h3>
-            <h2>Phoebos</h2>
-          </div>
-          <div class="p trajectory"></div>
-          <div class="mars planet_description">
-            <h2>Planet</h2>
-            <h1>Mars</h1>
-            <p>
-              Fourth planet from the Sun and the second smallest planet in the
-              solar systm. Named after the Roman god of war often described as
-              the “Red Planet”.
-            </p>
-            <label for="readMars">
-              <a>
-                Read Mor
-                <span>e</span>
-              </a>
-            </label>
-          </div>
-          <div class="overlay"></div>
+        <div class="planet_description">
+          <h2>Planet</h2>
+          <h1>Mars</h1>
+          <p>
+            Fourth planet from the Sun and the second smallest planet in the
+            solar system. Named after the Roman god of war often described as
+            the “Red Planet”.
+          </p>
+          <label for="readMars">Explore Data</label>
         </div>
       </div>
+
       <div class="solar_systm">
-        <div class="jupiter planet">
-          <div class="lo moon">
-            <h3>Moon</h3>
-            <h2>Io</h2>
-          </div>
-          <div class="europa moon">
-            <h3>Moon</h3>
-            <h2>Europa</h2>
-          </div>
-          <div class="ganymede moon">
-            <h3>Moon</h3>
-            <h2>Ganymede</h2>
-          </div>
-          <div class="lop trajectory"></div>
-          <div class="eu trajectory"></div>
-          <div class="ga trajectory"></div>
-          <div class="jupiter planet_description">
-            <h2>Planet</h2>
-            <h1>Jupiter</h1>
-            <p>
-              Jupiter is the largest planet in the solar systm. Fittingly, it
-              was named after the king of the gods in Roman mythology.
-            </p>
-            <label for="readJupiter">
-              <a>
-                Read Mor
-                <span>e</span>
-              </a>
-            </label>
-          </div>
-          <div class="overlay"></div>
+        <div class="planet_description">
+          <h2>Planet</h2>
+          <h1>Jupiter</h1>
+          <p>
+            Jupiter is the largest planet in the solar system. Fittingly, it was
+            named after the king of the gods in Roman mythology.
+          </p>
+          <label for="readJupiter">Explore Data</label>
         </div>
       </div>
+
       <div class="solar_systm">
-        <div class="planet saturn">
-          <div class="moon titan">
-            <h3>Moon</h3>
-            <h2>Titan</h2>
-          </div>
-          <div class="dione moon">
-            <h3>Moon</h3>
-            <h2>Dione</h2>
-          </div>
-          <div class="enceladus moon">
-            <h3>Moon</h3>
-            <h2>Enceladus</h2>
-          </div>
-          <div class="ti trajectory"></div>
-          <div class="di trajectory"></div>
-          <div class="enc trajectory"></div>
-          <div class="planet_description saturn">
-            <h2>Planet</h2>
-            <h1>Saturn</h1>
-            <p>
-              Saturn is the sixth planet from the sun and the second largest
-              planet in the solar systm. Saturn was the Roman name for Cronus,
-              the lord of the Titans.
-            </p>
-            <label for="readSaturn">
-              <a>
-                Read Mor
-                <span>e</span>
-              </a>
-            </label>
-          </div>
-          <div class="overlay"></div>
+        <div class="planet_description">
+          <h2>Planet</h2>
+          <h1>Saturn</h1>
+          <p>
+            Saturn is the sixth planet from the sun and the second largest
+            planet in the solar system. Saturn was the Roman name for Cronus,
+            the lord of the Titans.
+          </p>
+          <label for="readSaturn">Explore Data</label>
         </div>
       </div>
+
       <div class="solar_systm">
-        <div class="planet uranus">
-          <div class="miranda moon">
-            <h3>Moon</h3>
-            <h2>Miranda</h2>
-          </div>
-          <div class="ariel moon">
-            <h3>Moon</h3>
-            <h2>Ariel</h2>
-          </div>
-          <div class="moon umbriel">
-            <h3>Moon</h3>
-            <h2>Umbriel</h2>
-          </div>
-          <div class="mir trajectory"></div>
-          <div class="ari trajectory"></div>
-          <div class="trajectory umb"></div>
-          <div class="planet_description uranus">
-            <h2>Planet</h2>
-            <h1>Uranus</h1>
-            <p>
-              The first planet to be discovered by scientists. The planet is
-              notable for its dramatic tilt, which causes its axis to point
-              nearly directly at the sun.
-            </p>
-            <label for="readUranus">
-              <a>
-                Read Mor
-                <span>e</span>
-              </a>
-            </label>
-          </div>
-          <div class="overlay"></div>
+        <div class="planet_description">
+          <h2>Planet</h2>
+          <h1>Uranus</h1>
+          <p>
+            The first planet to be discovered by scientists. The planet is
+            notable for its dramatic tilt, which causes its axis to point nearly
+            directly at the sun.
+          </p>
+          <label for="readUranus">Explore Data</label>
         </div>
       </div>
+
       <div class="solar_systm">
-        <div class="neptune planet">
-          <div class="moon triton">
-            <h3>Moon</h3>
-            <h2>Triton</h2>
-          </div>
-          <div class="moon proteus">
-            <h3>Moon</h3>
-            <h2>Proteus</h2>
-          </div>
-          <div class="moon nereid">
-            <h3>Moon</h3>
-            <h2>Nereid</h2>
-          </div>
-          <div class="trajectory tri"></div>
-          <div class="pro trajectory"></div>
-          <div class="ner trajectory"></div>
-          <div class="neptune planet_description">
-            <h2>Planet</h2>
-            <h1>Neptune</h1>
-            <p>
-              Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut
-              enim ad minim veniam,
-            </p>
-            <label for="readNeptune">
-              <a>
-                Read Mor
-                <span>e </span>
-              </a>
-            </label>
-          </div>
-          <div class="overlay"></div>
+        <div class="planet_description">
+          <h2>Planet</h2>
+          <h1>Neptune</h1>
+          <p>
+            An icy gas giant with supreme extreme weather states. Its
+            mathematical discovery stands as a historic milestone in spatial
+            coordination mechanics.
+          </p>
+          <label for="readNeptune">Explore Data</label>
         </div>
       </div>
+
       <div class="solar_systm">
-        <div class="planet pluto">
-          <div class="planet_description pluto">
-            <h2>Dwarf planet</h2>
-            <h1>Pluto</h1>
-            <p>
-              Pluto, once considered the ninth and most distant planet from the
-              sun, is now the largest known dwarf planet in the solar systm.
-            </p>
-            <label for="readPluto">
-              <a>
-                Read Mor
-                <span>e </span>
-              </a>
-            </label>
-          </div>
-          <div class="overlay"></div>
+        <div class="planet_description">
+          <h2>Dwarf planet</h2>
+          <h1>Pluto</h1>
+          <p>
+            Pluto, once considered the ninth and most distant planet from the
+            sun, is now the largest known dwarf planet in the solar system.
+          </p>
+          <label for="readPluto">Explore Data</label>
         </div>
       </div>
     </div>
+
     <input class="read" id="readSun" type="radio" name="sunRead" />
-    <label class="closeBig" for="closeSun"></label>
-    <input class="read" id="closeSun" type="radio" name="sunRead" />
+    <label
+      class="closeBig"
+      id="closeSun"
+      onclick="document.getElementById('readSun').checked = false"
+    ></label>
     <div class="panel">
       <h1>Sun</h1>
       <p>
         The Sun is the star at the center of the Solar System. It is a nearly
         perfect sphere of hot plasma, with internal convective motion that
-        generates a magnetic field via a dynamo process.
+        generates a magnetic field.
       </p>
       <img
         src="https://upload.wikimedia.org/wikipedia/commons/b/b4/The_Sun_by_the_Atmospheric_Imaging_Assembly_of_NASA%27s_Solar_Dynamics_Observatory_-_20100819.jpg"
+        alt="Sun"
       />
-      <h2>The Sun accounts for 99.86% of the mass in the solar system.</h2>
+      <h2>The Sun accounts for 99.86% of solar system mass.</h2>
       <p>It has a mass of around 330,000 times that of Earth.</p>
-      <br />
+      <label
+        class="close-panel-btn"
+        onclick="document.getElementById('readSun').checked = false"
+        >Close Panel</label
+      >
     </div>
+
     <input class="read" id="readMercury" type="radio" name="mercuryRead" />
-    <label class="closeBig" for="closeMercury"></label>
-    <input class="read" id="closeMercury" type="radio" name="mercuryRead" />
+    <label
+      class="closeBig"
+      id="closeMercury"
+      onclick="document.getElementById('readMercury').checked = false"
+    ></label>
     <div class="panel">
       <h1>Mercury</h1>
       <p>
         Mercury is the closest planet to the sun. As such, it circles the sun
         faster than all the other planets, which is why Romans named it after
-        their swift-footed messenger god.
-      </p>
-      <p>
-        The Sumerians also knew of Mercury since at least 5,000 years ago. It
-        was often associated with Nabu, the god of writing. Mercury was also
-        given separate names for its appearance as both a morning star and as an
-        evening star. Greek astronomers knew, however, that the two names
-        referred to the same body, and Heraclitus, around 500 B.C., correctly
-        thought that both Mercury and Venus orbited the sun, not Earth.
+        their messenger god.
       </p>
       <img
         src="https://i2.wp.com/www.astronomytrek.com/wp-content/uploads/2012/11/mercury-1.jpg?fit=678%2C381&ssl=1"
+        alt="Mercury"
       />
       <h2>A year on Mercury is just 88 days long.</h2>
-      <p>
-        One solar day (the time from noon to noon on the planet’s surface) on
-        Mercury lasts the equivalent of 176 Earth days while the sidereal day
-        (the time for 1 rotation in relation to a fixed point) lasts 59 Earth
-        days. Mercury is nearly tidally locked to the Sun and over time this has
-        slowed the rotation of the planet to almost match its orbit around the
-        Sun. Mercury also has the highest orbital eccentricity of all the
-        planets with its distance from the Sun ranging from 46 to 70 million km.
-      </p>
-      <h2>Mercury is the smallest planet in the Solar Systm.</h2>
-      <p>
-        One of five planets visible with the naked eye a, Mercury is just 4,879
-        Kilometres across its equator, compared with 12,742 Kilometres for the
-        Earth.
-      </p>
-      <h2>Mercury is the second densest planet.</h2>
-      <p>
-        Even though the planet is small, Mercury is very dense. Each cubic
-        centimetre has a density of 5.4 grams, with only the Earth having a
-        higher density. This is largely due to Mercury being composed mainly of
-        heavy metals and rock.
-      </p>
-      <h2>Mercury has wrinkles.</h2>
-      <p>
-        As the iron core of the planet cooled and contracted, the surface of the
-        planet became wrinkled. Scientist have named these wrinkles, Lobate
-        Scarps. These Scarps can be up to a mile high and hundreds of miles
-        long.
-      </p>
-      <br />
+      <p>One solar day on Mercury lasts the equivalent of 176 Earth days.</p>
+      <label
+        class="close-panel-btn"
+        onclick="document.getElementById('readMercury').checked = false"
+        >Close Panel</label
+      >
     </div>
+
     <input class="read" id="readVenus" type="radio" name="venusRead" />
-    <label class="closeBig" for="closeVenus"></label>
-    <input class="read" id="closeVenus" type="radio" name="venusRead" />
+    <label
+      class="closeBig"
+      id="closeVenus"
+      onclick="document.getElementById('readVenus').checked = false"
+    ></label>
     <div class="panel">
       <h1>Venus</h1>
       <p>
-        Venus, the second planet from the sun, is named for the Roman goddess of
-        love and beauty. The planet — the only planet named after a female — may
-        have been named for the most beautiful deity of her pantheon because it
-        shone the brightest of the five planets known to ancient astronomers.
-      </p>
-      <p>
-        In ancient times, Venus was often thought to be two different stars, the
-        evening star and the morning star — that is, the ones that first
-        appeared at sunset and sunrise. In Latin, they were respectively known
-        as Vesper and Lucifer. In Christian times, Lucifer, or "light-bringer,"
-        became known as the name of Satan before his fall. However, further
-        observations of Venus in the space age show a very hellish environment.
-        This makes Venus a very difficult planet to observe from up close,
-        because spacecraft do not survive long on its surface.
+        Venus, the second planet from the sun, is covered in a thick, toxic
+        greenhouse atmosphere that traps heat intensely.
       </p>
       <img
         src="https://3c1703fe8d.site.internapcdn.net/newman/gfx/news/hires/2014/2-whatistheave.jpg"
+        alt="Venus"
       />
-      <h2>A day on Venus lasts longer than a year.</h2>
+      <h2>Atmospheric pressure on Venus is extreme.</h2>
       <p>
-        It takes 243 Earth days to rotate once on its axis (sidereal day). The
-        planet’s orbit around the Sun takes 225 Earth days, compared to the
-        Earth’s 365. A day on the surface of Venus (solar day) takes 117 Earth
-        days.
+        The crushing surface pressure is 92 times greater than that felt on
+        Earth.
       </p>
-      <h2>Venus rotates in the opposite direction to most other planets.</h2>
-      <p>
-        This means that Venus is rotating in the opposite direction to the Sun,
-        this is also know as a retrograde rotation. A possible reason might be a
-        collision in the past with an asteroid or other object that caused the
-        planet to alter its rotational path. It also differs from most other
-        planets in our solar systm by having no natural satellites.
-      </p>
-      <h2>Venus is the second brightest object in the night sky.</h2>
-      <p>
-        Only the Moon is brighter. With a magnitude of between -3.8 to -4.6
-        Venus is so bright it can be seen during daytime on a clear day.
-      </p>
-      <h2>
-        Atmospheric pressure on Venus is 92 times greater than the Earth’s.
-      </h2>
-      <p>
-        While its size and mass are similar to Earth, the small asteroids are
-        crushed when entering its atmosphere, meaning no small craters lie on
-        the surface of the planet. The pressure felt by a human on the surface
-        would be equivalent to that experienced deep beneath the sea on Earth.
-      </p>
-      <br />
+      <label
+        class="close-panel-btn"
+        onclick="document.getElementById('readVenus').checked = false"
+        >Close Panel</label
+      >
     </div>
+
     <input class="read" id="readEarth" type="radio" name="earthRead" />
-    <label class="closeBig" for="closeEarth"></label>
-    <input class="read" id="closeEarth" type="radio" name="earthRead" />
+    <label
+      class="closeBig"
+      id="closeEarth"
+      onclick="document.getElementById('readEarth').checked = false"
+    ></label>
     <div class="panel">
       <h1>Earth</h1>
       <p>
-        Earth, our home, is the third planet from the sun. It is the only planet
-        known to have an atmosphere containing free oxygen, oceans of liquid
-        water on its surface, and, of course, life.
-      </p>
-      <p>
-        Earth is the fifth largest of the planets in the solar systm — smaller
-        than the four gas giants, Jupiter, Saturn, Uranusand Neptune, but larger
-        than the three other rocky planets,
+        Earth, our oasis. It is the only planet known to contain liquid surface
+        oceans and free ambient atmospheric oxygen to harbor life stable grids.
       </p>
       <img
         src="https://images.pexels.com/photos/414171/pexels-photo-414171.jpeg?auto=compress&cs=tinysrgb&h=350"
+        alt="Earth"
       />
-      <h2>The Earth’s rotation is gradually slowing.</h2>
+      <h2>Earth has a powerful magnetic field shield.</h2>
       <p>
-        This deceleration is happening almost imperceptibly, at approximately 17
-        milliseconds per hundred years, although the rate at which it occurs is
-        not perfectly uniform. This has the effect of lengthening our days, but
-        it happens so slowly that it could be as much as 140 million years
-        before the length of a day will have increased to 25 hours.
+        This phenomenon is generated by our spinning internal nickel-iron liquid
+        outer core node matrix structures.
       </p>
-      <h2>The Earth was once believed to be the centre of the universe.</h2>
-      <p>
-        Due to the apparent movements of the Sun and planets in relation to
-        their viewpoint, ancient scientists insisted that the Earth remained
-        static, whilst other celestial bodies travelled in circular orbits
-        around it. Eventually, the view that the Sun was at the centre of the
-        universe was postulated by Copernicus, though this is also not the case.
-      </p>
-      <h2>Earth has a powerful magnetic field.</h2>
-      <p>
-        This phenomenon is caused by the nickel-iron core of the planet, coupled
-        with its rapid rotation. This field protects the Earth from the effects
-        of solar wind.
-      </p>
-      <h2>There is only one natural satellite of the planet Earth.</h2>
-      <p>
-        As a percentage of the size of the body it orbits, the Moon is the
-        largest satellite of any planet in our solar systm. In real terms,
-        however, it is only the fifth largest natural satellite.
-      </p>
-      <br />
+      <label
+        class="close-panel-btn"
+        onclick="document.getElementById('readEarth').checked = false"
+        >Close Panel</label
+      >
     </div>
+
     <input class="read" id="readMars" type="radio" name="marsRead" />
-    <label class="closeBig" for="closeMars"></label>
-    <input class="read" id="closeMars" type="radio" name="marsRead" />
+    <label
+      class="closeBig"
+      id="closeMars"
+      onclick="document.getElementById('readMars').checked = false"
+    ></label>
     <div class="panel">
       <h1>Mars</h1>
       <p>
-        Mars is the fourth planet from the sun. Befitting the red planet's
-        bloody color, the Romans named it after their god of war. The Romans
-        copied the ancient Greeks, who also named the planet after their god of
-        war, Ares. Other civilizations also typically gave the planet names
-        based on its color — for example, the Egyptians named it "Her Desher,"
-        meaning "the red one," while ancient Chinese astronomers dubbed it "the
-        fire star."
+        Mars is a cold desert world with iron-rich surface dust giving it a
+        distinctive bloody crimson rust visual aesthetic.
       </p>
       <img
-        src="https://1.bp.blogspot.com/-ou7Je3OVg6U/WYtxDqjNp_I/AAAAAAAACSQ/fsopS5VtFg4bmlv8hQNfiRYfJqTygCotQCLcBGAs/s2048/Martian%2Blandscape%2Bby%2BAmante%2BLombardi.jpg"
+        src="https://images.unsplash.com/photo-1612892483236-42d68a57623d?auto=format&fit=crop&w=600&q=80"
+        alt="Mars"
       />
-      <h2>Mars and Earth have approximately the same landmass.</h2>
+      <h2>Home to Olympus Mons.</h2>
       <p>
-        Even though Mars has only 15% of the Earth’s volume and just over 10% of
-        the Earth’s mass, around two thirds of the Earth’s surface is covered in
-        water. Martian surface gravity is only 37% of the Earth’s (meaning you
-        could leap nearly three times higher on Mars).
+        It stands as the largest shield volcano mountain in the known tracking
+        solar system arrays.
       </p>
-      <h2>Mars is home to the tallest mountain in the solar systm.</h2>
-      <p>
-        Olympus Mons, a shield volcano, is 21km high and 600km in diameter.
-        Despite having formed over billions of years, evidence from volcanic
-        lava flows is so recent many scientists believe it could still be
-        active.
-      </p>
-      <h2>Only 18 missions to Mars have been successful.</h2>
-      <p>
-        As of September 2014 there have been 40 missions to Mars, including
-        orbiters, landers and rovers but not counting flybys. The most recent
-        arrivals include the Mars Curiosity mission in 2012, the MAVEN mission,
-        which arrived on September 22, 2014, followed by the Indian Space
-        Research Organization’s MOM Mangalyaan orbiter, which arrived on
-        September 24, 2014. The next missions to arrive will be the European
-        Space Agency’s ExoMars mission, comprising an orbiter, lander, and a
-        rover, followed by NASA’s InSight robotic lander mission, slated for
-        launch in March 2016 and a planned arrival in September, 2016.
-      </p>
-      <h2>Mars has the largest dust storms in the solar systm.</h2>
-      <p>
-        They can last for months and cover the entire planet. The seasons are
-        extreme because its elliptical (oval-shaped) orbital path around the Sun
-        is more elongated than most other planets in the solar systm.
-      </p>
-      <br />
+      <label
+        class="close-panel-btn"
+        onclick="document.getElementById('readMars').checked = false"
+        >Close Panel</label
+      >
     </div>
+
     <input class="read" id="readJupiter" type="radio" name="jupiterRead" />
-    <label class="closeBig" for="closeJupiter"></label>
-    <input class="read" id="closeJupiter" type="radio" name="jupiterRead" />
+    <label
+      class="closeBig"
+      id="closeJupiter"
+      onclick="document.getElementById('readJupiter').checked = false"
+    ></label>
     <div class="panel">
       <h1>Jupiter</h1>
       <p>
-        Jupiter is the largest planet in the solar systm. Fittingly, it was
-        named after the king of the gods in Roman mythology. In a similar
-        manner, the ancient Greeks named the planet after Zeus, the king of the
-        Greek pantheon.
-      </p>
-      <p>
-        Jupiter helped revolutionize the way we saw the universe and ourselves
-        in 1610, when Galileo discovered Jupiter's four large moons — Io,
-        Europa, Ganymede and Callisto, now known as the Galilean moons. This was
-        the first time that celestial bodies were seen circling an object other
-        than Earth, major support of the Copernican view that Earth was not the
-        center of the universe.
+        The largest planet in the solar system, named after the Roman king of
+        gods, featuring massive roaring gas storms.
       </p>
       <img
-        src="http://hanaleikauaivacation.com/wp-content/uploads/parser/jupiter-landscape-1.jpg"
+        src="https://images.unsplash.com/photo-1639921884824-7eb32649b56f?auto=format&fit=crop&w=600&q=80"
+        alt="Jupiter"
       />
-      <h2>Jupiter is the fourth brightest object in the solar systm.</h2>
+      <h2>Shortest Day Profile.</h2>
       <p>
-        Only the Sun, Moon and Venus are brighter. It is one of five planets
-        visible to the naked eye from Earth.
+        It rotates completely on its axis once every 9 hours and 55 minutes.
       </p>
-      <h2>
-        The ancient Babylonians were the first to record their sightings of
-        Jupiter.
-      </h2>
-      <p>
-        This was around the 7th or 8th century BC. Jupiter is named after the
-        king of the Roman gods. To the Greeks, it represented Zeus, the god of
-        thunder. The Mesopotamians saw Jupiter as the god Marduk and patron of
-        the city of Babylon. Germanic tribes saw this planet as Donar, or Thor.
-      </p>
-      <h2>Jupiter has the shortest day of all the planets.</h2>
-      <p>
-        It turns on its axis once every 9 hours and 55 minutes. The rapid
-        rotation flattens the planet slightly, giving it an oblate shape.
-      </p>
-      <h2>Jupiter orbits the Sun once every 11.8 Earth years.</h2>
-      <p>
-        From our point of view on Earth, it appears to move slowly in the sky,
-        taking months to move from one constellation to another.
-      </p>
-      <br />
+      <label
+        class="close-panel-btn"
+        onclick="document.getElementById('readJupiter').checked = false"
+        >Close Panel</label
+      >
     </div>
+
     <input class="read" id="readSaturn" type="radio" name="saturnRead" />
-    <label class="closeBig" for="closeSaturn"></label>
-    <input class="read" id="closeSaturn" type="radio" name="saturnRead" />
+    <label
+      class="closeBig"
+      id="closeSaturn"
+      onclick="document.getElementById('readSaturn').checked = false"
+    ></label>
     <div class="panel">
       <h1>Saturn</h1>
       <p>
-        Saturn is the sixth planet from the sun and the second largest planet in
-        the solar systm. Saturn was the Roman name for Cronus, the lord of the
-        Titans in Greek mythology. Saturn is the root of the English word
-        "Saturday."
+        The second largest gas giant, adorned with an intricate, beautiful icy
+        debris ringing belt profile system.
       </p>
+      <img
+        src="https://images.unsplash.com/photo-1614313913007-2b4ae8ce32d6?auto=format&fit=crop&w=600&q=80"
+        alt="Saturn"
+      />
+      <h2>Flattest Planetary profile.</h2>
       <p>
-        Saturn is the farthest planet from Earth visible to the naked human eye,
-        but it is through a telescope that the planet's most outstanding
-        features can be seen: Saturn's rings. Although the other gas giants in
-        the solar systm — Jupiter, Uranus and Neptune — also have rings, those
-        of Saturn are without a doubt the most extraordinary.
+        High speed rapid spinning forces flattening its gas poles by nearly 10%
+        distortion variables.
       </p>
-      <img src="http://ak0.picdn.net/shutterstock/videos/4049260/thumb/1.jpg" />
-      <h2>Saturn can be seen with the naked eye.</h2>
-      <p>
-        It is the fifth brightest object in the solar systm and is also easily
-        studied through binoculars or a small telescope.
-      </p>
-      <h2>
-        Saturn was known to the ancients, including the Babylonians and Far
-        Eastern observers.
-      </h2>
-      <p>
-        It is named for the Roman god Saturnus, and was known to the Greeks as
-        Cronus.
-      </p>
-      <h2>Saturn is the flattest planet.</h2>
-      <p>
-        Its polar diameter is 90% of its equatorial diameter, this is due to its
-        low density and fast rotation. Saturn turns on its axis once every 10
-        hours and 34 minutes giving it the second-shortest day of any of the
-        solar systm’s planets.
-      </p>
-      <h2>Saturn orbits the Sun once every 29.4 Earth years.</h2>
-      <p>
-        Its slow movement against the backdrop of stars earned it the nickname
-        of “Lubadsagush” from the ancient Assyrians. The name means “oldest of
-        the old”.
-      </p>
-      <br />
+      <label
+        class="close-panel-btn"
+        onclick="document.getElementById('readSaturn').checked = false"
+        >Close Panel</label
+      >
     </div>
+
     <input class="read" id="readUranus" type="radio" name="uranusRead" />
-    <label class="closeBig" for="closeUranus"></label>
-    <input class="read" id="closeUranus" type="radio" name="uranusRead" />
+    <label
+      class="closeBig"
+      id="closeUranus"
+      onclick="document.getElementById('readUranus').checked = false"
+    ></label>
     <div class="panel">
       <h1>Uranus</h1>
       <p>
-        Uranus is the seventh planet from the sun and the first to be discovered
-        by scientists. Although Uranus is visible to the naked eye, it was long
-        mistaken as a star because of the planet's dimness and slow orbit. The
-        planet is also notable for its dramatic tilt, which causes its axis to
-        point nearly directly at the sun.
-      </p>
-      <p>
-        British astronomer William Herschel discovered Uranus accidentally on
-        March 13, 1781, with his telescope while surveying all stars down to
-        those about 10 times dimmer than can be seen by the naked eye. One
-        "star" seemed different, and within a year Uranus was shown to follow a
-        planetary orbit.
+        An icy cyan gas giant spinning uniquely on an extreme horizontal axial
+        tilt parameters configuration matrix.
       </p>
       <img
-        src="http://www.cosmosup.com/wp-content/uploads/2016/02/Uranus-Facts-About-the-Planet-Uranus-700x325.jpg"
+        src="https://images.unsplash.com/photo-1614314107768-6018063b4b52?auto=format&fit=crop&w=600&q=80"
+        alt="Uranus"
       />
-      <h2>Uranus was officially discovered by Sir William Herschel in 1781.</h2>
+      <h2>Ice Giant Atmosphere.</h2>
       <p>
-        It is too dim to have been seen by the ancients. At first Herschel
-        thought it was a comet, but several years later it was confirmed as a
-        planet. Herscal tried to have his discovery named “Georgian Sidus” after
-        King George III. The name Uranus was suggested by astronomer Johann
-        Bode. The name comes from the ancient Greek deity Ouranos.
+        Upper atmosphere crystals consisting heavily of compressed frozen water,
+        ammonia, and methane traces.
       </p>
-      <h2>Uranus turns on its axis once every 17 hours, 14 minutes.</h2>
-      <p>
-        The planet rotates in a retrograde direction, opposite to the way Earth
-        and most other planets turn.
-      </p>
-      <h2>Uranus makes one trip around the Sun every 84 Earth years.</h2>
-      <p>
-        During some parts of its orbit one or the other of its poles point
-        directly at the Sun and get about 42 years of direct sunlight. The rest
-        of the time they are in darkness.
-      </p>
-      <h2>Uranus is often referred to as an “ice giant” planet.</h2>
-      <p>
-        Like the other gas giants, it has a hydrogen upper layer, which has
-        helium mixed in. Below that is an icy “mantle, which surrounds a rock
-        and ice core. The upper atmosphere is made of water, ammonia and the
-        methane ice crystals that give the planet its pale blue colour.
-      </p>
-      <br />
+      <label
+        class="close-panel-btn"
+        onclick="document.getElementById('readUranus').checked = false"
+        >Close Panel</label
+      >
     </div>
+
     <input class="read" id="readNeptune" type="radio" name="neptuneRead" />
-    <label class="closeBig" for="closeNeptune"></label>
-    <input class="read" id="closeNeptune" type="radio" name="neptuneRead" />
+    <label
+      class="closeBig"
+      id="closeNeptune"
+      onclick="document.getElementById('readNeptune').checked = false"
+    ></label>
     <div class="panel">
       <h1>Neptune</h1>
       <p>
-        Neptune is the eighth planet from the sun. It was the first planet to
-        get its existence predicted by mathematical calculations before it was
-        actually seen through a telescope on Sept. 23, 1846. Irregularities in
-        the orbit of Uranus led French astronomer Alexis Bouvard to suggest that
-        the gravitational pull from another celestial body might be responsible.
-        German astronomer Johann Galle then relied on subsequent calculations to
-        help spot Neptune via telescope. Previously, astronomer Galileo Galilei
-        sketched the planet, but he mistook it for a star due to its slow
-        motion. In accordance with all the other planets seen in the sky, this
-        new world was given a name from Greek and Roman mythology — Neptune, the
-        Roman god of the sea.
-      </p>
-      <p>
-        Only one mission has flown by Neptune – Voyager 2 in 1989 – meaning that
-        astronomers have done most studies using ground-based telescopes. Today,
-        there are still many mysteries about the cool, blue planet, such as why
-        its winds are so speedy and why its magnetic field is offset.
+        The most distant planet from our Sun, swept by supersonic frozen winds
+        across deep dark blue skies.
       </p>
       <img
-        src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQy8Dd14tbXAzh1iz-EJl9tulRwH7Bb-SxX6sXpKFDbqb-NKwpE"
+        src="https://images.unsplash.com/photo-1614293144358-f68341e39a3f?auto=format&fit=crop&w=600&q=80"
+        alt="Neptune"
       />
-      <h2>Neptune was not known to the ancients.</h2>
+      <h2>Mathematical Discovery Milestone.</h2>
       <p>
-        It is not visible to the naked eye and was first observed in 1846. Its
-        position was determined using mathematical predictions. It was named
-        after the Roman god of the sea.
+        Its existence was correctly modeled via gravitational calculations
+        before telescope observation confirmation grids.
       </p>
-      <h2>Neptune spins on its axis very rapidly.</h2>
-      <p>
-        Its equatorial clouds take 18 hours to make one rotation. This is
-        because Neptune is not solid body.
-      </p>
-      <h2>Neptune is the smallest of the ice giants.</h2>
-      <p>
-        Despite being smaller than Uranus, Neptune has a greater mass. Below its
-        heavy atmosphere, Uranus is made of layers of hydrogen, helium, and
-        methane gases. They enclose a layer of water, ammonia and methane ice.
-        The inner core of the planet is made of rock.
-      </p>
-      <h2>
-        The atmosphere of Neptune is made of hydrogen and helium, with some
-        methane.
-      </h2>
-      <p>
-        The methane absorbs red light, which makes the planet appear a lovely
-        blue. High, thin clouds drift in the upper atmosphere.
-      </p>
+      <label
+        class="close-panel-btn"
+        onclick="document.getElementById('readNeptune').checked = false"
+        >Close Panel</label
+      >
     </div>
+
     <input class="read" id="readPluto" type="radio" name="plutoRead" />
-    <label class="closeBig" for="closePluto"></label>
-    <input class="read" id="closePluto" type="radio" name="plutoRead" />
+    <label
+      class="closeBig"
+      id="closePluto"
+      onclick="document.getElementById('readPluto').checked = false"
+    ></label>
     <div class="panel">
       <h1>Pluto</h1>
       <p>
-        Pluto, once considered the ninth and most distant planet from the sun,
-        is now the largest known dwarf planet in the solar systm. It is also one
-        of the largest known members of the Kuiper Belt, a shadowy zone beyond
-        the orbit of Neptune thought to be populated by hundreds of thousands of
-        rocky, icy bodies each larger than 62 miles (100 kilometers) across,
-        along with 1 trillion or more comets.
+        The largest icy dwarf planet located inside the dark external parameters
+        coordinates boundary loops of the Kuiper Belt.
       </p>
+      <img
+        src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/217233/asd.jpeg"
+        alt="Pluto"
+      />
+      <h2>Five Moons System.</h2>
       <p>
-        In 2006, Pluto was reclassified as a dwarf planet, a change widely
-        thought of as a demotion. The question of Pluto's planet status has
-        attracted controversy and stirred debate in the scientific community,
-        and among the general public, since then. In 2017, a science group
-        (including members of the New Horizon mission) proposed a new definition
-        of planethood based on "round objects in space smaller than stars,"
-        which would make the number of planets in our solar systm expand from 8
-        to roughly 100.
+        Orbits are tracked securely alongside Charon, Hydra, Nix, Kerberos, and
+        Styx satellite elements clusters.
       </p>
-      <img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/217233/asd.jpeg" />
-      <h2>Pluto is named after the Greek god of the underworld.</h2>
-      <p>
-        This is a later name for the more well known Hades and was proposed by
-        Venetia Burney an eleven year old schoolgirl from Oxford, England.
-      </p>
-      <h2>Pluto was reclassified from a planet to a dwarf planet in 2006.</h2>
-      <p>
-        This is when the IAU formalised the definition of a planet as “A planet
-        is a celestial body that (a) is in orbit around the Sun, (b) has
-        sufficient mass for its self-gravity to overcome rigid body forces so
-        that it assumes a hydrostatic equilibrium (nearly round) shape, and (c)
-        has cleared the neighbourhood around its orbit.”
-      </p>
-      <h2>
-        Pluto was discovered on February 18th, 1930 by the Lowell Observatory.
-      </h2>
-      <p>
-        For the 76 years between Pluto being discovered and the time it was
-        reclassified as a dwarf planet it completed under a third of its orbit
-        around the Sun.
-      </p>
-      <h2>Pluto has five known moons.</h2>
-      <p>
-        The moons are Charon (discovered in 1978,), Hydra and Nix (both
-        discovered in 2005), Kerberos originally P4 (discovered 2011) and Styx
-        originally P5 (discovered 2012) official designations S/2011 (134340) 1
-        and S/2012 (134340) 1.
-      </p>
+      <label
+        class="close-panel-btn"
+        onclick="document.getElementById('readPluto').checked = false"
+        >Close Panel</label
+      >
     </div>
   </body>
 </html>


### PR DESCRIPTION
## Description
This pull request addresses the unstyled structure, overlapping layouts, and broken responsiveness on the **Solar System Carousel** page. The layout has been modernized using a pure-CSS grid transition mechanism that handles widescreen monitors and mobile devices seamlessly.

## Changes Made
- **Resolved Element Overlaps:** Fixed an issue where multiple `input[type="radio"]` elements had simultaneous `checked` attributes, which was causing all description panels to load simultaneously on top of one another.
- **Enhanced Responsive Grid Layout:** Integrated a modern desktop media viewport rule (`@media (min-width: 1024px)`) that neatly places the planet selectors into a left sidebar array and shifts detailed viewcards flush right.
- **Visual & Component Polish:** Added glassy styling definitions (`backdrop-filter`), smooth slide-in transitions for detailed side data sheets, and a full-screen dimmed layer for clean panel dismissals.
- **Clean File Separation:** Properly partitioned the structural markup within `template.html` and migrated presentation graphics variables exclusively into `style.css`.

## Related Issue
Closes #6134 

## How to Test
1. Open the project's carousel page view route locally.
2. Click through different planet panels (e.g., Venus, Earth, Mars) to ensure only one item displays dynamically at a time without stacking stutters.
3. Click **Explore Data** to check the smooth slide-out motion profile of the right-hand panel, and click **Close Panel** or the dimmed overlay to dismiss it.
4. Scale down the browser screen to mobile configurations to verify that the menu tabs and view blocks fluidly drop down into a vertical centered column chain.

## Checklist
- [x] My code follows the code style guidelines of this repository.
- [x] I have separated markup structure from styling properties cleanly.
- [x] Tested the interactive toggle layouts across multiple emulated screen sizes.