### PR TITLE
fix: resolve relative asset path loading issue

### DIFF
--- a/public/Carousel Solar System/index.html
+++ b/public/Carousel Solar System/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="index.css" />
+  <link rel="stylesheet" href="/public/Carousel%20Solar%20System/index.css" />
   <link rel="icon" href="../favv.png" type="image/x-icon" />
   <title>Solar System Carousel</title>
 </head>
@@ -26,63 +26,63 @@
          <div class="planet-mini-list">
 
 <div class="planet-item">
-<img alt="" src="./images/sun-image.png"
+<img alt="" src="/public/Carousel%20Solar%20System/images/sun-image.png"
 class="mini-planet"
 data-index="0">
 <span>Sun</span>
 </div>
 
 <div class="planet-item">
-<img alt="" src="./images/mercury-image.png"
+<img alt="" src="/public/Carousel%20Solar%20System/images/mercury-image.png"
 class="mini-planet"
 data-index="1">
 <span>Mercury</span>
 </div>
 
 <div class="planet-item">
-<img alt="" src="./images/venus-image.png"
+<img alt="" src="/public/Carousel%20Solar%20System/images/venus-image.png"
 class="mini-planet"
 data-index="2">
 <span>Venus</span>
 </div>
 
 <div class="planet-item">
-<img alt="" src="./images/earth-image.png"
+<img alt="" src="/public/Carousel%20Solar%20System/images/earth-image.png"
 class="mini-planet"
 data-index="3">
 <span>Earth</span>
 </div>
 
 <div class="planet-item">
-<img alt="" src="./images/mars-image.png"
+<img alt="" src="/public/Carousel%20Solar%20System/images/mars-image.png"
 class="mini-planet"
 data-index="4">
 <span>Mars</span>
 </div>
 
 <div class="planet-item">
-<img alt="" src="./images/jupiter-image.png"
+<img alt="" src="/public/Carousel%20Solar%20System/images/jupiter-image.png"
 class="mini-planet"
 data-index="5">
 <span>Jupiter</span>
 </div>
 
 <div class="planet-item">
-<img alt="" src="./images/saturn-image.png"
+<img alt="" src="/public/Carousel%20Solar%20System/images/saturn-image.png"
 class="mini-planet"
 data-index="6">
 <span>Saturn</span>
 </div>
 
 <div class="planet-item">
-<img alt="" src="./images/Uranus.png"
+<img alt="" src="/public/Carousel%20Solar%20System/images/Uranus.png"
 class="mini-planet"
 data-index="7">
 <span>Uranus</span>
 </div>
 
 <div class="planet-item">
-<img alt="" src="./images/Neptune.png"
+<img alt="" src="/public/Carousel%20Solar%20System/images/Neptune.png"
 class="mini-planet"
 data-index="8">
 <span>Neptune</span>
@@ -108,7 +108,7 @@ data-index="8">
           </div>
 
           <div class="center-col">
-            <img src="./images/sun-image.png" alt="Sun" class="planet-img" />
+            <img src="/public/Carousel%20Solar%20System/images/sun-image.png" alt="Sun" class="planet-img" />
           </div>
 
           <div class="right-col">
@@ -141,7 +141,7 @@ data-index="8">
           </div>
 
           <div class="center-col">
-            <img src="./images/mercury-image.png" alt="Mercury" class="planet-img" />
+            <img src="/public/Carousel%20Solar%20System/images/mercury-image.png" alt="Mercury" class="planet-img" />
           </div>
 
           <div class="right-col">
@@ -174,7 +174,7 @@ data-index="8">
           </div>
 
           <div class="center-col">
-            <img src="./images/venus-image.png" alt="Venus" class="planet-img" />
+            <img src="/public/Carousel%20Solar%20System/images/venus-image.png" alt="Venus" class="planet-img" />
           </div>
 
           <div class="right-col">
@@ -207,7 +207,7 @@ data-index="8">
           </div>
 
           <div class="center-col">
-            <img src="./images/earth-image.png" alt="Earth" class="planet-img blue-glow" />
+            <img src="/public/Carousel%20Solar%20System/images/earth-image.png" alt="Earth" class="planet-img blue-glow" />
           </div>
 
           <div class="right-col">
@@ -240,7 +240,7 @@ data-index="8">
           </div>
 
           <div class="center-col">
-            <img src="./images/mars-image.png" alt="Mars" class="planet-img" />
+            <img src="/public/Carousel%20Solar%20System/images/mars-image.png" alt="Mars" class="planet-img" />
           </div>
 
           <div class="right-col">
@@ -273,7 +273,7 @@ data-index="8">
           </div>
 
           <div class="center-col">
-            <img src="./images/jupiter-image.png" alt="Jupiter" class="planet-img" />
+            <img src="/public/Carousel%20Solar%20System/images/jupiter-image.png" alt="Jupiter" class="planet-img" />
           </div>
 
           <div class="right-col">
@@ -306,7 +306,7 @@ data-index="8">
           </div>
 
           <div class="center-col">
-            <img src="./images/saturn-image.png" alt="Saturn" class="planet-img planet-large" />
+            <img src="/public/Carousel%20Solar%20System/images/saturn-image.png" alt="Saturn" class="planet-img planet-large" />
           </div>
 
           <div class="right-col">
@@ -339,7 +339,7 @@ data-index="8">
           </div>
 
           <div class="center-col">
-            <img src="./images/Uranus.png" alt="Uranus" class="planet-img blue-glow planet-large" />
+            <img src="/public/Carousel%20Solar%20System/images/Uranus.png" alt="Uranus" class="planet-img blue-glow planet-large" />
           </div>
 
           <div class="right-col">
@@ -373,7 +373,7 @@ data-index="8">
           </div>
 
           <div class="center-col">
-            <img src="./images/Neptune.png" alt="Neptune" class="planet-img blue-glow planet-large" />
+            <img src="/public/Carousel%20Solar%20System/images/Neptune.png" alt="Neptune" class="planet-img blue-glow planet-large" />
           </div>
 
           <div class="right-col">


### PR DESCRIPTION
## 📝 Pull Request Description

### Summary
This PR fixes asset loading issues in the Solar System Carousel project caused by incorrect relative path resolution.

When the project is accessed through the directory URL, relative paths for the stylesheet and image assets are resolved incorrectly, resulting in missing styles and broken images. This change updates the asset references to use explicit paths, ensuring resources load consistently regardless of how the project is accessed.


---

## 🛠️ Changes Made
1. Updated the stylesheet reference from a relative path to an explicit path:
2. index.css → /public/Carousel%20Solar%20System/index.css
3. Updated image asset references to use explicit paths.
4. Resolved 404 errors caused by incorrect path resolution.
5. Ensured CSS and image resources load correctly when the project is accessed via the directory URL.

---
Before: Missing styles and broken image assets.
<img width="614" height="601" alt="image" src="https://github.com/user-attachments/assets/1c2d089e-4de6-4910-8ccb-58cb770014f2" />

After: Correct styling and successful image rendering.
<img width="868" height="520" alt="image" src="https://github.com/user-attachments/assets/ad438204-0f6f-4d38-b0de-660f7d8e9e1a" />

Fixes #7189
