### PR TITLE
feat: enhance dictionary app with multiple meanings, synonyms, favour…

### DIFF
--- a/public/dictionary-app/README.md
+++ b/public/dictionary-app/README.md
@@ -2,51 +2,82 @@
 
 ## Description
 
-A dictionary lookup interface that retrieves English word definitions, phonetics, example usage, and pronunciation audio from a public dictionary API.
+A feature-rich dictionary lookup interface that retrieves English word definitions, phonetics, multiple meanings, synonyms, antonyms, example usages, and pronunciation audio from the free Dictionary API — all with a polished, accessible UI.
 
 ## Features
 
-* Searches for a word through a text input and button.
-* Supports pressing Enter to submit a lookup.
-* Fetches definitions from `dictionaryapi.dev`.
-* Displays the word, phonetic spelling, part of speech, definition, and example context.
-* Shows or hides the example and audio controls based on available API data.
-* Plays pronunciation audio when an audio file is returned.
-* Displays loading and no-result status messages.
+### Core
+- Search for any English word via text input or pressing **Enter**
+- Fetches data from `dictionaryapi.dev` (free, no API key needed)
+- Displays the word, phonetic spelling, part of speech, definition, and example context
+- Plays native audio pronunciation when available
+
+### New in this version
+| Feature | Description |
+|---|---|
+| **Multiple meanings / tabs** | Each part of speech (noun, verb, adj…) gets its own tab; up to 5 definitions shown per tab |
+| **Synonyms & Antonyms** | Displayed as clickable chips at the bottom — clicking searches that word instantly |
+| **Search History** | Last 25 searches saved to `localStorage`; accessible from the sidebar |
+| **Favourites** | Star any word; persists across sessions; click to re-search |
+| **Sidebar panel** | Slide-in panel with History + Favourites; can be cleared |
+| **Dark / Light theme toggle** | Preference saved to `localStorage` |
+| **Copy definition** | Copies `word (partOfSpeech): definition` to clipboard |
+| **Share word** | Uses Web Share API (mobile) or copies a deep-link URL to clipboard |
+| **Clear input button** | × button inside the search field |
+| **Word of the Day** | A new word shown each day from a curated pool; click "Look it up →" to search it |
+| **Deep-link support** | Opening `index.html?q=serendipity` auto-searches that word |
+| **Spinner / loading state** | Animated spinner while fetching |
+| **Toast notifications** | Non-blocking feedback for copy, share, and favourite actions |
 
 ## Technologies Used
 
-* HTML5
-* CSS3
-* JavaScript
-* Free Dictionary API
-* Web Audio playback through the browser `Audio` API
+- HTML5
+- CSS3 (custom properties, CSS animations, responsive layout)
+- Vanilla JavaScript (ES2020+)
+- [DM Serif Display & DM Sans](https://fonts.google.com/) via Google Fonts
+- [Free Dictionary API](https://dictionaryapi.dev/)
+- `localStorage` for persistent history, favourites, and theme
+- Web Audio API (`new Audio()`) for pronunciation playback
+- Web Share API for native sharing on mobile
 
 ## Folder Structure
 
 ```text
 dictionary-app/
-|-- index.html
-|-- styles.css
-`-- app.js
+├── index.html
+├── styles.css
+├── app.js
+└── README.md
 ```
 
 ## How to Run
 
 1. Clone the repository.
-2. Navigate to `public/dictionary-app`.
-3. Open `index.html` in a browser.
-4. Ensure you have an internet connection for dictionary results and audio.
+2. Navigate to `public/dictionary-app` (or wherever the files live).
+3. Open `index.html` in any modern browser.
+4. Ensure you have an internet connection for dictionary results, audio, and Google Fonts.
+
+> No build step, no dependencies, no API key required.
+
+## Deep-link Example
+
+```
+index.html?q=ephemeral
+```
+
+Opens the app and immediately searches for "ephemeral".
 
 ## Screenshots
 
-> Screenshots can be added here.
+> Screenshots can be added here after deployment.
 
 ## Future Enhancements
 
-* Show multiple meanings when a word has several definitions.
-* Add a search history or favorite words list.
+- Offline support via Service Worker caching
+- Multi-language support
+- Flashcard / quiz mode using the favourites list
+- Export favourites as CSV or JSON
 
 ## Author / Contributor
 
-Developed as part of the GSSoC project collection.
+Enhanced as part of the GSSoC project collection.

--- a/public/dictionary-app/app.js
+++ b/public/dictionary-app/app.js
@@ -1,108 +1,402 @@
-// Native Domain Endpoint Configuration Mapping
-const DICTIONARY_API_BASE = "https://api.dictionaryapi.dev/api/v2/entries/en/";
+/* ─── API Configuration ──────────────────────────────────────────── */
+const DICTIONARY_API = "https://api.dictionaryapi.dev/api/v2/entries/en/";
 
-const wordInput = document.getElementById("wordInput");
-const searchBtn = document.getElementById("searchBtn");
+/* ─── Word of the Day pool ───────────────────────────────────────── */
+const WOTD_POOL = [
+  "serendipity", "ephemeral", "luminous", "resonance", "eloquent",
+  "melancholy", "zenith", "solstice", "labyrinth", "nebulous",
+  "persevere", "rhetoric", "sanguine", "tranquil", "vivacious",
+  "wistful", "axiom", "cascade", "diligent", "equanimity",
+  "felicity", "gossamer", "halcyon", "impassive", "jubilant"
+];
 
-const resultsArea = document.getElementById("resultsArea");
-const statusBox = document.getElementById("statusBox");
-
-const targetWord = document.getElementById("targetWord");
+/* ─── DOM References ─────────────────────────────────────────────── */
+const wordInput    = document.getElementById("wordInput");
+const searchBtn    = document.getElementById("searchBtn");
+const clearInputBtn= document.getElementById("clearInputBtn");
+const resultsArea  = document.getElementById("resultsArea");
+const statusBox    = document.getElementById("statusBox");
+const statusText   = document.getElementById("statusText");
+const targetWord   = document.getElementById("targetWord");
 const phoneticText = document.getElementById("phoneticText");
-const partOfSpeech = document.getElementById("partOfSpeech");
-const definitionText = document.getElementById("definitionText");
-const exampleText = document.getElementById("exampleText");
-const exampleWrapper = document.getElementById("exampleWrapper");
-const audioBtn = document.getElementById("audioBtn");
+const audioBtn     = document.getElementById("audioBtn");
+const copyBtn      = document.getElementById("copyBtn");
+const favBtn       = document.getElementById("favBtn");
+const shareBtn     = document.getElementById("shareBtn");
+const meaningsTabs = document.getElementById("meaningsTabs");
+const meaningPanels= document.getElementById("meaningPanels");
+const synAntRow    = document.getElementById("synAntRow");
+const synBlock     = document.getElementById("synBlock");
+const antBlock     = document.getElementById("antBlock");
+const synList      = document.getElementById("synList");
+const antList      = document.getElementById("antList");
+const copyToast    = document.getElementById("copyToast");
+const themeToggle  = document.getElementById("themeToggle");
+const sidebarToggle= document.getElementById("sidebarToggle");
+const sidebarClose = document.getElementById("sidebarClose");
+const sidebar      = document.getElementById("sidebar");
+const historyList  = document.getElementById("historyList");
+const favouritesList=document.getElementById("favouritesList");
+const clearHistory = document.getElementById("clearHistory");
+const wotdWord     = document.getElementById("wotdWord");
+const wotdLookBtn  = document.getElementById("wotdLookBtn");
 
-let activeAudioTrackUrl = "";
+/* ─── State ──────────────────────────────────────────────────────── */
+let activeAudioUrl = "";
+let currentWord    = "";
+let currentPayload = null;
+let searchHistory  = JSON.parse(localStorage.getItem("vl_history") || "[]");
+let favourites     = JSON.parse(localStorage.getItem("vl_favs")    || "[]");
+let activeTabIndex = 0;
 
-// Functional Module: API REST Engine Callback Interface
-async function lookUpWordDefinition(queryTerm) {
-  if (!queryTerm) return;
+/* ─── Theme ──────────────────────────────────────────────────────── */
+const savedTheme = localStorage.getItem("vl_theme") || "dark";
+applyTheme(savedTheme);
 
-  // Toggle runtime UI loading state elements
-  resultsArea.classList.add("hidden");
-  statusBox.classList.remove("hidden");
-  statusBox.innerText = `Searching lexicon references for "${queryTerm}"...`;
-  activeAudioTrackUrl = "";
-
-  try {
-    const response = await fetch(
-      `${DICTIONARY_API_BASE}${encodeURIComponent(queryTerm)}`,
-    );
-
-    if (!response.ok) {
-      throw new Error("Could not locate definition records for this keyword.");
-    }
-
-    const dataArray = await response.json();
-    populateDictionaryUI(dataArray[0]);
-  } catch (err) {
-    statusBox.classList.remove("hidden");
-    statusBox.innerText = `No results found for "${queryTerm}". Try verifying spelling rules or search another term.`;
-  }
+function applyTheme(t) {
+  document.documentElement.setAttribute("data-theme", t);
+  localStorage.setItem("vl_theme", t);
+  document.querySelector(".icon-moon").classList.toggle("hidden", t === "light");
+  document.querySelector(".icon-sun").classList.toggle("hidden",  t === "dark");
 }
 
-// Map Response Models directly down onto DOM structural nodes
-function populateDictionaryUI(wordPayload) {
-  statusBox.classList.add("hidden");
-  resultsArea.classList.remove("hidden");
-
-  // Populate foundational textual information fields
-  targetWord.innerText = wordPayload.word;
-  phoneticText.innerText =
-    wordPayload.phonetic ||
-    (wordPayload.phonetics &&
-      wordPayload.phonetics.find((p) => p.text)?.text) ||
-    "";
-
-  // Dig out first primary lexical object structures
-  const primaryMeaning = wordPayload.meanings[0];
-  partOfSpeech.innerText = primaryMeaning.partOfSpeech;
-
-  const operationalDefinition = primaryMeaning.definitions[0];
-  definitionText.innerText = operationalDefinition.definition;
-
-  // Handle Example Usage blocks cleanly
-  if (operationalDefinition.example) {
-    exampleWrapper.classList.remove("hidden");
-    exampleText.innerText = `"${operationalDefinition.example}"`;
-  } else {
-    exampleWrapper.classList.add("hidden");
-  }
-
-  // Isolate sound files containing audio configurations across phonetics arrays
-  const validAudioObj = wordPayload.phonetics.find(
-    (p) => p.audio && p.audio.trim() !== "",
-  );
-
-  if (validAudioObj) {
-    activeAudioTrackUrl = validAudioObj.audio;
-    audioBtn.style.display = "flex";
-  } else {
-    audioBtn.style.display = "none";
-  }
-}
-
-// Executive Click Events & Key listeners
-searchBtn.addEventListener("click", () => {
-  const cleanWord = wordInput.value.trim();
-  lookUpWordDefinition(cleanWord);
+themeToggle.addEventListener("click", () => {
+  const cur = document.documentElement.getAttribute("data-theme");
+  applyTheme(cur === "dark" ? "light" : "dark");
 });
 
-wordInput.addEventListener("keypress", (e) => {
+/* ─── Sidebar ────────────────────────────────────────────────────── */
+// Create overlay element
+const overlay = document.createElement("div");
+overlay.className = "sidebar-overlay";
+document.body.appendChild(overlay);
+
+function openSidebar() {
+  sidebar.classList.add("open");
+  overlay.classList.add("visible");
+  renderHistoryList();
+  renderFavouritesList();
+}
+function closeSidebar() {
+  sidebar.classList.remove("open");
+  overlay.classList.remove("visible");
+}
+
+sidebarToggle.addEventListener("click", openSidebar);
+sidebarClose.addEventListener("click", closeSidebar);
+overlay.addEventListener("click", closeSidebar);
+
+/* ─── Word of the Day ────────────────────────────────────────────── */
+const todayKey = new Date().toDateString();
+let wotd = localStorage.getItem("vl_wotd_word");
+let wotdDate = localStorage.getItem("vl_wotd_date");
+if (wotdDate !== todayKey) {
+  wotd = WOTD_POOL[Math.floor(Math.random() * WOTD_POOL.length)];
+  localStorage.setItem("vl_wotd_word", wotd);
+  localStorage.setItem("vl_wotd_date", todayKey);
+}
+wotdWord.textContent = wotd;
+wotdLookBtn.addEventListener("click", () => {
+  wordInput.value = wotd;
+  lookUpWord(wotd);
+});
+
+/* ─── Search Input helpers ───────────────────────────────────────── */
+wordInput.addEventListener("input", () => {
+  clearInputBtn.classList.toggle("hidden", wordInput.value.trim() === "");
+});
+clearInputBtn.addEventListener("click", () => {
+  wordInput.value = "";
+  clearInputBtn.classList.add("hidden");
+  wordInput.focus();
+});
+searchBtn.addEventListener("click", () => {
+  const w = wordInput.value.trim();
+  if (w) lookUpWord(w);
+});
+wordInput.addEventListener("keydown", (e) => {
   if (e.key === "Enter") searchBtn.click();
 });
 
-// Play Audio Track Using Native Audio Element API Elements
-audioBtn.addEventListener("click", () => {
-  if (activeAudioTrackUrl) {
-    const structuralAudioPlaybackNode = new Audio(activeAudioTrackUrl);
-    structuralAudioPlaybackNode.play().catch((err) => {
-      alert(
-        "Audio stream could not initialize. Try toggling browser permissions.",
-      );
+/* ─── Core API lookup ────────────────────────────────────────────── */
+async function lookUpWord(query) {
+  if (!query) return;
+  currentWord = query.toLowerCase();
+
+  // UI: loading state
+  resultsArea.classList.add("hidden");
+  statusBox.classList.remove("hidden");
+  statusText.textContent = `Looking up "${query}"…`;
+  activeAudioUrl = "";
+
+  try {
+    const res = await fetch(`${DICTIONARY_API}${encodeURIComponent(query)}`);
+    if (!res.ok) throw new Error("Not found");
+    const data = await res.json();
+    currentPayload = data[0];
+    renderResults(currentPayload);
+    addToHistory(query.toLowerCase());
+  } catch {
+    statusBox.classList.remove("hidden");
+    statusText.textContent = `No results found for "${query}". Check the spelling and try again.`;
+    resultsArea.classList.add("hidden");
+    // Remove spinner on error
+    document.querySelector(".spinner").style.display = "none";
+  }
+}
+
+/* ─── Render all results ─────────────────────────────────────────── */
+function renderResults(payload) {
+  statusBox.classList.add("hidden");
+  document.querySelector(".spinner").style.display = "";
+  resultsArea.classList.remove("hidden");
+  activeTabIndex = 0;
+
+  // Word & phonetic
+  targetWord.textContent = payload.word;
+  const phonetic = payload.phonetic
+    || (payload.phonetics && payload.phonetics.find(p => p.text)?.text)
+    || "";
+  phoneticText.textContent = phonetic || "";
+  phoneticText.style.display = phonetic ? "block" : "none";
+
+  // Audio
+  const audioObj = payload.phonetics?.find(p => p.audio && p.audio.trim());
+  if (audioObj) {
+    activeAudioUrl = audioObj.audio;
+    audioBtn.style.display = "flex";
+  } else {
+    activeAudioUrl = "";
+    audioBtn.style.display = "none";
+  }
+
+  // Favourite button state
+  favBtn.classList.toggle("active", favourites.includes(payload.word.toLowerCase()));
+
+  // Build tabs + panels
+  meaningsTabs.innerHTML = "";
+  meaningPanels.innerHTML = "";
+
+  payload.meanings.forEach((meaning, idx) => {
+    // Tab
+    const tab = document.createElement("button");
+    tab.className = "tab-btn" + (idx === 0 ? " active" : "");
+    tab.textContent = meaning.partOfSpeech;
+    tab.dataset.idx = idx;
+    tab.addEventListener("click", () => switchTab(idx));
+    meaningsTabs.appendChild(tab);
+
+    // Panel
+    const panel = document.createElement("div");
+    panel.className = "meaning-panel" + (idx === 0 ? " active" : "");
+    panel.id = `panel-${idx}`;
+
+    // Up to 5 definitions
+    meaning.definitions.slice(0, 5).forEach((def, dIdx) => {
+      const item = document.createElement("div");
+      item.className = "def-item";
+
+      const numBadge = document.createElement("span");
+      numBadge.className = "def-number";
+      numBadge.textContent = `Def. ${dIdx + 1}`;
+      item.appendChild(numBadge);
+
+      const defText = document.createElement("p");
+      defText.className = "def-text";
+      defText.textContent = def.definition;
+      item.appendChild(defText);
+
+      if (def.example) {
+        const ex = document.createElement("p");
+        ex.className = "example-text";
+        ex.textContent = `"${def.example}"`;
+        item.appendChild(ex);
+      }
+
+      // Synonyms / antonyms within definition
+      const allSyns = [...(def.synonyms || [])];
+      const allAnts = [...(def.antonyms || [])];
+      if (allSyns.length || allAnts.length) {
+        const chips = document.createElement("div");
+        chips.className = "def-chips";
+        allSyns.slice(0, 5).forEach(s => {
+          const c = document.createElement("span");
+          c.className = "def-chip";
+          c.textContent = s;
+          c.title = `Search "${s}"`;
+          c.addEventListener("click", () => { wordInput.value = s; lookUpWord(s); });
+          chips.appendChild(c);
+        });
+        if (chips.children.length) item.appendChild(chips);
+      }
+
+      panel.appendChild(item);
     });
+
+    meaningPanels.appendChild(panel);
+  });
+
+  // Aggregate synonyms / antonyms across all meanings
+  const allSyns = new Set();
+  const allAnts = new Set();
+  payload.meanings.forEach(m => {
+    m.synonyms?.forEach(s => allSyns.add(s));
+    m.antonyms?.forEach(a => allAnts.add(a));
+    m.definitions?.forEach(d => {
+      d.synonyms?.forEach(s => allSyns.add(s));
+      d.antonyms?.forEach(a => allAnts.add(a));
+    });
+  });
+
+  renderChips(synList, [...allSyns].slice(0, 10), "syn-chip");
+  renderChips(antList, [...allAnts].slice(0, 10), "ant-chip");
+
+  synBlock.classList.toggle("hidden", allSyns.size === 0);
+  antBlock.classList.toggle("hidden", allAnts.size === 0);
+  synAntRow.classList.toggle("hidden", allSyns.size === 0 && allAnts.size === 0);
+}
+
+function renderChips(container, words, cls) {
+  container.innerHTML = "";
+  words.forEach(w => {
+    const chip = document.createElement("span");
+    chip.className = cls;
+    chip.textContent = w;
+    chip.title = `Search "${w}"`;
+    chip.addEventListener("click", () => { wordInput.value = w; lookUpWord(w); });
+    container.appendChild(chip);
+  });
+}
+
+function switchTab(idx) {
+  activeTabIndex = idx;
+  document.querySelectorAll(".tab-btn").forEach((b, i) => b.classList.toggle("active", i === idx));
+  document.querySelectorAll(".meaning-panel").forEach((p, i) => p.classList.toggle("active", i === idx));
+}
+
+/* ─── Audio ──────────────────────────────────────────────────────── */
+audioBtn.addEventListener("click", () => {
+  if (!activeAudioUrl) return;
+  const audio = new Audio(activeAudioUrl);
+  audio.play().catch(() => alert("Audio could not play. Check browser permissions."));
+});
+
+/* ─── Copy definition ────────────────────────────────────────────── */
+copyBtn.addEventListener("click", () => {
+  if (!currentPayload) return;
+  const meaning = currentPayload.meanings[activeTabIndex] || currentPayload.meanings[0];
+  const def = meaning.definitions[0].definition;
+  const text = `${currentPayload.word} (${meaning.partOfSpeech}): ${def}`;
+  navigator.clipboard.writeText(text).then(() => showToast("Definition copied!"));
+});
+
+/* ─── Favourites ─────────────────────────────────────────────────── */
+favBtn.addEventListener("click", () => {
+  if (!currentWord) return;
+  if (favourites.includes(currentWord)) {
+    favourites = favourites.filter(w => w !== currentWord);
+    favBtn.classList.remove("active");
+    showToast("Removed from favourites");
+  } else {
+    favourites.unshift(currentWord);
+    favBtn.classList.add("active");
+    showToast("Added to favourites ★");
+  }
+  localStorage.setItem("vl_favs", JSON.stringify(favourites));
+  renderFavouritesList();
+});
+
+/* ─── Share ──────────────────────────────────────────────────────── */
+shareBtn.addEventListener("click", () => {
+  if (!currentWord) return;
+  const url = `${location.origin}${location.pathname}?q=${encodeURIComponent(currentWord)}`;
+  if (navigator.share) {
+    navigator.share({ title: `Look up "${currentWord}"`, url });
+  } else {
+    navigator.clipboard.writeText(url).then(() => showToast("Link copied to clipboard!"));
   }
 });
+
+/* ─── History ────────────────────────────────────────────────────── */
+function addToHistory(word) {
+  searchHistory = [word, ...searchHistory.filter(w => w !== word)].slice(0, 25);
+  localStorage.setItem("vl_history", JSON.stringify(searchHistory));
+  renderHistoryList();
+}
+
+clearHistory.addEventListener("click", () => {
+  searchHistory = [];
+  localStorage.removeItem("vl_history");
+  renderHistoryList();
+});
+
+function renderHistoryList() {
+  historyList.innerHTML = "";
+  if (!searchHistory.length) {
+    historyList.innerHTML = '<li class="empty-note">No searches yet.</li>';
+    return;
+  }
+  searchHistory.forEach(w => historyList.appendChild(makeWordChip(w, () => {
+    closeSidebar();
+    wordInput.value = w;
+    lookUpWord(w);
+  }, null)));
+}
+
+/* ─── Favourites list ────────────────────────────────────────────── */
+function renderFavouritesList() {
+  favouritesList.innerHTML = "";
+  if (!favourites.length) {
+    favouritesList.innerHTML = '<li class="empty-note">No favourites yet.</li>';
+    return;
+  }
+  favourites.forEach(w => favouritesList.appendChild(makeWordChip(w, () => {
+    closeSidebar();
+    wordInput.value = w;
+    lookUpWord(w);
+  }, () => {
+    favourites = favourites.filter(f => f !== w);
+    localStorage.setItem("vl_favs", JSON.stringify(favourites));
+    if (currentWord === w) favBtn.classList.remove("active");
+    renderFavouritesList();
+  })));
+}
+
+function makeWordChip(word, onClick, onRemove) {
+  const li = document.createElement("li");
+  const btn = document.createElement("button");
+  btn.textContent = word;
+  if (onRemove) {
+    const rm = document.createElement("span");
+    rm.className = "remove-chip";
+    rm.textContent = "✕";
+    rm.addEventListener("click", (e) => { e.stopPropagation(); onRemove(); });
+    btn.appendChild(rm);
+  }
+  btn.addEventListener("click", onClick);
+  li.appendChild(btn);
+  return li;
+}
+
+/* ─── Toast helper ───────────────────────────────────────────────── */
+let toastTimer;
+function showToast(msg) {
+  copyToast.textContent = msg;
+  copyToast.classList.add("show");
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => copyToast.classList.remove("show"), 2200);
+}
+
+/* ─── Deep-link: ?q=word on load ────────────────────────────────── */
+const params = new URLSearchParams(location.search);
+if (params.has("q")) {
+  const q = params.get("q").trim();
+  if (q) {
+    wordInput.value = q;
+    lookUpWord(q);
+  }
+}
+
+/* ─── Render history/favs on sidebar open ───────────────────────── */
+renderHistoryList();
+renderFavouritesList();

--- a/public/dictionary-app/index.html
+++ b/public/dictionary-app/index.html
@@ -1,68 +1,157 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Dictionary App with Audio Pronunciation</title>
+    <title>Vocal Lexicon — Dictionary</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,500;0,9..40,700;1,9..40,300&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <div class="app-container">
-      <header class="app-header">
-        <h1>Vocal Lexicon Dictionary</h1>
-        <p>
-          Explore instant definitions, example usages, and native audio
-          pronunciations
-        </p>
-      </header>
+    <!-- Decorative background blobs -->
+    <div class="bg-blob blob-1"></div>
+    <div class="bg-blob blob-2"></div>
 
-      <section class="search-box-panel">
-        <input
-          type="text"
-          id="wordInput"
-          placeholder="Type a word to look up... (e.g., resonance)"
-        />
-        <button id="searchBtn">Search</button>
-      </section>
+    <div class="app-wrapper">
 
-      <main class="results-layout hidden" id="resultsArea">
-        <div class="word-meta-row">
-          <div class="word-heading">
-            <h2 id="targetWord">Word</h2>
-            <span id="phoneticText">/phonetic/</span>
-          </div>
-          <button
-            class="audio-trigger-btn"
-            id="audioBtn"
-            title="Play Pronunciation"
-          >
-            <svg viewBox="0 0 24 24" class="speaker-icon">
-              <path
-                d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"
-              />
-            </svg>
+      <!-- ── Sidebar ───────────────────────────────────────────── -->
+      <aside class="sidebar" id="sidebar">
+        <div class="sidebar-header">
+          <span class="sidebar-logo">VL</span>
+          <button class="sidebar-close" id="sidebarClose" title="Close panel">✕</button>
+        </div>
+
+        <!-- Favorites -->
+        <section class="sidebar-section">
+          <h4 class="sidebar-label">
+            <svg viewBox="0 0 24 24" class="icon-sm"><path d="M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z"/></svg>
+            Favourites
+          </h4>
+          <ul class="word-chip-list" id="favouritesList">
+            <li class="empty-note">No favourites yet.</li>
+          </ul>
+        </section>
+
+        <!-- History -->
+        <section class="sidebar-section">
+          <h4 class="sidebar-label">
+            <svg viewBox="0 0 24 24" class="icon-sm"><path d="M13 3a9 9 0 0 0-9 9H1l3.89 3.89.07.14L9 12H6c0-3.87 3.13-7 7-7s7 3.13 7 7-3.13 7-7 7c-1.93 0-3.68-.79-4.95-2.05L6.7 18.3A8.964 8.964 0 0 0 13 21a9 9 0 0 0 0-18zm-1 5v5l4.28 2.54.72-1.21-3.5-2.08V8H12z"/></svg>
+            History
+          </h4>
+          <ul class="word-chip-list" id="historyList">
+            <li class="empty-note">No searches yet.</li>
+          </ul>
+          <button class="clear-btn" id="clearHistory">Clear history</button>
+        </section>
+      </aside>
+
+      <!-- ── Main ──────────────────────────────────────────────── -->
+      <main class="main-content">
+
+        <!-- Top bar -->
+        <nav class="top-bar">
+          <button class="icon-btn" id="sidebarToggle" title="Open history &amp; favourites">
+            <svg viewBox="0 0 24 24"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"/></svg>
           </button>
+          <span class="brand">Vocal Lexicon</span>
+          <button class="icon-btn" id="themeToggle" title="Toggle theme">
+            <svg class="icon-moon" viewBox="0 0 24 24"><path d="M12 3a9 9 0 1 0 9 9c0-.46-.04-.92-.1-1.36a5.389 5.389 0 0 1-4.4 2.26 5.403 5.403 0 0 1-3.14-9.8c-.44-.06-.9-.1-1.36-.1z"/></svg>
+            <svg class="icon-sun hidden" viewBox="0 0 24 24"><path d="M6.76 4.84l-1.8-1.79-1.41 1.41 1.79 1.79 1.42-1.41zM4 11H1v2h3v-2zm9-9h-2v2.99h2V2zm7.45 3.91l-1.41-1.41-1.79 1.79 1.41 1.41 1.79-1.79zm-3.21 13.7l1.79 1.8 1.41-1.41-1.8-1.79-1.4 1.4zM20 11v2h3v-2h-3zm-8-5a6 6 0 0 0 0 12 6 6 0 0 0 0-12zm-1 16.99h2V19h-2v2.99zm-7.45-3.91l1.41 1.41 1.79-1.8-1.41-1.41-1.79 1.8z"/></svg>
+          </button>
+        </nav>
+
+        <!-- Hero header -->
+        <header class="hero-header">
+          <h1 class="hero-title">Discover Words</h1>
+          <p class="hero-sub">Definitions · Phonetics · Synonyms · Audio · and more</p>
+        </header>
+
+        <!-- Search bar -->
+        <div class="search-panel">
+          <div class="search-field">
+            <svg class="search-icon" viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5 6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"/></svg>
+            <input
+              type="text"
+              id="wordInput"
+              class="search-input"
+              placeholder="Search a word… e.g. serendipity"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <button class="clear-input-btn hidden" id="clearInputBtn" title="Clear">✕</button>
+          </div>
+          <button class="search-btn" id="searchBtn">Search</button>
         </div>
 
-        <div class="lexical-card">
-          <span class="part-of-speech-tag" id="partOfSpeech">noun</span>
-          <div class="meaning-group">
-            <h3>Definition</h3>
-            <p id="definitionText">The definition will populate here.</p>
+        <!-- Word of the Day banner -->
+        <div class="wotd-banner" id="wotdBanner">
+          <div class="wotd-label">
+            <svg viewBox="0 0 24 24" class="icon-sm"><path d="M11.5 2C6.81 2 3 5.81 3 10.5S6.81 19 11.5 19h.5v3c4.86-2.34 8-7 8-11.5C20 5.81 16.19 2 11.5 2zm1 14.5h-2v-2h2v2zm0-4h-2c0-3.25 3-3 3-5 0-1.1-.9-2-2-2s-2 .9-2 2h-2c0-2.21 1.79-4 4-4s4 1.79 4 4c0 2.5-3 2.75-3 5z"/></svg>
+            Word of the Day
           </div>
-          <div class="example-group" id="exampleWrapper">
-            <h3>Example Context</h3>
-            <p id="exampleText" class="italic-context">
-              Example usage context will populate here.
-            </p>
-          </div>
+          <span class="wotd-word" id="wotdWord">Loading…</span>
+          <button class="wotd-look-btn" id="wotdLookBtn">Look it up →</button>
         </div>
+
+        <!-- Status message -->
+        <div class="status-box hidden" id="statusBox">
+          <div class="spinner"></div>
+          <span id="statusText">Searching…</span>
+        </div>
+
+        <!-- Results area -->
+        <section class="results-area hidden" id="resultsArea">
+
+          <!-- Word header row -->
+          <div class="word-header-row">
+            <div>
+              <h2 class="result-word" id="targetWord">word</h2>
+              <span class="result-phonetic" id="phoneticText">/phonetic/</span>
+            </div>
+            <div class="word-actions">
+              <button class="icon-btn" id="audioBtn" title="Play pronunciation" style="display:none">
+                <svg viewBox="0 0 24 24"><path d="M3 9v6h4l5 5V4L7 9H3zm13.5 3c0-1.77-1.02-3.29-2.5-4.03v8.05c1.48-.73 2.5-2.25 2.5-4.02zM14 3.23v2.06c2.89.86 5 3.54 5 6.71s-2.11 5.85-5 6.71v2.06c4.01-.91 7-4.49 7-8.77s-2.99-7.86-7-8.77z"/></svg>
+              </button>
+              <button class="icon-btn" id="copyBtn" title="Copy definition">
+                <svg viewBox="0 0 24 24"><path d="M16 1H4c-1.1 0-2 .9-2 2v14h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"/></svg>
+              </button>
+              <button class="icon-btn fav-btn" id="favBtn" title="Add to favourites">
+                <svg viewBox="0 0 24 24"><path d="M22 9.24l-7.19-.62L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21 12 17.27 18.18 21l-1.63-7.03L22 9.24zM12 15.4l-3.76 2.27 1-4.28-3.32-2.88 4.38-.38L12 6.1l1.71 4.04 4.38.38-3.32 2.88 1 4.28L12 15.4z"/></svg>
+              </button>
+              <button class="icon-btn" id="shareBtn" title="Share word">
+                <svg viewBox="0 0 24 24"><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z"/></svg>
+              </button>
+            </div>
+          </div>
+
+          <!-- Meanings tabs -->
+          <div class="meanings-tabs" id="meaningsTabs"></div>
+
+          <!-- Meaning panels -->
+          <div id="meaningPanels"></div>
+
+          <!-- Synonyms / Antonyms row -->
+          <div class="syn-ant-row hidden" id="synAntRow">
+            <div class="syn-block hidden" id="synBlock">
+              <h4 class="chip-label">Synonyms</h4>
+              <div class="chip-list" id="synList"></div>
+            </div>
+            <div class="ant-block hidden" id="antBlock">
+              <h4 class="chip-label">Antonyms</h4>
+              <div class="chip-list" id="antList"></div>
+            </div>
+          </div>
+
+        </section>
+
+        <!-- Copy toast -->
+        <div class="toast hidden" id="copyToast">Definition copied!</div>
+
       </main>
-
-      <div class="status-message hidden" id="statusBox">
-        Loading information...
-      </div>
     </div>
+
     <script src="app.js"></script>
   </body>
 </html>

--- a/public/dictionary-app/styles.css
+++ b/public/dictionary-app/styles.css
@@ -1,233 +1,593 @@
+/* ─── Google Fonts loaded in HTML ──────────────────────────────── */
+
+/* ─── Design Tokens ─────────────────────────────────────────────── */
 :root {
-  --bg-deep: #080c14;
-  --bg-surface: #101624;
-  --bg-card: #192239;
-  --border-subtle: rgba(255, 255, 255, 0.05);
-  --text-primary: #f8fafc;
-  --text-secondary: #94a3b8;
-  --accent-glow: #38bdf8;
-  --accent-hover: #0284c7;
+  /* Dark theme (default) */
+  --bg-base:        #09101f;
+  --bg-surface:     #111827;
+  --bg-card:        #1a2540;
+  --bg-chip:        rgba(56, 189, 248, 0.08);
+  --border:         rgba(255,255,255,0.07);
+  --border-accent:  rgba(56,189,248,0.35);
+  --text-primary:   #f1f5fb;
+  --text-secondary: #8898b4;
+  --text-muted:     #4f637d;
+  --accent:         #38bdf8;
+  --accent-2:       #818cf8;
+  --accent-danger:  #f87171;
+  --shadow:         0 20px 60px rgba(0,0,0,0.5);
+  --radius:         1rem;
+  --tab-active-bg:  rgba(56,189,248,0.12);
+  --toast-bg:       #1e3a5f;
 }
 
-* {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
+[data-theme="light"] {
+  --bg-base:        #f0f4fb;
+  --bg-surface:     #ffffff;
+  --bg-card:        #e8edf8;
+  --bg-chip:        rgba(2,132,199,0.08);
+  --border:         rgba(0,0,0,0.08);
+  --border-accent:  rgba(2,132,199,0.35);
+  --text-primary:   #0f1d36;
+  --text-secondary: #4a6080;
+  --text-muted:     #8899b0;
+  --accent:         #0284c7;
+  --accent-2:       #6366f1;
+  --accent-danger:  #dc2626;
+  --shadow:         0 10px 40px rgba(0,0,0,0.12);
+  --tab-active-bg:  rgba(2,132,199,0.08);
+  --toast-bg:       #0284c7;
 }
 
+/* ─── Reset ──────────────────────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
 body {
-  font-family:
-    system-ui,
-    -apple-system,
-    BlinkMacSystemFont,
-    sans-serif;
-  background-color: var(--bg-deep);
+  font-family: 'DM Sans', system-ui, sans-serif;
+  background: var(--bg-base);
   color: var(--text-primary);
   min-height: 100vh;
+  overflow-x: hidden;
+  transition: background 0.3s, color 0.3s;
+}
+
+/* ─── Background blobs ───────────────────────────────────────────── */
+.bg-blob {
+  position: fixed;
+  border-radius: 50%;
+  filter: blur(120px);
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.18;
+  transition: opacity 0.3s;
+}
+.blob-1 {
+  width: 600px; height: 600px;
+  background: radial-gradient(circle, #38bdf8, transparent 70%);
+  top: -200px; left: -200px;
+}
+.blob-2 {
+  width: 500px; height: 500px;
+  background: radial-gradient(circle, #818cf8, transparent 70%);
+  bottom: -150px; right: -150px;
+}
+[data-theme="light"] .bg-blob { opacity: 0.10; }
+
+/* ─── Layout ─────────────────────────────────────────────────────── */
+.app-wrapper {
+  position: relative;
+  z-index: 1;
   display: flex;
-  justify-content: center;
+  min-height: 100vh;
+}
+
+/* ─── Sidebar ────────────────────────────────────────────────────── */
+.sidebar {
+  width: 280px;
+  min-height: 100vh;
+  background: var(--bg-surface);
+  border-right: 1px solid var(--border);
+  padding: 1.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  position: fixed;
+  left: -300px;
+  top: 0;
+  bottom: 0;
+  z-index: 200;
+  transition: left 0.3s cubic-bezier(0.4,0,0.2,1), box-shadow 0.3s;
+  overflow-y: auto;
+}
+.sidebar.open {
+  left: 0;
+  box-shadow: 4px 0 40px rgba(0,0,0,0.35);
+}
+.sidebar-header {
+  display: flex;
   align-items: center;
-  padding: 2rem 1rem;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
 }
-
-.app-container {
-  width: 100%;
-  max-width: 620px;
-  background-color: var(--bg-surface);
-  border: 1px solid var(--border-subtle);
-  border-radius: 1.25rem;
-  padding: 2.5rem;
-  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.4);
+.sidebar-logo {
+  font-family: 'DM Serif Display', serif;
+  font-size: 1.4rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  font-weight: 400;
 }
-
-.app-header {
-  text-align: center;
-  margin-bottom: 2.5rem;
+.sidebar-close {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.35rem;
+  transition: background 0.15s;
 }
+.sidebar-close:hover { background: var(--bg-card); }
 
-.app-header h1 {
-  font-size: 2.2rem;
+.sidebar-section { display: flex; flex-direction: column; gap: 0.6rem; }
+.sidebar-label {
+  font-size: 0.75rem;
   font-weight: 700;
-  letter-spacing: -0.02em;
-  background: linear-gradient(to right, #38bdf8, #818cf8);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.sidebar-label .icon-sm { fill: var(--text-muted); }
+
+.word-chip-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.word-chip-list li button {
+  background: none;
+  border: none;
+  color: var(--text-primary);
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.9rem;
+  cursor: pointer;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.5rem;
+  width: 100%;
+  text-align: left;
+  transition: background 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+.word-chip-list li button:hover { background: var(--bg-card); }
+.word-chip-list li button .remove-chip {
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  flex-shrink: 0;
+}
+.word-chip-list li button:hover .remove-chip { color: var(--accent-danger); }
+.empty-note {
+  font-size: 0.82rem;
+  color: var(--text-muted);
+  padding: 0.4rem 0.75rem;
+  font-style: italic;
+}
+.clear-btn {
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 0.78rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 0.4rem;
+  cursor: pointer;
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  transition: border-color 0.15s, color 0.15s;
+}
+.clear-btn:hover { border-color: var(--accent-danger); color: var(--accent-danger); }
+
+/* Sidebar overlay */
+.sidebar-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  z-index: 190;
+  backdrop-filter: blur(2px);
+}
+.sidebar-overlay.visible { display: block; }
+
+/* ─── Main content ───────────────────────────────────────────────── */
+.main-content {
+  flex: 1;
+  padding: 1.5rem 1.5rem 4rem;
+  max-width: 760px;
+  margin: 0 auto;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+/* ─── Top bar ────────────────────────────────────────────────────── */
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 0;
+}
+.brand {
+  font-family: 'DM Serif Display', serif;
+  font-size: 1.25rem;
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
 }
 
-.app-header p {
-  color: var(--text-secondary);
-  font-size: 0.95rem;
-  margin-top: 0.5rem;
-  line-height: 1.4;
-}
-
-/* Search Console Control Field */
-.search-box-panel {
-  display: flex;
-  gap: 0.75rem;
-  margin-bottom: 2rem;
-}
-
-.search-box-panel input {
-  flex: 1;
-  background: rgba(0, 0, 0, 0.25);
-  border: 1px solid var(--border-subtle);
-  border-radius: 0.5rem;
-  padding: 0.8rem 1rem;
-  color: var(--text-primary);
-  font-size: 1rem;
-  outline: none;
-  transition: border-color 0.15s ease;
-}
-
-.search-box-panel input:focus {
-  border-color: var(--accent-glow);
-}
-
-.search-box-panel button {
-  background-color: var(--accent-glow);
-  color: #080c14;
-  border: none;
-  padding: 0.8rem 1.75rem;
-  border-radius: 0.5rem;
-  font-weight: 700;
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background-color 0.15s ease;
-}
-
-.search-box-panel button:hover {
-  background-color: var(--accent-hover);
-  color: white;
-}
-
-/* Results Structure Area */
-.results-layout {
-  animation: fadeIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.word-meta-row {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1.5rem;
-  border-bottom: 1px solid var(--border-subtle);
-  padding-bottom: 1.25rem;
-}
-
-.word-heading h2 {
-  font-size: 1.8rem;
-  font-weight: 700;
-  letter-spacing: -0.01em;
-}
-
-.word-heading span {
-  display: block;
-  color: var(--accent-glow);
-  font-size: 1rem;
-  font-family: monospace;
-  margin-top: 0.2rem;
-}
-
-.audio-trigger-btn {
-  background: rgba(56, 189, 248, 0.1);
-  border: 1px solid rgba(56, 189, 248, 0.2);
-  width: 50px;
-  height: 50px;
+/* ─── Icon button ────────────────────────────────────────────────── */
+.icon-btn {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  width: 42px; height: 42px;
   border-radius: 50%;
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background 0.2s, border-color 0.2s, transform 0.15s;
+  flex-shrink: 0;
 }
+.icon-btn svg { width: 20px; height: 20px; fill: var(--text-secondary); transition: fill 0.2s; }
+.icon-btn:hover { background: var(--accent); border-color: var(--accent); transform: scale(1.05); }
+.icon-btn:hover svg { fill: #fff; }
+.fav-btn.active svg { fill: #fbbf24; }
+.fav-btn.active { border-color: #fbbf24; background: rgba(251,191,36,0.1); }
 
-.audio-trigger-btn:hover {
-  background: var(--accent-glow);
-  transform: scale(1.05);
+/* ─── Hero ───────────────────────────────────────────────────────── */
+.hero-header { text-align: center; padding-top: 1rem; }
+.hero-title {
+  font-family: 'DM Serif Display', serif;
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  background: linear-gradient(135deg, var(--accent) 30%, var(--accent-2) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  line-height: 1.1;
+  margin-bottom: 0.6rem;
 }
+.hero-sub { color: var(--text-secondary); font-size: 1rem; font-weight: 300; }
 
-.speaker-icon {
-  width: 24px;
-  height: 24px;
-  fill: var(--accent-glow);
-  transition: fill 0.2s ease;
+/* ─── Search panel ───────────────────────────────────────────────── */
+.search-panel {
+  display: flex;
+  gap: 0.75rem;
 }
-
-.audio-trigger-btn:hover .speaker-icon {
-  fill: #080c14;
-}
-
-/* Definition Output Cards */
-.lexical-card {
-  background-color: var(--bg-card);
-  border: 1px solid var(--border-subtle);
-  border-radius: 0.75rem;
-  padding: 1.5rem;
+.search-field {
+  flex: 1;
   position: relative;
+  display: flex;
+  align-items: center;
 }
-
-.part-of-speech-tag {
+.search-icon {
   position: absolute;
-  top: 1.25rem;
-  right: 1.5rem;
-  background: rgba(255, 255, 255, 0.05);
-  padding: 0.25rem 0.6rem;
-  border-radius: 0.25rem;
-  font-size: 0.75rem;
-  font-weight: 700;
-  color: var(--text-secondary);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  left: 1rem;
+  width: 20px; height: 20px;
+  fill: var(--text-muted);
+  pointer-events: none;
 }
-
-.meaning-group h3,
-.example-group h3 {
+.search-input {
+  width: 100%;
+  background: var(--bg-surface);
+  border: 1.5px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.9rem 2.75rem 0.9rem 3rem;
+  color: var(--text-primary);
+  font-family: 'DM Sans', sans-serif;
+  font-size: 1rem;
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.search-input::placeholder { color: var(--text-muted); }
+.search-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(56,189,248,0.15);
+}
+.clear-input-btn {
+  position: absolute;
+  right: 0.9rem;
+  background: none;
+  border: none;
+  color: var(--text-muted);
   font-size: 0.85rem;
+  cursor: pointer;
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.3rem;
+  transition: color 0.15s;
+}
+.clear-input-btn:hover { color: var(--accent-danger); }
+
+.search-btn {
+  background: linear-gradient(135deg, var(--accent), var(--accent-2));
+  color: #fff;
+  border: none;
+  padding: 0.9rem 1.75rem;
+  border-radius: 0.75rem;
+  font-family: 'DM Sans', sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: opacity 0.2s, transform 0.15s, box-shadow 0.2s;
+  box-shadow: 0 4px 20px rgba(56,189,248,0.25);
+}
+.search-btn:hover { opacity: 0.9; transform: translateY(-1px); box-shadow: 0 8px 28px rgba(56,189,248,0.35); }
+.search-btn:active { transform: translateY(0); }
+
+/* ─── Word of the Day banner ─────────────────────────────────────── */
+.wotd-banner {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-accent);
+  border-radius: var(--radius);
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+  animation: fadeSlide 0.5s ease both;
+}
+.wotd-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--text-secondary);
-  margin-bottom: 0.5rem;
-  font-weight: 600;
+  letter-spacing: 0.07em;
+  color: var(--accent);
 }
-
-.meaning-group {
-  margin-bottom: 1.5rem;
+.wotd-label .icon-sm { fill: var(--accent); }
+.wotd-word {
+  font-family: 'DM Serif Display', serif;
+  font-size: 1.35rem;
+  flex: 1;
 }
-
-.meaning-group p {
-  font-size: 1.05rem;
-  line-height: 1.5;
+.wotd-look-btn {
+  background: none;
+  border: 1px solid var(--border-accent);
+  color: var(--accent);
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 700;
+  padding: 0.4rem 0.9rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: background 0.15s;
 }
+.wotd-look-btn:hover { background: var(--bg-chip); }
 
-.italic-context {
-  font-style: italic;
-  color: #cbd5e1;
-  border-left: 3px solid var(--accent-glow);
-  padding-left: 0.75rem;
-  line-height: 1.4;
-}
-
-/* State Modifiers Utilities */
-.status-message {
-  text-align: center;
+/* ─── Status / Spinner ───────────────────────────────────────────── */
+.status-box {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
   color: var(--text-secondary);
   font-size: 0.95rem;
   padding: 1rem 0;
+  justify-content: center;
+}
+.spinner {
+  width: 22px; height: 22px;
+  border: 2.5px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
 }
 
-.hidden {
-  display: none !important;
+/* ─── Results area ───────────────────────────────────────────────── */
+.results-area {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  animation: fadeSlide 0.35s ease both;
+  box-shadow: var(--shadow);
 }
 
-@keyframes fadeIn {
-  from {
-    opacity: 0;
-    transform: translateY(4px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
+/* Word header */
+.word-header-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.result-word {
+  font-family: 'DM Serif Display', serif;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  line-height: 1.1;
+}
+.result-phonetic {
+  display: block;
+  font-family: 'DM Sans', sans-serif;
+  font-weight: 300;
+  font-style: italic;
+  color: var(--accent);
+  font-size: 1.05rem;
+  margin-top: 0.3rem;
+}
+.word-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+/* ─── Meanings tabs ──────────────────────────────────────────────── */
+.meanings-tabs {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.tab-btn {
+  background: none;
+  border: 1.5px solid var(--border);
+  color: var(--text-secondary);
+  font-family: 'DM Sans', sans-serif;
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.4rem 1rem;
+  border-radius: 2rem;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.tab-btn.active {
+  background: var(--tab-active-bg);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.tab-btn:hover:not(.active) { border-color: var(--text-secondary); color: var(--text-primary); }
+
+/* ─── Meaning panel ──────────────────────────────────────────────── */
+.meaning-panel { display: none; flex-direction: column; gap: 1.25rem; }
+.meaning-panel.active { display: flex; animation: fadeSlide 0.25s ease both; }
+
+.def-item {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 1.25rem 1.5rem;
+  position: relative;
+}
+.def-number {
+  position: absolute;
+  top: -0.65rem;
+  left: 1.25rem;
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  padding: 0.1rem 0.5rem;
+  border-radius: 1rem;
+}
+.def-text { font-size: 1.05rem; line-height: 1.65; color: var(--text-primary); }
+.example-text {
+  margin-top: 0.85rem;
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--text-secondary);
+  border-left: 3px solid var(--border-accent);
+  padding-left: 0.85rem;
+  line-height: 1.55;
+}
+.def-chips { margin-top: 0.75rem; display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.def-chip {
+  background: var(--bg-chip);
+  border: 1px solid var(--border-accent);
+  color: var(--accent);
+  font-size: 0.75rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 1rem;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.def-chip:hover { background: rgba(56,189,248,0.18); }
+
+/* ─── Synonyms / Antonyms ────────────────────────────────────────── */
+.syn-ant-row {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  padding-top: 0.5rem;
+  border-top: 1px solid var(--border);
+}
+.syn-block, .ant-block { flex: 1; min-width: 180px; }
+.chip-label {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-muted);
+  margin-bottom: 0.6rem;
+}
+.chip-list { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.syn-chip, .ant-chip {
+  font-size: 0.82rem;
+  padding: 0.25rem 0.7rem;
+  border-radius: 1rem;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+  border: 1px solid transparent;
+}
+.syn-chip:hover, .ant-chip:hover { transform: scale(1.05); }
+.syn-chip {
+  background: rgba(56,189,248,0.08);
+  color: var(--accent);
+  border-color: rgba(56,189,248,0.2);
+}
+.ant-chip {
+  background: rgba(248,113,113,0.08);
+  color: var(--accent-danger);
+  border-color: rgba(248,113,113,0.2);
+}
+
+/* ─── Toast ──────────────────────────────────────────────────────── */
+.toast {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%) translateY(10px);
+  background: var(--toast-bg);
+  color: #fff;
+  font-size: 0.9rem;
+  font-weight: 700;
+  padding: 0.65rem 1.5rem;
+  border-radius: 2rem;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+  z-index: 999;
+  opacity: 0;
+  transition: opacity 0.25s, transform 0.25s;
+  pointer-events: none;
+}
+.toast.show {
+  opacity: 1;
+  transform: translateX(-50%) translateY(0);
+}
+
+/* ─── Utilities ──────────────────────────────────────────────────── */
+.hidden { display: none !important; }
+.icon-sm { width: 16px; height: 16px; flex-shrink: 0; }
+
+/* ─── Keyframes ──────────────────────────────────────────────────── */
+@keyframes fadeSlide {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ─── Responsive ─────────────────────────────────────────────────── */
+@media (max-width: 600px) {
+  .main-content { padding: 1rem 1rem 3rem; gap: 1.25rem; }
+  .search-panel { flex-direction: column; }
+  .search-btn { width: 100%; }
+  .results-area { padding: 1.25rem; }
+  .word-actions { gap: 0.35rem; }
+  .icon-btn { width: 36px; height: 36px; }
+  .icon-btn svg { width: 17px; height: 17px; }
+  .syn-ant-row { flex-direction: column; gap: 1rem; }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #ISSUE_NUMBER

### Summary
Enhanced the **Vocal Lexicon Dictionary** app with multiple new features and a fully redesigned UI. The update introduces tabbed multiple meanings, synonyms/antonyms chips, a persistent favourites and search history panel, dark/light theme toggle, Word of the Day, copy & share actions, and responsive improvements — while keeping all original functionality intact.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [x] ♻️ Code refactoring / clean-up
- [x] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made

**`index.html`**
- Restructured layout into a sidebar + main-content flex layout
- Added slide-in sidebar panel with History and Favourites sections
- Added top navigation bar with sidebar toggle and theme toggle buttons
- Added Word of the Day banner with a "Look it up →" action button
- Replaced single definition card with a tabbed meanings system (`#meaningsTabs` + `#meaningPanels`)
- Added synonyms and antonyms section with clickable chips
- Added Copy, Favourite (★), and Share action buttons on each result
- Added animated spinner inside the status/loading box
- Added toast notification element for non-blocking user feedback
- Added `?q=word` deep-link support via URL params

**`styles.css`**
- Full design system rewrite using CSS custom properties for light/dark theming
- Added `[data-theme="light"]` token overrides for all colour variables
- Added DM Serif Display + DM Sans Google Fonts pairing
- Added decorative background blob elements with CSS animations
- Added `.tab-btn` and `.meaning-panel` styles for the tabbed meanings UI
- Added `.syn-chip` and `.ant-chip` styles with hover/click states
- Added `.sidebar`, `.sidebar-overlay`, `.word-chip-list` styles for the history/favourites panel
- Added `.wotd-banner` styles for the Word of the Day section
- Added `.toast` animation styles for clipboard/share feedback
- Full responsive layout for viewports down to 375px

**`app.js`**
- Added `localStorage` persistence for search history (last 25), favourites, and theme preference
- Added `renderResults()` that builds tabbed meaning panels dynamically from API response
- Added `switchTab()` to toggle between part-of-speech tabs
- Added `addToHistory()` and `renderHistoryList()` for history management
- Added `renderFavouritesList()` and `makeWordChip()` for the favourites panel
- Added `copyBtn` handler — copies `word (partOfSpeech): definition` to clipboard
- Added `favBtn` handler — toggles favourite state with visual feedback
- Added `shareBtn` handler — uses Web Share API on mobile, clipboard fallback on desktop
- Added `showToast()` utility for non-blocking success messages
- Added Word of the Day logic — picks a random word once per calendar day and caches it
- Added `clearInputBtn` for the search field × button
- Added URL param (`?q=`) auto-search on page load
- Extracted all synonyms and antonyms across all meanings and rendered as clickable search chips
- Clicking any synonym, antonym, or definition-level chip triggers a new `lookUpWord()` call

**`README.md`**
- Updated Features section to document all new functionality
- Added a feature comparison table (original vs new)
- Added Deep-link usage example
- Added updated Technologies Used section

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [ ] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
<img width="1517" height="727" alt="image" src="https://github.com/user-attachments/assets/a75415b6-a1e0-41c7-9eec-0e9542fe4f95" />

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.