### PR TITLE
fix: resolve issue #6760 - External link target='_blank' lacks security rel attributes

### DIFF
--- a/public/github-repository-analyser/index.html
+++ b/public/github-repository-analyser/index.html
@@ -63,7 +63,7 @@
                             <p id="profile-bio" class="profile-bio"></p>
                             <div class="profile-meta-row">
                                 <span id="profile-location" class="profile-meta-item hidden"><i class="fas fa-map-marker-alt"></i> <span></span></span>
-                                <span id="profile-blog" class="profile-meta-item hidden"><i class="fas fa-link"></i> <a href="#" target="_blank"></a></span>
+                                <span id="profile-blog" class="profile-meta-item hidden"><i class="fas fa-link"></i> <a href="#" target="_blank" rel="noopener noreferrer"></a></span>
                                 <span id="profile-joined" class="profile-meta-item"><i class="fas fa-calendar-alt"></i> <span></span></span>
                             </div>
                         </div>


### PR DESCRIPTION
Closes #6760

This PR addresses the issue by applying the required standard fix or enhancement. Tested locally.