### PR TITLE
fix: dynamically scale QR code size based on input length (fixes #6153)

### DIFF
--- a/public/qr generator/qr.js
+++ b/public/qr generator/qr.js
@@ -255,15 +255,37 @@ function generateQRCode() {
        QR GENERATION
     ========================================= */
 
+// fix #6153: dynamically scale QR size based on input length
+  // so dense (long) inputs still produce scannable modules.
+  // Thresholds follow QR capacity guidelines per error-correction level.
+  const dataLength = result.data.length;
+  let qrSize = 240;
+
+  if (dataLength > 500) {
+    qrSize = 480;
+  } else if (dataLength > 200) {
+    qrSize = 380;
+  } else if (dataLength > 100) {
+    qrSize = 300;
+  }
+
+  // Warn the user when input is very long
+  if (dataLength > 800) {
+    setStatus(
+      "⚠️ Input is very long — try a shorter URL or the QR may not scan reliably.",
+      true
+    );
+  }
+
   qrCode = new QRCode(
     qrcodeDiv,
 
     {
       text: result.data,
 
-      width: 240,
+      width: qrSize,
 
-      height: 240,
+      height: qrSize,
 
       colorDark: qrColor.value,
 


### PR DESCRIPTION
## Description
Fixes QR codes becoming too dense to scan when long URLs
or large strings are entered into the QR Code Generator.

Fixes #6153

## Changes Made
- Updated `generateQRCode()` in `public/qr generator/qr.js`:
  - QR output size now scales dynamically based on input length:
    - Default: 240px (short inputs)
    - 100+ chars: 300px
    - 200+ chars: 380px
    - 500+ chars: 480px
  - Added a visible warning when input exceeds 800 characters
    informing the user the QR may not scan reliably
  - Download button and size validation were already present

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings