### PR TITLE
fix(#6542): add missing particleCanvas element to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,6 +94,7 @@
     <div class="noise-layer" aria-hidden="true"></div>
     <div class="cursor-ring cursor-ring--outer" aria-hidden="true"></div>
     <div class="cursor-ring cursor-ring--inner" aria-hidden="true"></div>
+    <canvas id="particleCanvas" aria-hidden="true"></canvas>
 
     <div id="navbar-container"></div>
     <section class="hero" id="hero">


### PR DESCRIPTION
﻿## Description

This PR resolves **#6542** — the #particleCanvas element referenced extensively in index.js and style.css was missing from index.html, causing 180+ lines of particle network background code to run as dead code on every page load with no visible effect.

## Changes Made

- **Added <canvas id="particleCanvas">** to index.html right after the cursor-ring ambient elements
- Uses ria-hidden="true" consistent with other background/decorative elements
- No changes to JS or CSS — the existing particle system was fully implemented and merely needed the DOM element to attach to

## Impact

- The particle network background animation now renders correctly as the intended visual enhancement for the hub page
- Eliminates wasted CPU cycles from dead code execution
- CSS already handles positioning (position: fixed, full viewport, pointer-events: none, z-index: 0) and reduced-motion preferences
- No breaking changes — the JS guard if (!canvas) return; gracefully handled the missing element before

Closes #6542
