### PR TITLE
fix: resolve issue #6750 - specify type='button' on control button

### DIFF
--- a/public/Flipkart-clone/index.html
+++ b/public/Flipkart-clone/index.html
@@ -147,6 +147,7 @@
       </div>
 
       <button
+        type="button"
         class="section-control prev"
         onclick="moveSlide(-1)"
         aria-label="Previous slide"


### PR DESCRIPTION
Closes #6750

This PR fixes the button type to prevent default form submission reloading. Tested locally.