### PR TITLE
ux(todo): show empty state placeholders for empty Kanban board lanes

### DIFF
--- a/public/TO_DO_LIST/todolist.html
+++ b/public/TO_DO_LIST/todolist.html
@@ -380,9 +380,8 @@
 
       // ─── Render Kanban Board ───────────────────────────────────────────────
       function renderKanban() {
-        document
-          .querySelectorAll(".kanban-column-drop-zone")
-          .forEach((zone) => (zone.innerHTML = ""));
+        const zones = document.querySelectorAll(".kanban-column-drop-zone");
+        zones.forEach((zone) => (zone.innerHTML = ""));
 
         tasks.forEach((task) => {
           const laneDropTarget = document.getElementById(task.status);
@@ -442,6 +441,17 @@
           });
 
           laneDropTarget.appendChild(card);
+        });
+
+        // Add visual empty state placeholders if lanes contain no elements
+        zones.forEach((zone) => {
+          if (zone.children.length === 0) {
+            const emptyCard = document.createElement("div");
+            emptyCard.className = "kanban-empty-lane-placeholder";
+            emptyCard.style.cssText = "text-align: center; padding: 24px 12px; border: 2px dashed rgba(255,255,255,0.06); border-radius: 8px; color: rgba(255,255,255,0.25); font-size: 0.8rem; pointer-events: none; margin: 8px 0;";
+            emptyCard.innerHTML = `<p>✨ Lane is empty</p>`;
+            zone.appendChild(emptyCard);
+          }
         });
 
         calculateSystemCounters();


### PR DESCRIPTION
Closes #7224 


### Description
This PR improves Kanban board layout feedback by rendering dashed placeholder empty states inside empty columns.

### Key Changes
- **Empty States**: Updated `renderKanban()` to append placeholder elements (`.kanban-empty-lane-placeholder`) styled with dashed borders when columns have no tasks.

### Verification & Testing
- Cleared columns to verify placeholders appear correctly and do not interfere with drag-and-drop operations.
