### PR TITLE
fix(#6993): [HIGH] 5 projects missing required projectType field - category filtering broken for Days 209-213

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2619,6 +2619,7 @@
   {
     "projectNo": 209,
     "projectName": "Kanban Board",
+    "projectType": "Tool",
     "projectPath": "./public/Kanban_Board/index.html",
     "techStack": [
       "html",
@@ -2631,6 +2632,7 @@
   {
     "projectNo": 210,
     "projectName": "IP Address Tracker",
+    "projectType": "Tool",
     "projectPath": "./public/Ip_Address_tracker/index.html",
     "techStack": [
       "html",
@@ -2643,6 +2645,7 @@
   {
     "projectNo": 211,
     "projectName": "Cricket Scorecard",
+    "projectType": "Tool",
     "projectPath": "./public/Cricket-Scorecard/index.html",
     "techStack": [
       "html",
@@ -2655,6 +2658,7 @@
   {
     "projectNo": 212,
     "projectName": "Tower Blocks Stacker",
+    "projectType": "Game",
     "projectPath": "./public/tower_stacker/index.html",
     "techStack": [
       "html",
@@ -2668,6 +2672,7 @@
   {
     "projectNo": 213,
     "projectName": "Photo Studio",
+    "projectType": "Website",
     "projectPath": "./public/Photo Studio/Project.html",
     "techStack": [
       "html",


### PR DESCRIPTION
Fixes #6993

Added missing projectType fields:
- Day 209 (Kanban Board): Tool
- Day 210 (IP Address Tracker): Tool
- Day 211 (Cricket Scorecard): Tool
- Day 212 (Tower Blocks Stacker): Game
- Day 213 (Photo Studio): Website