### PR TITLE
fix: resolve issue #6757 - specify type='button' on control button

### DIFF
--- a/public/geo-guesser/index.html
+++ b/public/geo-guesser/index.html
@@ -27,6 +27,7 @@
             <span class="score-value" id="totalScore">0</span>
           </div>
           <button
+            type="button"
             class="theme-toggle"
             id="themeToggle"
             aria-label="Toggle theme"


### PR DESCRIPTION
Closes #6757

This PR fixes the button type to prevent default form submission reloading. Tested locally.