### PR TITLE
Fix #6990: Remove project entries with missing files (Amazon Clone Day 42 & Photo Studio Day 213)

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -369,15 +369,6 @@
     "projectPath": "./public/Scroll%20Game%20Dark%20Run/index.html"
   },
   {
-    "projectNo": 42,
-    "projectName": "Amazon Clone",
-    "projectType": "Clone",
-    "projectDesc": "Frontend clone inspired by Amazon layouts and shopping interfaces.",
-    "techStack": ["clone", "javascript"],
-    "difficulty": "intermediate",
-    "projectPath": "./public/Amazon_Clone/index.html"
-  },
-  {
     "projectNo": 43,
     "projectName": "Password Generator",
     "projectType": "Tool",
@@ -1934,14 +1925,6 @@
     "techStack": ["html", "css", "javascript", "canvas"],
     "difficulty": "advanced",
     "projectDesc": "A responsive physics-inspired arcade game challenging users to stack moving horizontal blocks cleanly. Implements strict boundary checking, block-slicing logic, dynamic camera tracking, and interactive start/pause state controls."
-  },
-  {
-  "projectNo": 213,
-  "projectName": "Photo Studio",
-  "projectPath": "./public/Photo Studio/Project.html",
-  "techStack": ["html", "css"],
-  "difficulty": "intermediate",
-  "projectDesc": "A responsive photography portfolio and gallery website designed to showcase visual content through structured layouts, image presentation sections, and modern styling. Features an engaging user interface optimized for desktop and mobile viewing."
   },
   {
     "projectNo": 214,


### PR DESCRIPTION
﻿## Description

Two project entries in \projects.json\ point to files that **do not exist** on disk, causing 404 errors when users try to access them:

1. **Day 42 (Amazon Clone)**: \projectPath: "./public/Amazon_Clone/index.html"\ — The directory exists but contains only \preview.png\. No \index.html\ file.
2. **Day 213 (Photo Studio)**: \projectPath: "./public/Photo Studio/Project.html"\ — The entire \public/Photo Studio/\ directory does not exist.

## Fix

Removed both entries from \projects.json\ since the referenced project files are missing and cannot be served.

## Impact
- Users will no longer encounter 404 errors for these projects
- The \alidateProjects.js\ script now correctly passes (previously it caught these but couldn't run at all due to the missing schema)

Fixes #6990
