### PR TITLE
fix: resolve issue #6572 - Input fields remain locked after session completion

### DIFF
--- a/public/CountDown Timer/script.js
+++ b/public/CountDown Timer/script.js
@@ -598,6 +598,7 @@ function showCompletion(emoji, title, msg) {
 function closeCompletion() {
   els.completionOverlay.classList.add('hidden');
   state.status = 'idle';
+  lockInputs(false);
   updateStartPauseBtn();
 }
 


### PR DESCRIPTION
Closes #6572

This PR implements the necessary bug fix or improvement for this issue. Tested locally.