### PR TITLE
Fix #6989: Create missing schema/projects.schema.json for validateProjects.js

### DIFF
--- a/schema/projects.schema.json
+++ b/schema/projects.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": [
+      "projectNo",
+      "projectName",
+      "projectType",
+      "projectDesc",
+      "techStack",
+      "difficulty",
+      "projectPath"
+    ],
+    "properties": {
+      "projectNo": { "type": "number" },
+      "projectName": { "type": "string" },
+      "projectType": { "type": "string" },
+      "projectDesc": { "type": "string" },
+      "techStack": { "type": "array", "items": { "type": "string" } },
+      "difficulty": { "type": "string", "enum": ["beginner", "intermediate", "advanced"] },
+      "projectPath": { "type": "string" }
+    }
+  }
+}


### PR DESCRIPTION
﻿## Description

The \scripts/validateProjects.js\ script crashes at startup because it requires \./schema/projects.schema.json\ which does not exist. The entire \schema/\ directory is missing from the repository.

\\\javascript
// Line 8-9 of validateProjects.js
const schema = JSON.parse(
  fs.readFileSync("./schema/projects.schema.json", "utf8")
);
\\\

## Fix

Created \schema/projects.schema.json\ with a JSON Schema definition containing all required fields:
- \projectNo\ (number)
- \projectName\ (string)
- \projectType\ (string)
- \projectDesc\ (string)
- \	echStack\ (array of strings)
- \difficulty\ (string, enum: beginner/intermediate/advanced)
- \projectPath\ (string)

## Impact
- The CI validation script now runs instead of crashing
- Projects with missing required fields are correctly caught during validation
- Contributors get proper feedback when submitting incomplete entries

Fixes #6989
