### PR TITLE
fix: show sidebar labels below icons in YouTube clone

### DIFF
--- a/public/youtube clone/styles/sidebar.css
+++ b/public/youtube clone/styles/sidebar.css
@@ -12,15 +12,15 @@
 }
 
 .sidebar-link {
-  height: 74px; /* default collapsed height */
+  height: 74px;
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
+  justify-content: center;
   align-items: center;
-  padding-left: 24px; /* centers 24px icon in 72px width */
   cursor: pointer;
-  transition: height 0.3s ease, background-color 0.15s ease;
+  transition: background-color 0.15s ease;
+  padding-left: 0;
 }
-
 /* Real-time Interaction Engine: Applies background capsule highlights exclusively on hover states */
 .sidebar-link:hover {
   background-color: rgb(240, 240, 240);
@@ -33,12 +33,21 @@
 }
 
 .sidebar-link div {
-  font-size: 14px;
+  font-size: 10px;
   color: rgb(15, 15, 15);
   font-weight: 400;
-  opacity: 0;
-  max-width: 0;
-  margin-left: 0;
+  margin-top: 6px;
+  text-align: center;
+  opacity: 1;
+  max-width: none;
+  white-space: nowrap;
+}
+
+.sidebar {
+  width: 120px;
+}
+
+.sidebar-link div {
   white-space: nowrap;
   overflow: hidden;
   transition: opacity 0.25s ease, max-width 0.25s ease, margin-left 0.25s ease;
@@ -53,11 +62,11 @@ body.sidebar-expanded .sidebar-link {
   height: 48px;
 }
 
-body.sidebar-expanded .sidebar-link div {
+/* body.sidebar-expanded .sidebar-link div {
   opacity: 1;
   max-width: 150px;
   margin-left: 24px;
-}
+} */
 
 /* Mobile responsive drawer styling */
 @media (max-width: 750px) {


### PR DESCRIPTION
📝 Pull Request Description
Related Issue

Closes #6854

**### Summary**

Fixed a bug in the Day 129 YouTube Clone sidebar where navigation text labels (Home, Shorts, Subscriptions, You) were not visible due to CSS styling. Updated the CSS so labels are properly displayed below the icons, improving usability and matching YouTube’s UI more closely.

**Type of Change**
 🐛 Bug fix (non-breaking change which fixes an issue)

**🛠️ Changes Made**

- Fixed CSS that was hiding sidebar text labels
- Made labels visible below navigation icons
- Improved sidebar readability and UI clarity
- Ensured layout matches YouTube-style navigation

**🧪 Testing and Verification**
- Local Validation
 Verified changes locally in browser
- Browser Compatibility Check
 Tested in Google Chrome
- Responsive & Accessibility Checks
 Verified sidebar layout on desktop view
 Checked mobile responsiveness

🤝 Contributor Checklist

-  My code follows the code style guidelines of the project
-  I have tested my changes locally
-  No console errors introduced
-  No unrelated changes included


📷 Screenshots / Video Recording

✔ Added (after sidebar visibility fix)
<img width="456" height="734" alt="Screenshot 2026-06-07 101246" src="https://github.com/user-attachments/assets/b2dcbda9-2c65-4fb4-b0bf-235ad87ffd77" />
