### PR TITLE
fix: theme toggle icon and syntax error in Notes App

### DIFF
--- a/public/notes-app/script.js
+++ b/public/notes-app/script.js
@@ -29,11 +29,9 @@ function generateUUID() {
 
 const defaultNotes = [
   {
-
     id: crypto.randomUUID(),
     title: "Welcome to Premium Notes",
-    content:
-
+    content: "This is your first note. Click to edit it!",
     tag: "Ideas",
     color: "teal",
     favorite: true,
@@ -810,10 +808,10 @@ function setTheme(theme) {
     theme === "light"
   );
 
-  elements.themeToggle.textContent =
+  elements.themeToggle.innerHTML =
     theme === "light"
-      ? "Dark"
-      : "Light";
+      ? '<i class="ri-moon-line"></i>'
+      : '<i class="ri-sun-line"></i>';
 
   localStorage.setItem(
     THEME_KEY,


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #6981

### Summary
Fixed two bugs in the Notes App:
1. Theme toggle button icon not updating when switching between dark and light mode
2. SyntaxError in script.js caused by missing content value in default note object

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ♻️ Code refactoring / clean-up

---

## 🛠️ Changes Made
- Updated `setTheme()` function to use `innerHTML` instead of `textContent` so the moon/sun icon updates correctly on theme toggle
- Fixed missing `content` value in default welcome note object in script.js that was causing an Uncaught SyntaxError on page load

---

## 🧪 Testing and Verification

### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [x] Tested and verified in **Mozilla Firefox**
- [x] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [x] Verified responsive layout on Mobile viewports (using DevTools)
- [x] Verified responsive layout on Tablet viewports
- [x] Keyboard navigation and focus outlines checked
- [x- ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
Screenshots attached showing theme toggle icon updating correctly and no console errors after fix.
<img width="1920" height="922" alt="Screenshot 2026-06-07 140717" src="https://github.com/user-attachments/assets/861e5ba2-7e8a-4ec4-bc9e-5eefd060a5dc" />
<img width="1920" height="905" alt="Screenshot 2026-06-07 140723" src="https://github.com/user-attachments/assets/77f38314-9775-475f-85b6-a44bc46c5cef" />


---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.

