### PR TITLE
fix: update README project count from 205 to 218 (fixes #6799)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 
 ## 🌟 About This Project
 
-Welcome to **100 Days 100 Web Projects**! This is a comprehensive collection of **205+ web development projects** built using HTML, CSS, JavaScript, React, Node.js, and more.
+Welcome to **100 Days 100 Web Projects**! This is a comprehensive collection of **218+ web development projects** built using HTML, CSS, JavaScript, React, Node.js, and more.
 
 
 ### 🎯 What You'll Find Here:
@@ -60,7 +60,7 @@ The website features:
 - Beautiful dark/light theme toggle
 - Responsive design for all devices
 
-## 📚 All Projects (205 Total)
+## 📚 All Projects (218 Total)
 
 <div align="center">
 
@@ -353,7 +353,7 @@ The easiest way to explore all projects is through our **live website**:
 │   ├── TO_DO_LIST/       # Day 1: Todo List
 │   ├── digital_clock/    # Day 2: Digital Clock
 │   ├── snake_game/       # Day 29: Snake Game
-│   └── ...               # 205+ projects
+│   └── ...               # 218+ projects
 ├── contributors/          # Contributors page
 ├── vercel.json           # Deployment configuration
 └── README.md             # You are here!
@@ -456,7 +456,7 @@ For developers with some experience:
 - Complex animations
 - Interactive games and applications
 
-### 🔥 Advanced Projects (Days 71-205)
+### 🔥 Advanced Projects (Days 71-218)
 Challenging projects for experienced developers:
 - Full-stack applications
 - Complex algorithms


### PR DESCRIPTION
## Summary
Fixes #6799

The README was displaying an outdated project count (205) while the actual number of projects in `projects.json` is 218, causing inconsistency between the README and the website.

## Changes Made
Updated the project count from 205 → 218 in 4 places in `README.md`:

- Line 30: `205+ web development projects` → `218+ web development projects`
- Line 63: `All Projects (205 Total)` → `All Projects (218 Total)`
- Line 356: `# 205+ projects` → `# 218+ projects`
- Line 459: `Advanced Projects (Days 71-205)` → `Advanced Projects (Days 71-218)`

## Root Cause
`projects.json` is the source of truth for the website and currently contains 218 entries, but the README was never updated to reflect newly added projects.

## Type of Change
- [x] Bug fix (documentation inconsistency)

## Checklist
- [x] I have read the CONTRIBUTING guidelines
- [x] My changes are limited to the reported issue
- [x] No new bugs introduced