### PR TITLE
Fix missing particleCanvas element causing inactive particle background

### DIFF
--- a/index.html
+++ b/index.html
@@ -89,6 +89,7 @@
   </head>
 
   <body>
+    <canvas id="particleCanvas"></canvas>
     <div class="ambient ambient-left" aria-hidden="true"></div>
     <div class="ambient ambient-right" aria-hidden="true"></div>
     <div class="noise-layer" aria-hidden="true"></div>


### PR DESCRIPTION
## Description

The hub page contained a particle animation system referenced in both
`index.js` and `style.css`, but the required `#particleCanvas`
element was missing from `index.html`.

As a result:

- Particle initialization code executed on every page load
- No particle background was rendered
- Existing particle animation functionality remained inactive

## Changes Made

- Added the missing `<canvas id="particleCanvas"></canvas>` element to `index.html`
- Restored the intended particle network background effect
- Ensured compatibility with the existing JavaScript and CSS implementation

## Type of Change

- Bug Fix

## Testing

- Verified particle animation renders correctly
- Verified no console errors
- Verified page content remains accessible and visible
- Tested responsive behavior