### PR TITLE
fix(#7005): JWT tokens never expire + Date.now() evaluated at schema definition time

### DIFF
--- a/public/Voting_Application_Backend/server/jwt.js
+++ b/public/Voting_Application_Backend/server/jwt.js
@@ -19,7 +19,7 @@ const jwtAuthMiddleware = (req, res, next)=> {
 }
 
 const generateToken = (voterData) => {
-    return jwt.sign(voterData, process.env.JWT_SECRET);
+    return jwt.sign(voterData, process.env.JWT_SECRET, { expiresIn: '24h' });
 }
 
 module.exports = {jwtAuthMiddleware, generateToken};

--- a/public/Voting_Application_Backend/server/models/candidate.js
+++ b/public/Voting_Application_Backend/server/models/candidate.js
@@ -22,7 +22,7 @@ const candidateSchema = new mongoose.Schema({
             },
             votedAt: {
                 type: Date,
-                default: Date.now()
+                default: Date.now
             }
         }
     ],


### PR DESCRIPTION
Fixes #7005

- Added expiresIn: '24h' to jwt.sign() so tokens actually expire
- Changed Date.now() to Date.now (without parens) so the timestamp is evaluated at document creation time, not schema definition time