### PR TITLE
fix: resolve Medical App asset loading failures and broken stylesheet paths (#7113)

### DIFF
--- a/public/Medical_App/index.html
+++ b/public/Medical_App/index.html
@@ -1,6 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script>
+        // Enforce trailing slash redirect if accessed without trailing slash or file name
+        if (window.location.pathname.endsWith('/Medical_App')) {
+            window.location.replace(window.location.pathname + '/');
+        }
+    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>MedConsult Dashboard</title>

--- a/public/Medical_App/remedies.html
+++ b/public/Medical_App/remedies.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Basic Remedies | MedConsult</title>
-    <link rel="stylesheet" href="/public/Medical_App/styles.css" />
+    <link rel="stylesheet" href="css/styles.css" />
     <link rel="stylesheet" href="css/toast.css" />
     <link rel="stylesheet" href="assets/css/auth.css" />
 

--- a/public/Medical_App/reschedule.html
+++ b/public/Medical_App/reschedule.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Reschedule Appointment</title>
-    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/toast.css">
     <link rel="stylesheet" href="assets/css/auth.css">
     <link rel="icon" href="../favv.png" type="image/x-icon" />


### PR DESCRIPTION
Use the following PR structure. It follows the style that has been getting accepted in this repository and clearly documents the bug, root cause, fix, and verification.

---

# PR Title

```text
fix: resolve Medical App asset loading failures and broken stylesheet paths (#7113)
```

---

# PR Description

## Related Issue

Closes #7113

---

## Summary

This PR fixes a critical asset-loading issue in the Medical App that caused the dashboard to render as unstyled HTML and generated multiple CSS/JS 404 errors when the application was accessed through the project directory URL.

The issue occurred because relative asset paths were being resolved incorrectly when the app was loaded from:

```text
/public/Medical_App
```

instead of:

```text
/public/Medical_App/
```

As a result, browsers attempted to load assets from incorrect locations such as:

```text
/public/css/styles.css
```

instead of:

```text
/public/Medical_App/css/styles.css
```

---

## Changes Implemented

### 1. Trailing Slash Enforcement

Added a lightweight redirect mechanism inside:

```text
public/Medical_App/index.html
```

This ensures users accessing:

```text
/public/Medical_App
```

are automatically redirected to:

```text
/public/Medical_App/
```

allowing all relative CSS and JS assets to resolve correctly.

---

### 2. Fixed Incorrect Stylesheet Reference in Home Remedies Page

Updated:

```text
public/Medical_App/remedies.html
```

from:

```html
<link rel="stylesheet" href="/public/Medical_App/styles.css">
```

to:

```html
<link rel="stylesheet" href="css/styles.css">
```

---

### 3. Fixed Incorrect Stylesheet Reference in Reschedule Page

Updated:

```text
public/Medical_App/reschedule.html
```

from:

```html
<link rel="stylesheet" href="styles.css">
```

to:

```html
<link rel="stylesheet" href="css/styles.css">
```

---

## Root Cause

The Medical App uses relative asset references such as:

```html
<link rel="stylesheet" href="css/styles.css">
<script src="js/script.js"></script>
```

When the application was opened without a trailing slash, the browser resolved assets relative to:

```text
/public/
```

instead of:

```text
/public/Medical_App/
```

causing all CSS and JavaScript resources to return 404 errors.

---

## Testing Performed

### Dashboard Verification

* [x] Opened `/public/Medical_App`
* [x] Verified automatic redirect to `/public/Medical_App/`
* [x] Verified dashboard styling loads correctly
* [x] Verified sidebar styling
* [x] Verified hero section styling
* [x] Verified doctor cards styling
* [x] Verified dark mode controls

### Network Verification

* [x] styles.css loads successfully
* [x] darkmode.css loads successfully
* [x] toast.css loads successfully
* [x] animation.css loads successfully
* [x] hero.css loads successfully
* [x] auth.css loads successfully

### JavaScript Verification

* [x] session.js loads successfully
* [x] auth.js loads successfully
* [x] roleManager.js loads successfully
* [x] script.js loads successfully
* [x] dashboard.js loads successfully
* [x] appointments.js loads successfully

### Subpage Verification

* [x] remedies.html styling loads correctly
* [x] reschedule.html styling loads correctly
* [x] No stylesheet 404 errors observed

---

## Screenshots

### Before
<img width="1920" height="1080" alt="Screenshot (623)" src="https://github.com/user-attachments/assets/8aa6291c-769c-4a67-a686-684fd0823225" />
<img width="1920" height="1080" alt="Screenshot (624)" src="https://github.com/user-attachments/assets/c8601543-67fa-4caf-b8c7-ee60488ac416" />

* Dashboard rendered as unstyled HTML
* Multiple CSS and JS 404 errors in Network tab

### After
<img width="1920" height="1080" alt="Screenshot (626)" src="https://github.com/user-attachments/assets/06c5ba70-ec46-4233-8446-bd8968262fd3" />

* Dashboard styling loads correctly
* Assets return HTTP 200
* No Medical App asset loading failures

*(Attach your before/after screenshots here)*

---

## Type of Change

* [x] Bug Fix
* [ ] New Feature
* [ ] Breaking Change
* [ ] Documentation Update

---

## Additional Notes

This fix is fully localized to the Medical App and does not modify any global repository configuration, routing rules, or shared project assets. The solution remains compatible with local development environments, Vercel deployments, and subdirectory-based hosting.
