### PR TITLE
fix: reuse Docker image artifact between jobs, pin trivy-action, enforce CVE exit-code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,17 @@ jobs:
           echo "✅ Container is serving content successfully"
           docker stop test-container
 
+      - name: Save Docker image as artifact
+        run: |
+          docker save 100days-web:ci-${{ github.sha }} | gzip > image.tar.gz
+
+      - name: Upload Docker image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-image
+          path: image.tar.gz
+          retention-days: 1
+
   # ── Security Scan ─────────────────────────────────────────────
   security-scan:
     name: 🛡️ Security Scan
@@ -107,24 +118,23 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build Docker image for scan
-        uses: docker/build-push-action@v7
+      - name: Download Docker image artifact
+        uses: actions/download-artifact@v4
         with:
-          context: .
-          push: false
-          load: true
-          tags: 100days-web:scan
+          name: docker-image
+
+      - name: Load Docker image
+        run: |
+          gunzip -c image.tar.gz | docker load
+          docker tag 100days-web:ci-${{ github.sha }} 100days-web:scan
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.30.0
         with:
           image-ref: "100days-web:scan"
           format: "table"
           severity: "CRITICAL,HIGH"
-          exit-code: "0" # Warn-only — don't block on base image CVEs
+          exit-code: "1"
 
       - name: Run Validation Script
         run: |


### PR DESCRIPTION
## What changed

- **Save Docker image as artifact** in `docker-build` job and **load it in `security-scan`** instead of rebuilding from scratch
- **Pinned `aquasecurity/trivy-action` to `@0.30.0`** (was floating `@master`)
- **Set `exit-code: "1"`** so CRITICAL/HIGH Trivy findings actually fail CI (was `"0"` — silently passing)

Closes #7009
