### PR TITLE
fix(age): enforce realistic past date bounds on birth date input

### DIFF
--- a/public/age-calculator/script.js
+++ b/public/age-calculator/script.js
@@ -101,6 +101,13 @@ function initCalculator() {
       return;
     }
 
+    const minBirthDate = new Date();
+    minBirthDate.setFullYear(minBirthDate.getFullYear() - 120);
+    if (birthDate < minBirthDate) {
+      alert('Date of birth cannot be more than 120 years in the past.');
+      return;
+    }
+
     const age = calculateAge(birthDate, new Date());
     const diffMs = new Date() - birthDate;
     const totalDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));


### PR DESCRIPTION
Closes #7213 

### Description
This PR adds input limits to the Age Calculator to prevent calculations for unrealistic ages.

### Key Changes
- **Past Bounds**: Added validation checking if the input birth date is older than 120 years from the current date.

### Verification & Testing
- Inputting a date like `01/01/1850` triggers a validation alert.
