### PR TITLE
feat: Added smooth scrolling to Results Card in GPA after load

### DIFF
--- a/public/GPA/app.js
+++ b/public/GPA/app.js
@@ -395,16 +395,20 @@ function updateWhatIfSummary(plan) {
   const entries = entered.map(([sem, sgpa]) => `Sem ${sem}: <strong>${formatNum(sgpa)}</strong>`).join(', ');
   const req = calc.impossible ? 'more than 10.0 (impossible)' : formatNum(calc.requiredSgpa);
 
-  $('#whatifSummary').innerHTML = `
-    <p>📌 <strong>What-If:</strong> With ${entries}, you now need an average SGPA of <strong>${req}</strong> across the remaining <strong>${calc.semestersLeftAfterWhatIf}</strong> semester(s).</p>
-  `;
+  $('#whatifSummary').innerHTML = `<p>📌 
+  <strong>What-If:</strong> With ${entries}, you now need an average SGPA of <strong>${req}</strong> 
+  across the remaining <strong>${calc.semestersLeftAfterWhatIf}</strong> semester(s).</p>`;
 }
 
 // ===== Main Calculate =====
 function calculatePlan() {
   const data = getFormData();
 
-  if ([data.currentCgpa, data.completedSemesters, data.targetCgpa, data.remainingSemesters].some((v) => v === null || isNaN(v))) {
+  if ([data.currentCgpa, 
+    data.completedSemesters, 
+    data.targetCgpa, 
+    data.remainingSemesters]
+    .some((v) => v === null || isNaN(v))) {
     alert('Please fill in all required fields.');
     return;
   }
@@ -449,8 +453,7 @@ function renderSavedPlans() {
 
   container.innerHTML = plans
     .map(
-      (plan, idx) => `
-    <div class="plan-item" data-idx="${idx}">
+      (plan, idx) => `<div class="plan-item" data-idx="${idx}">
       <div class="plan-info">
         <h4>${escapeHtml(plan.name)}</h4>
         <p>CGPA ${formatNum(plan.data.currentCgpa)} → ${formatNum(plan.data.targetCgpa)} · ${plan.data.remainingSemesters} sem remaining · Req: ${formatNum(plan.calc.requiredSgpa)}</p>
@@ -459,8 +462,7 @@ function renderSavedPlans() {
         <button type="button" class="load-btn" data-idx="${idx}">Load</button>
         <button type="button" class="delete-btn" data-idx="${idx}">Delete</button>
       </div>
-    </div>
-  `
+    </div>`
     )
     .join('');
 
@@ -499,6 +501,10 @@ function loadPlan(idx) {
 
   renderResults(currentPlan);
   renderPredictor(currentPlan);
+  $('#resultsCard').scrollIntoView({ 
+    block: 'start',
+    behavior: 'smooth'
+  });
 }
 
 function deletePlan(idx) {


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #7126

### Summary
This PR adds Smooth Scrolling after clicking the load button in the Saved plans for users to see the loaded plan on the Results card for better user accessibility.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added Smooth Scrolling to the element
- Added Scroll into View function with start block and smooth behaviour
---


## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
