### PR TITLE
fix(2048): prevent runtime error during pause and resume

### DIFF
--- a/public/2048_game/script.js
+++ b/public/2048_game/script.js
@@ -892,11 +892,12 @@ document.getElementById('wr').addEventListener(
 document.addEventListener('visibilitychange', () => {
   if (mode !== 'timed' || over) return;
 
+  const tfill = document.getElementById('tfill');
   if (document.hidden) {
     paused = true;
     clearInterval(timerInterval);
 
-    document.getElementById('tfill').classList.add('paused');
+    if (tfill) tfill.classList.add('paused');
 
     showToast('Timer paused');
   } else {
@@ -904,7 +905,7 @@ document.addEventListener('visibilitychange', () => {
       paused = false;
       startTimer();
 
-      document.getElementById('tfill').classList.remove('pgit aused');
+      if (tfill) tfill.classList.remove('paused');
 
       showToast('Timer resumed');
     }


### PR DESCRIPTION
Closes #6250

## Summary

Fixes a runtime error in the 2048 Game that could occur when the page visibility changes and the game automatically pauses or resumes.

## Changes Made

* Corrected the invalid class token `pgit aused` to `paused`
* Added null checks before accessing the `#tfill` element
* Preserved the existing pause/resume behavior

## Testing

* Verified tab switching pauses and resumes the timed game correctly
* Confirmed no DOMException is thrown during pause/resume
* Verified gameplay continues normally after resuming
