### PR TITLE
fix: add amount input validation to Budget Tracker (fixes #6152)

### DIFF
--- a/public/Budget_Tracker/index.html
+++ b/public/Budget_Tracker/index.html
@@ -165,10 +165,18 @@
               placeholder="Enter Amount"
               required
               min="1"
+              max="1000000"
               inputmode="numeric"
             />
 
           </div>
+
+          <!-- Inline validation error — fix #6152 -->
+          <p
+            id="amt-error"
+            style="color:#ff4d4d;font-size:0.78rem;margin:-8px 0 4px 4px;min-height:1.1em;"
+            aria-live="polite"
+          ></p>
 
           <!-- DESCRIPTION -->
           <div class="input-group">

--- a/public/Budget_Tracker/script.js
+++ b/public/Budget_Tracker/script.js
@@ -145,13 +145,29 @@ updateClock();
 form.addEventListener("submit", (e) => {
   e.preventDefault();
 
-  const amount = Number(amountInput.value);
+const rawValue = amountInput.value.trim();
+  const amount   = Number(rawValue);
+  const errorEl  = document.getElementById("amt-error");
 
-  if (amount <= 0) {
-    showToast("Enter valid amount ⚠️");
-
+  if (rawValue === "" || isNaN(amount) || !isFinite(amount)) {
+    if (errorEl) errorEl.textContent = "Please enter a valid number ⚠️";
+    amountInput.focus();
     return;
   }
+
+  if (amount <= 0) {
+    if (errorEl) errorEl.textContent = "Amount must be greater than zero ⚠️";
+    amountInput.focus();
+    return;
+  }
+
+  if (amount > 1_000_000) {
+    if (errorEl) errorEl.textContent = "Amount cannot exceed ₹10,00,000 ⚠️";
+    amountInput.focus();
+    return;
+  }
+
+  if (errorEl) errorEl.textContent = "";
 
   showLoader();
 


### PR DESCRIPTION
## Description
Adds proper client-side validation to the amount input field
in the Budget Tracker to prevent empty, non-numeric, negative,
and excessively large values from corrupting the balance display.

Fixes #6152

## Changes Made
- Updated `index.html` — added `max="1000000"` attribute to the
  amount input and an inline `<p id="amt-error">` element for
  accessible error display (`aria-live="polite"`)
- Updated `script.js` — replaced the single `amount <= 0` check
  with full validation:
  - Empty / non-numeric / non-finite values are rejected
  - Zero or negative amounts are rejected
  - Amounts above ₹10,00,000 are rejected to prevent
    display and calculation corruption
  - Inline error message shown below the input on failure
  - Error is cleared automatically on successful validation

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings