### PR TITLE
fix: resolve dark/light theme toggle functionality

### DIFF
--- a/public/BordemBuster/index.html
+++ b/public/BordemBuster/index.html
@@ -305,6 +305,7 @@
         initProgress();
     });
   </script>
+  <script src="script.js"></script>
 </body>
 
 </html>

--- a/public/BordemBuster/script.js
+++ b/public/BordemBuster/script.js
@@ -1,0 +1,16 @@
+const savedTheme = localStorage.getItem("theme") || "dark";
+document.documentElement.setAttribute("data-theme", savedTheme);
+
+themeBtn.textContent = savedTheme ===  "dark" ? "☀️" : "🌙";
+
+themeBtn.addEventListener("click", () => {
+  const currentTheme =
+    document.documentElement.getAttribute("data-theme");
+
+  const newTheme = currentTheme === "dark" ? "light" : "dark";
+
+  document.documentElement.setAttribute("data-theme", newTheme);
+  localStorage.setItem("theme", newTheme);
+
+  themeBtn.textContent = newTheme === "dark" ? "☀️" : "🌙";
+});

--- a/public/BordemBuster/style.css
+++ b/public/BordemBuster/style.css
@@ -486,12 +486,12 @@ body::after {
   font-size: 1.2rem;
   margin-top: 0;
   margin-bottom: 12px;
-  color: #fff;
+ color: var(--text);
 }
 
 .progress-stats p {
   font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text2);
   margin-bottom: 15px;
 }
 #completedCount {
@@ -520,7 +520,7 @@ body::after {
 /* State A: LOCKED (Desaturated & Translucent) */
 .badge.locked {
   background: rgba(255, 255, 255, 0.04);
-  color: rgba(255, 255, 255, 0.25);
+ color: var(--text3);
   border: 1px dashed rgba(255, 255, 255, 0.1);
   filter: grayscale(100%);
   cursor: not-allowed;


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #6892

### Summary

Fixed the non-functional dark/light theme toggle button in the Boredom Buster project by implementing theme switching, theme persistence, and improving light theme readability.

### Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 🛠️ Changes Made

* [x] Added theme toggle functionality for switching between dark and light modes
* [x] Updated the theme button icon dynamically based on the active theme
* [x] Added theme persistence using localStorage
* [x] Improved light theme readability for progress-related UI elements

---

## 🧪 Testing and Verification

### Local Validation

* [x] Verified dark-to-light theme switching
* [x] Verified light-to-dark theme switching
* [x] Verified theme persistence after page refresh
* [x] Verified UI readability in both themes

### Browser Compatibility Check

* [x] Tested and verified in Google Chrome

### Responsive & Accessibility Checks

* [x] Verified responsive layout on mobile viewports (using DevTools)
* [x] Verified responsive layout on tablet viewports

---

## 📷 Screenshots
<img width="907" height="892" alt="Screenshot 2026-06-06 153205" src="https://github.com/user-attachments/assets/7cd458e8-c3de-4e45-ac67-3c4161ad1091" />
---

## 🤝 Contributor Checklist

* [x] My code follows the code style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] There are no unrelated changes or formatter noise in this PR.
