### PR TITLE
fix: resolve issue #6612 - External link target='_blank' lacks security rel attributes

### DIFF
--- a/public/AI ChatBot/chatbot.html
+++ b/public/AI ChatBot/chatbot.html
@@ -272,7 +272,7 @@
 
             <div class="settings-hint">
               Free at
-              <a href="https://aistudio.google.com/app/api-keys" target="_blank">
+              <a href="https://aistudio.google.com/app/api-keys" target="_blank" rel="noopener noreferrer">
                 Google AI Studio
               </a>
             </div>


### PR DESCRIPTION
Closes #6612

This PR addresses the issue by applying the required standard fix or enhancement. Tested locally.