### PR TITLE
accessibility(notes): add visible keyboard focus ring styles

### DIFF
--- a/public/notes-app/style.css
+++ b/public/notes-app/style.css
@@ -1343,3 +1343,17 @@ button {
 #importInput {
     display: none;
 }
+
+/* ============================================================
+   ACCESSIBILITY: Keyboard Focus rings for WCAG compliance
+   ============================================================ */
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible,
+.nav-item:focus-visible,
+.tag-chip:focus-visible {
+  outline: 2px solid var(--primary) !important;
+  outline-offset: 2px !important;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25) !important;
+}


### PR DESCRIPTION
CLOSES #7226

### Description
Restores keyboard navigation focus indicators for the Notes App inputs and controls.

### Key Changes
- **Focus Rings**: Added WCAG AA compliant `:focus-visible` outlines using the primary color variables.

### Verification & Testing
- Traversed the Notes App using the `Tab` key to confirm focus outlines appear on all interactive components.
