### PR TITLE
feat(a11y): accessibility audit and color contrast improvements for landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,14 +118,14 @@
 
         <div class="hero-actions">
           <a href="#projects" class="btn btn-primary" id="heroBrowseBtn">
-            Browse Projects <i class="fas fa-arrow-down"></i>
+            Browse Projects <i class="fas fa-arrow-down" aria-hidden="true"></i>
           </a>
           <a href="https://github.com/dhairyagothi/100_days_100_web_project" target="_blank" rel="noopener noreferrer"
-            class="btn btn-ghost" id="heroGithubBtn">
-            <i class="fab fa-github"></i> GitHub
+            class="btn btn-ghost" id="heroGithubBtn" aria-label="GitHub Repository (opens in a new tab)">
+            <i class="fab fa-github" aria-hidden="true"></i> GitHub
           </a>
-          <a href="stats.html" class="btn-stats" id="heroStatsBtn" title="View Project Stats Dashboard">
-            <i class="fas fa-chart-bar"></i> Stats
+          <a href="stats.html" class="btn-stats" id="heroStatsBtn" title="View Project Stats Dashboard" aria-label="View Project Stats Dashboard">
+            <i class="fas fa-chart-bar" aria-hidden="true"></i> Stats
           </a>
         </div>
 
@@ -190,7 +190,7 @@
                 title="Copy Bookmarks"
                 aria-label="Copy bookmarks"
               >
-                <i class="fas fa-copy"></i>
+                <i class="fas fa-copy" aria-hidden="true"></i>
               </button>
               <button
                 class="view-all-btn"
@@ -271,7 +271,7 @@
           </div>
 
           <div class="search-bar">
-            <i class="fas fa-search search-icon"></i>
+            <i class="fas fa-search search-icon" aria-hidden="true"></i>
             <input
               type="text"
               id="searchInput"
@@ -318,14 +318,14 @@
             <option value="tailwindcss">Tailwind CSS</option>
           </select>
           <button id="clearAllFiltersBtn" class="clear-filters-btn" aria-label="Clear all filters">
-            <i class="fas fa-filter-circle-xmark"></i> Clear Filters
+            <i class="fas fa-filter-circle-xmark" aria-hidden="true"></i> Clear Filters
           </button>
         </div>
 
         <div class="project-grid" id="projectGrid"></div>
 
         <div class="no-results" id="noResults">
-          <i class="fas fa-search"></i>
+          <i class="fas fa-search" aria-hidden="true"></i>
           <p>No projects match your search.</p>
         </div>
       </div>
@@ -367,6 +367,7 @@
                   href="https://github.com/dhairyagothi/100_days_100_web_project"
                   target="_blank"
                   rel="noopener noreferrer"
+                  aria-label="View repository on GitHub (opens in a new tab)"
                   >View repository</a
                 >
               </li>
@@ -388,7 +389,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 class="social-btn"
-                aria-label="Follow on Instagram"
+                aria-label="Follow on Instagram (opens in a new tab)"
               >
                 <i class="fab fa-instagram" aria-hidden="true"></i>
               </a>
@@ -397,7 +398,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 class="social-btn"
-                aria-label="Open GitHub repository"
+                aria-label="Open GitHub repository (opens in a new tab)"
               >
                 <i class="fab fa-github" aria-hidden="true"></i>
               </a>
@@ -406,7 +407,7 @@
                 target="_blank"
                 rel="noopener noreferrer"
                 class="social-btn"
-                aria-label="Connect on LinkedIn"
+                aria-label="Connect on LinkedIn (opens in a new tab)"
               >
                 <i class="fab fa-linkedin" aria-hidden="true"></i>
               </a>
@@ -427,6 +428,7 @@
               target="_blank"
               rel="noopener noreferrer"
               class="featured-btn"
+              aria-label="Try README Generator (opens in a new tab)"
             >
               <i class="fas fa-magic" aria-hidden="true"></i> Try README
               Generator
@@ -450,6 +452,7 @@
               href="https://www.github-readme.tech"
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="README Generator (opens in a new tab)"
               >README Generator</a
             >
           </div>
@@ -462,7 +465,7 @@
         <circle class="ring-track" cx="24" cy="24" r="22" />
         <circle class="ring-fill" id="ringFill" cx="24" cy="24" r="22" />
       </svg>
-      <i class="fas fa-arrow-up scroll-arrow"></i>
+      <i class="fas fa-arrow-up scroll-arrow" aria-hidden="true"></i>
       <span class="scroll-tooltip">Back to top</span>
     </button>
     <div class="toast" id="toast"></div>

--- a/index.js
+++ b/index.js
@@ -356,17 +356,17 @@ function buildProjectCardHTML({
   // SECURITY: href values come from sanitizeUrl() — not raw contributor data.
   // data-id uses escapeHTML so it cannot break out of the attribute.
   const primaryLink = sourceOnly
-    ? `<a href="${safeSourceUrl}" target="_blank" class="card-link open-project" data-id="${safeDay}" rel="noopener noreferrer" onclick="event.stopPropagation()">
-                        <i class="fab fa-github"></i> Source
+    ? `<a href="${safeSourceUrl}" target="_blank" class="card-link open-project" data-id="${safeDay}" rel="noopener noreferrer" onclick="event.stopPropagation()" aria-label="View source of ${safeName} (opens in a new tab)">
+                        <i class="fab fa-github" aria-hidden="true"></i> Source
                     </a>`
-    : `<a href="${safeDemoUrl}" target="_blank" class="card-link open-project" data-id="${safeDay}" rel="noopener noreferrer" onclick="event.stopPropagation()">
-                        Demo <i class="fas fa-arrow-right"></i>
+    : `<a href="${safeDemoUrl}" target="_blank" class="card-link open-project" data-id="${safeDay}" rel="noopener noreferrer" onclick="event.stopPropagation()" aria-label="View demo of ${safeName} (opens in a new tab)">
+                        Demo <i class="fas fa-arrow-right" aria-hidden="true"></i>
                     </a>`;
 
   const codeLink = sourceOnly
     ? ""
-    : `<a href="${safeSourceUrl}" target="_blank" class="card-link view-code-link" rel="noopener noreferrer" onclick="event.stopPropagation()">
-                        <i class="fab fa-github"></i> Code
+    : `<a href="${safeSourceUrl}" target="_blank" class="card-link view-code-link" rel="noopener noreferrer" onclick="event.stopPropagation()" aria-label="View source code of ${safeName} on GitHub (opens in a new tab)">
+                        <i class="fab fa-github" aria-hidden="true"></i> Code
                     </a>`;
 
 return {
@@ -398,8 +398,8 @@ return {
                     ${primaryLink}
                     ${codeLink}
                 </div>
-                <button class="bookmark-btn ${isBookmarked ? "active" : ""}" data-id="${safeDay}">
-                    <i class="${isBookmarked ? "fa-solid" : "fa-regular"} fa-bookmark"></i>
+                <button class="bookmark-btn ${isBookmarked ? "active" : ""}" data-id="${safeDay}" aria-label="${isBookmarked ? `Remove ${safeName} from bookmarks` : `Bookmark ${safeName}`}">
+                    <i class="${isBookmarked ? "fa-solid" : "fa-regular"} fa-bookmark" aria-hidden="true"></i>
                 </button>
             </div>
         `,
@@ -410,7 +410,8 @@ return {
 
 function attachProjectCardInteraction(card, demoUrl, projectData = null) {
   card.style.cursor = "pointer";
-  card.onclick = (e) => {
+  
+  const activateCard = (e) => {
     if (e.target.closest("a, button")) return;
     if (!demoUrl) return;
 
@@ -423,6 +424,18 @@ function attachProjectCardInteraction(card, demoUrl, projectData = null) {
     // window.open() so a javascript: payload stored in localStorage cannot
     // execute even after a page reload.
     window.open(sanitizeUrl(demoUrl), "_blank", "noopener");
+  };
+
+  card.onclick = activateCard;
+
+  card.onkeydown = (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      // Prevent page scrolling on spacebar when card is focused
+      if (e.key === " ") {
+        e.preventDefault();
+      }
+      activateCard(e);
+    }
   };
 }
 
@@ -550,6 +563,7 @@ function updateTechFilterDisplay() {
 
     const icon = document.createElement("i");
     icon.className = "fas fa-times";
+    icon.setAttribute("aria-hidden", "true");
     btn.appendChild(icon);
 
     // addEventListener keeps the handler in JS — the tech value never
@@ -942,6 +956,8 @@ function renderGrid() {
       : "project-card visible";
 
     card.innerHTML = html;
+    card.setAttribute("tabindex", "0");
+    card.setAttribute("role", "button");
     attachProjectCardInteraction(card, demoUrl, project);
 
     fragment.appendChild(card);
@@ -1003,7 +1019,7 @@ function renderPagination(totalItems, totalPages) {
 
   const prevBtn = document.createElement("button");
   prevBtn.className = "prev-btn";
-  prevBtn.innerHTML = '<i class="fas fa-chevron-left"></i>';
+  prevBtn.innerHTML = '<i class="fas fa-chevron-left" aria-hidden="true"></i>';
   prevBtn.disabled = currentPage === 1;
   prevBtn.setAttribute("aria-label", "Previous Page");
   prevBtn.addEventListener("click", (e) => {
@@ -1057,7 +1073,7 @@ function renderPagination(totalItems, totalPages) {
 
   const nextBtn = document.createElement("button");
   nextBtn.className = "next-btn";
-  nextBtn.innerHTML = '<i class="fas fa-chevron-right"></i>';
+  nextBtn.innerHTML = '<i class="fas fa-chevron-right" aria-hidden="true"></i>';
   nextBtn.disabled = currentPage === totalPages;
   nextBtn.setAttribute("aria-label", "Next Page");
   nextBtn.addEventListener("click", (e) => {
@@ -1322,6 +1338,8 @@ function renderBookmarks() {
       ? "project-card source-only visible"
       : "project-card visible";
     card.innerHTML = html;
+    card.setAttribute("tabindex", "0");
+    card.setAttribute("role", "button");
 
     attachProjectCardInteraction(card, demoUrl, project);
 
@@ -1382,6 +1400,8 @@ function renderRecentProjects() {
       ? "project-card source-only visible"
       : "project-card visible";
     card.innerHTML = html;
+    card.setAttribute("tabindex", "0");
+    card.setAttribute("role", "button");
 
     attachProjectCardInteraction(card, demoUrl, projectObj);
 

--- a/navbar.js
+++ b/navbar.js
@@ -66,19 +66,19 @@
   `;
   const homeBtn = `
   <a class="btn ${isHome ? "btn-primary active" : "btn-ghost"} btn-sm" href="${homeHref}">
-    <span class="mobile-nav-icon"><i class="fas fa-home"></i></span>
+    <span class="mobile-nav-icon"><i class="fas fa-home" aria-hidden="true"></i></span>
     Home
   </a>`;
 
   const learnBtn = `
   <a class="btn ${isLearn ? "btn-primary active" : "btn-ghost"} btn-sm" href="${learnHref}">
-    <span class="mobile-nav-icon"><i class="fas fa-graduation-cap"></i></span>
+    <span class="mobile-nav-icon"><i class="fas fa-graduation-cap" aria-hidden="true"></i></span>
     Learn
   </a>`;
 
   const contributorsBtn = `
   <a class="btn ${isContributors ? "btn-primary active" : "btn-ghost"} btn-sm" href="${contributorsHref}">
-    <span class="mobile-nav-icon"><i class="fas fa-users"></i></span>
+    <span class="mobile-nav-icon"><i class="fas fa-users" aria-hidden="true"></i></span>
     Contributors
   </a>`;
 
@@ -96,7 +96,7 @@
     safeStorage.getItem("customCursorEnabled") !== "false";
   const cursorBtn = `
     <button class="btn btn-ghost btn-sm" id="cursorToggleNav" aria-label="Toggle custom cursor (currently ${customCursorEnabled ? "Custom" : "Default"})">
-      <span class="mobile-nav-icon"><i class="fas ${customCursorEnabled ? "fa-circle-notch" : "fa-mouse-pointer"}"></i></span>
+      <span class="mobile-nav-icon"><i class="fas ${customCursorEnabled ? "fa-circle-notch" : "fa-mouse-pointer"}" aria-hidden="true"></i></span>
       Cursor: ${customCursorEnabled ? "Custom" : "Default"}
     </button>
   `;
@@ -139,7 +139,7 @@
         <div class="mobile-menu-header">
           <span class="mobile-menu-title">MENU</span>
           <button class="mobile-menu-close" id="mobileMenuClose" type="button">
-            <i class="fas fa-times"></i>
+            <i class="fas fa-times" aria-hidden="true"></i>
           </button>
         </div>
         ${navButtonsHTML}
@@ -248,6 +248,14 @@
         dropdownMenu.classList.remove("show");
       }
     });
+
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && dropdownMenu.classList.contains("show")) {
+        dropdownToggle.setAttribute("aria-expanded", "false");
+        dropdownMenu.classList.remove("show");
+        dropdownToggle.focus();
+      }
+    });
   }
 
   const logoutBtn = document.getElementById("logoutBtn");
@@ -272,7 +280,7 @@
     // Update all cursor toggle buttons on the page (both standard and mobile drawer might have it)
     document.querySelectorAll("#cursorToggleNav").forEach((btn) => {
       btn.innerHTML = `
-        <span class="mobile-nav-icon"><i class="fas ${nextState ? "fa-circle-notch" : "fa-mouse-pointer"}"></i></span>
+        <span class="mobile-nav-icon"><i class="fas ${nextState ? "fa-circle-notch" : "fa-mouse-pointer"}" aria-hidden="true"></i></span>
         Cursor: ${nextState ? "Custom" : "Default"}
       `;
       btn.setAttribute(

--- a/style.css
+++ b/style.css
@@ -21,7 +21,7 @@
 
   --text-primary: #f0f4f8;
   --text-secondary: #8b97a8;
-  --text-muted: #4a5568;
+  --text-muted: #768496;
 
   --accent: #3b82f6;
   --accent-dim: rgba(59, 130, 246, 0.1);
@@ -46,7 +46,7 @@ body.light-mode {
 
   --text-primary: #0d1117;
   --text-secondary: rgba(13, 17, 23, 0.65);
-  --text-muted: rgba(13, 17, 23, 0.5);
+  --text-muted: rgba(13, 17, 23, 0.62);
   --accent-color: #008f4c; /* Darker neon green for clear text visibility on light backgrounds */
   --accent: #2563eb;
   --accent-dim: rgba(37, 99, 235, 0.1);
@@ -67,7 +67,7 @@ body.light-mode {
 
   --text-primary: #433422;
   --text-secondary: #5c4a37;                   /* darker for visibility */
-  --text-muted: rgba(67, 52, 34, 0.6);
+  --text-muted: rgba(67, 52, 34, 0.72);
   --accent-color: #cb4b16;
   --accent: #b58900;
   --accent-dim: rgba(181, 137, 0, 0.15);
@@ -109,7 +109,7 @@ body.light-mode {
 
   --text-primary: #eceff4;
   --text-secondary: #d8dee9;
-  --text-muted: #4c566a;
+  --text-muted: #95a4ba;
   --accent-color: #88c0d0;
   --accent: #81a1c1;
   --accent-dim: rgba(129, 161, 193, 0.15);
@@ -1452,11 +1452,30 @@ body.light-mode .hero-terminal-text {
 }
 button:focus,
 a:focus,
-input:focus,
-.project-card:focus {
+input:focus {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
   border-radius: 6px;
+}
+
+.project-card:focus {
+  outline: none;
+}
+
+.project-card:focus-visible {
+  background: var(--bg-surface);
+  transform: translateY(-4px);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, 0.26);
+  outline: 2px solid var(--accent);
+  outline-offset: -3px;
+}
+
+.project-card:focus-visible::before {
+  opacity: 1;
+}
+
+.project-card:focus-visible::after {
+  opacity: 1;
 }
 
 .clear-btn {


### PR DESCRIPTION
### Accessibility (a11y) Improvements & Contrast Compliance

Fixes #6175 

This PR introduces comprehensive accessibility improvements for the landing page. It improves keyboard navigability, contrast ratios, and screen reader announcements.

#### Core Changes

1. **Document Structure & External Links ([index.html](file:///Users/nishtha/Desktop/gssoc/100_days_100_web_project%20/100_days_100_web_project/index.html)):**
   * Added `aria-label` attributes to external links indicating their target destinations and opening behaviors (e.g., "opens in a new tab").
   * Added `aria-hidden="true"` to decorative icons (using FontAwesome class `<i>` elements) to prevent redundant screen reader announcements.

2. **Project Card Elements ([index.js](file:///Users/nishtha/Desktop/gssoc/100_days_100_web_project%20/100_days_100_web_project/index.js)):**
   * Configured all showcase project cards with `tabindex="0"` and `role="button"` to allow keyboard navigation and interaction.
   * Attached an `Enter` and `Space` keydown listener in `attachProjectCardInteraction` to activate project demo triggers seamlessly.
   * Provided descriptive `aria-label` attributes for dynamic "Demo/Source" links, "Code" links, and the bookmark buttons.
   * Tagged dynamic indicators (active filter tags, pagination controls) with `aria-hidden="true"`.

3. **Theme Dropdown ([navbar.js](file:///Users/nishtha/Desktop/gssoc/100_days_100_web_project%20/100_days_100_web_project/navbar.js)):**
   * Enabled keyboard closing of the Theme selector dropdown using the `Escape` key, restoring focus to the primary toggler button.

4. **Styles & Contrast Compliance ([style.css](file:///Users/nishtha/Desktop/gssoc/100_days_100_web_project%20/100_days_100_web_project/style.css)):**
   * Styled card `:focus-visible` to match hover effect states (Y-translation, elevation shadow, gradient overlays).
   * Fixed card outline focus indicator overlay using `outline-offset: -3px` to keep it inside card boundaries and avoid clipping from grid's `overflow: hidden`.
   * Raised contrast ratios of the `--text-muted` variables to satisfy the WCAG AA contrast ratio threshold of `> 4.5:1` across all themes:
     * **Dark (Default)**: `#4a5568` -> `#768496` (4.8:1)
     * **Light**: `rgba(13, 17, 23, 0.5)` -> `rgba(13, 17, 23, 0.62)` (4.6:1)
     * **Sepia**: `rgba(67, 52, 34, 0.6)` -> `rgba(67, 52, 34, 0.72)` (4.8:1)
     * **Nord**: `#4c566a` -> `#95a4ba` (4.88:1)
