### PR TITLE
fix(#7004): 4 critical bugs in AI ChatBot/server.js - https missing, double listen, hardcoded certs, permissive CORS

### DIFF
--- a/public/AI ChatBot/server.js
+++ b/public/AI ChatBot/server.js
@@ -1,23 +1,16 @@
 const express = require('express');
 const http = require('http');
-const fs = require('fs');
 const { Server } = require('socket.io');
 const { v4: uuidv4 } = require('uuid');
 const path = require('path');
 
-const options = {
-  key: fs.readFileSync('path/to/private.key'),
-  cert: fs.readFileSync('path/to/certificate.crt')
-};
-
 const app = express();
-const server = https.createServer(options, app);
-server.listen(443, () => console.log('Secure server running on port 443'));
+const server = http.createServer(app);
 
 // Initialize Socket.io and allow connections from your frontend development server
 const io = new Server(server, {
   cors: {
-    origin: "*", // Adjust this in production to match your frontend URL
+    origin: process.env.NODE_ENV === 'production' ? process.env.FRONTEND_URL || 'https://yourdomain.com' : "*",
     methods: ["GET", "POST"]
   }
 });


### PR DESCRIPTION
Fixes #7004

- Removed broken HTTPS options with hardcoded cert paths (lines 8-11)
- Fixed missing https/http: changed https.createServer to http.createServer (http was already imported)
- Removed duplicate server.listen(443) call (line 15), keeping only the single listen at line 75
- Restricted CORS origin based on NODE_ENV instead of allowing all origins