### PR TITLE
Fix image captcha accepting text answers

### DIFF
--- a/public/captcha/captcha.js
+++ b/public/captcha/captcha.js
@@ -176,6 +176,7 @@ const generateCaptcha = () => {
         case 'image': {
             const { images, correct } = generateImageCaptcha();
             currentCaptcha = correct.name;
+            textInput.disabled=true
             textInput.placeholder = `Select the ${correct.name}`;
             captchaContainer.innerHTML = `
                 <p>Select the ${correct.name}</p>


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #6536 

### Summary
i have added textInput.disabled=true so that the user can not type in during image captcha 

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
inside captcha.js added disabled the text input for image

---

## 🧪 Testing and Verification

### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**



---


