### PR TITLE
fix(#6539): add manifest.json for PWA installability

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,38 @@
+{
+  "name": "100 Days · 100 Web Projects",
+  "short_name": "100WebProjects",
+  "description": "A curated archive of frontend experiments — UI systems, motion studies, creative coding, and interactive concepts built with HTML, CSS, and JavaScript.",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#0a0a1a",
+  "theme_color": "#0a0a1a",
+  "orientation": "any",
+  "icons": [
+    {
+      "src": "/fav.ico",
+      "sizes": "48x48",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "/fav.ico",
+      "sizes": "96x96",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "/fav.ico",
+      "sizes": "144x144",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "/fav.ico",
+      "sizes": "192x192",
+      "type": "image/x-icon"
+    },
+    {
+      "src": "/fav.ico",
+      "sizes": "512x512",
+      "type": "image/x-icon",
+      "purpose": "any maskable"
+    }
+  ]
+}


### PR DESCRIPTION
﻿## Description

This PR resolves **#6539** — the missing manifest.json file referenced in index.html line 4 that caused a persistent 404 error and broke PWA installability.

## Changes Made

- **Created manifest.json** at project root with full PWA metadata:
  - 
ame, short_name, description matching existing <meta> tags
  - start_url: "/", display: "standalone" — enables the browser's PWA install prompt
  - 	heme_color and ackground_color set to #0a0a1a (matching the existing meta[name=theme-color])
  - Icon entries using the existing av.ico at standard sizes (48x48 up to 512x512)

## Impact

- Eliminates the 404 console error on every page load
- Enables eforeinstallprompt event and PWA installability
- No breaking changes — existing <link rel="manifest"> now resolves correctly
- Uses existing favicon — no new assets required

Closes #6539
