### PR TITLE
 Sanitize preview image metadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -308,6 +308,42 @@ function sanitizeUrl(url) {
   return "#";
 }
 
+const SAFE_PREVIEW_SEGMENT_RE = /^[A-Za-z0-9._% &()+-]+$/;
+const UNSAFE_PREVIEW_SEGMENT_RE = /["'<>`\\/:]|[\u0000-\u001F\u007F]/;
+
+function isSafePreviewPathSegment(segment) {
+  const raw = String(segment || "").trim();
+
+  if (!raw || raw === "." || raw === "..") {
+    return false;
+  }
+
+  if (!SAFE_PREVIEW_SEGMENT_RE.test(raw)) {
+    return false;
+  }
+
+  try {
+    const decoded = decodeURIComponent(raw);
+    return decoded !== "." && decoded !== ".." && !UNSAFE_PREVIEW_SEGMENT_RE.test(decoded);
+  } catch (_error) {
+    return false;
+  }
+}
+
+function getPreviewImagePath({ name, url }) {
+  const rawUrl = String(url || "").trim();
+  const pathWithoutFragment = rawUrl.split("#")[0].split("?")[0];
+  const pathSegment = rawUrl.startsWith("./")
+    ? pathWithoutFragment.split("/")[2]
+    : String(name || "").trim().replace(/\s+/g, "_");
+
+  if (!isSafePreviewPathSegment(pathSegment)) {
+    return "";
+  }
+
+  return `./${pathSegment}/preview.png`;
+}
+
 function buildProjectCardHTML({
   day,
   name,
@@ -360,6 +396,12 @@ function buildProjectCardHTML({
   const difficultyBadge = difficulty
     ? `<span class="card-difficulty ${difficultyKey}">${safeDifficultyLabel}</span>`
     : "";
+  const previewImagePath = getPreviewImagePath({ name, url });
+  const previewImageHTML = previewImagePath
+    ? `<div class="card-preview-image-container" style="margin: 12px 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9; background: #1a1a1a;">
+                <img class="card-preview-image" src="${escapeHTML(previewImagePath)}" alt="${safeName} preview" style="width: 100%; height: 100%; object-fit: cover;">
+            </div>`
+    : "";
 
   const sourceOnlyBadge = sourceOnly
     ? '<span class="source-only-badge" title="Requires local server setup">Source only</span>'
@@ -392,9 +434,7 @@ return {
                 </span>
             </div>
 
-            <div class="card-preview-image-container" style="margin: 12px 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9; background: #1a1a1a;">
-                <img src="./${url && url.startsWith('./') ? url.split('/')[2] : name.replace(/\s+/g, '_')}/preview.png" alt="${safeName} preview" onerror="this.parentNode.style.display='none';" style="width: 100%; height: 100%; object-fit: cover;">
-            </div>
+            ${previewImageHTML}
 
             <h3 class="card-name">${safeName}</h3>
 
@@ -421,7 +461,24 @@ return {
   };
 }
 
+function attachPreviewImageErrorHandler(card) {
+  const previewImage = card.querySelector(".card-preview-image");
+
+  if (!previewImage) {
+    return;
+  }
+
+  previewImage.addEventListener("error", () => {
+    const previewContainer = previewImage.closest(".card-preview-image-container");
+
+    if (previewContainer) {
+      previewContainer.style.display = "none";
+    }
+  }, { once: true });
+}
+
 function attachProjectCardInteraction(card, demoUrl, projectData = null) {
+  attachPreviewImageErrorHandler(card);
   card.style.cursor = "pointer";
   
   const activateCard = (e) => {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "generate-previews": "node scripts/generate-previews.js",
     "dev": "npx -y serve . -p 3000",
     "validate:projects": "node scripts/validate-projects.js",
+    "validate:metadata-security": "node scripts/validate-metadata-security-fixture.js",
     "lint": "eslint --no-config-lookup -c eslint.config.js .",
     "lint:all": "npx -y htmlhint '**/*.html' --ignore 'node_modules/**,**/node_modules/**'",
     "format": "prettier --config .prettierrc --write .",

--- a/scripts/fixtures/unsafe-preview-metadata.json
+++ b/scripts/fixtures/unsafe-preview-metadata.json
@@ -1,0 +1,30 @@
+[
+  {
+    "projectNo": 9001,
+    "projectName": "\"><img src=x onerror=alert(1)>",
+    "techStack": ["javascript"],
+    "difficulty": "beginner",
+    "projectPath": "./public/safe-preview/index.html"
+  },
+  {
+    "projectNo": 9002,
+    "projectName": "Unsafe Preview Path",
+    "techStack": ["javascript"],
+    "difficulty": "beginner",
+    "projectPath": "./public/bad%22segment/index.html"
+  },
+  {
+    "projectNo": 9003,
+    "projectName": "Traversal Preview Path",
+    "techStack": ["javascript"],
+    "difficulty": "beginner",
+    "projectPath": "./public/../escape/index.html"
+  },
+  {
+    "projectNo": 9004,
+    "projectName": "Unsafe Protocol",
+    "techStack": ["javascript"],
+    "difficulty": "beginner",
+    "projectPath": "javascript:alert(1)"
+  }
+]

--- a/scripts/validate-metadata-security-fixture.js
+++ b/scripts/validate-metadata-security-fixture.js
@@ -1,0 +1,32 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+const validatorPath = path.join(__dirname, 'validate-metadata.js');
+const fixturePath = path.join(__dirname, 'fixtures', 'unsafe-preview-metadata.json');
+
+const result = spawnSync(process.execPath, [validatorPath, fixturePath], {
+  encoding: 'utf8'
+});
+const output = `${result.stdout}\n${result.stderr}`;
+
+const expectedMessages = [
+  '"projectName" contains double quotes, angle brackets, backticks, or control characters',
+  'preview image path segment derived from metadata is unsafe',
+  '"projectPath" must not contain path traversal',
+  '"projectPath" uses an unsafe URL protocol'
+];
+
+if (result.status === 0) {
+  console.error('Expected unsafe preview metadata fixture to fail validation.');
+  process.exit(1);
+}
+
+const missingMessages = expectedMessages.filter(message => !output.includes(message));
+
+if (missingMessages.length > 0) {
+  console.error('Unsafe preview metadata fixture did not trigger expected validation errors.');
+  missingMessages.forEach(message => console.error(`- Missing: ${message}`));
+  process.exit(1);
+}
+
+console.log('Success: unsafe preview metadata fixture is rejected.');

--- a/scripts/validate-metadata.js
+++ b/scripts/validate-metadata.js
@@ -1,8 +1,69 @@
 const fs = require('fs');
 const path = require('path');
 
-const projectsPath = path.join(__dirname, '..', 'projects.json');
+const projectsPath = process.argv[2]
+  ? path.resolve(process.argv[2])
+  : path.join(__dirname, '..', 'projects.json');
 const rootDir = path.join(__dirname, '..');
+const UNSAFE_METADATA_CHARS_RE = /["<>`]|[\u0000-\u001F\u007F]/;
+const UNSAFE_PROTOCOL_RE = /^(?:javascript|data|vbscript):/i;
+const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+const SAFE_PREVIEW_SEGMENT_RE = /^[A-Za-z0-9._% &()+-]+$/;
+const UNSAFE_PREVIEW_SEGMENT_RE = /["'<>`\\/:]|[\u0000-\u001F\u007F]/;
+
+function formatProjectLabel(index, project) {
+  return `Index ${index} (Day ${project.projectNo || 'Unknown'} - ${project.projectName || 'Unnamed'})`;
+}
+
+function validateMetadataString(value, fieldName, index, project, errors) {
+  if (UNSAFE_METADATA_CHARS_RE.test(value)) {
+    errors.push(`${formatProjectLabel(index, project)}: "${fieldName}" contains double quotes, angle brackets, backticks, or control characters`);
+  }
+}
+
+function hasPathTraversal(value) {
+  return value
+    .replace(/\\/g, '/')
+    .split('/')
+    .some(segment => segment === '..');
+}
+
+function isSafePreviewPathSegment(segment) {
+  const raw = String(segment || '').trim();
+
+  if (!raw || raw === '.' || raw === '..') {
+    return false;
+  }
+
+  if (!SAFE_PREVIEW_SEGMENT_RE.test(raw)) {
+    return false;
+  }
+
+  try {
+    const decoded = decodeURIComponent(raw);
+    return decoded !== '.' && decoded !== '..' && !UNSAFE_PREVIEW_SEGMENT_RE.test(decoded);
+  } catch (_error) {
+    return false;
+  }
+}
+
+function getPreviewPathSegment(projectPath, projectName) {
+  const rawPath = String(projectPath || '').trim();
+
+  if (rawPath.startsWith('./')) {
+    return rawPath.split('#')[0].split('?')[0].split('/')[2];
+  }
+
+  return String(projectName || '').trim().replace(/\s+/g, '_');
+}
+
+function validatePreviewPathSegment(project, index, errors) {
+  const previewSegment = getPreviewPathSegment(project.projectPath, project.projectName);
+
+  if (!isSafePreviewPathSegment(previewSegment)) {
+    errors.push(`${formatProjectLabel(index, project)}: preview image path segment derived from metadata is unsafe`);
+  }
+}
 
 try {
   const data = fs.readFileSync(projectsPath, 'utf8');
@@ -44,6 +105,8 @@ try {
     if (project.projectName !== undefined && project.projectName !== null && project.projectName !== '') {
       if (typeof project.projectName !== 'string') {
         errors.push(`Index ${index}: "projectName" must be a string, got "${typeof project.projectName}"`);
+      } else {
+        validateMetadataString(project.projectName, 'projectName', index, project, errors);
       }
     }
 
@@ -63,6 +126,21 @@ try {
       if (typeof project.projectPath !== 'string') {
         errors.push(`Index ${index}: "projectPath" must be a string, got "${typeof project.projectPath}"`);
       } else {
+        validateMetadataString(project.projectPath, 'projectPath', index, project, errors);
+        validatePreviewPathSegment(project, index, errors);
+
+        if (UNSAFE_PROTOCOL_RE.test(project.projectPath.trim())) {
+          errors.push(`${formatProjectLabel(index, project)}: "projectPath" uses an unsafe URL protocol`);
+        }
+
+        if (
+          URL_SCHEME_RE.test(project.projectPath.trim()) &&
+          !project.projectPath.startsWith('http://') &&
+          !project.projectPath.startsWith('https://')
+        ) {
+          errors.push(`${formatProjectLabel(index, project)}: "projectPath" must use http(s) or a local relative path`);
+        }
+
         // Detect duplicate projectPath values
         if (seenProjectPaths.has(project.projectPath)) {
           errors.push(`Index ${index} (Day ${project.projectNo || 'Unknown'} - ${project.projectName || 'Unnamed'}): Duplicate projectPath "${project.projectPath}"`);
@@ -81,6 +159,10 @@ try {
             relPath = decodeURIComponent(relPath);
           } catch (e) {
             errors.push(`Index ${index}: Failed to decode URI component for projectPath "${relPath}"`);
+          }
+
+          if (hasPathTraversal(relPath)) {
+            errors.push(`${formatProjectLabel(index, project)}: "projectPath" must not contain path traversal`);
           }
 
           const resolvedPath = path.resolve(rootDir, relPath);


### PR DESCRIPTION
## Summary
- Sanitize project-card preview image paths before writing them into generated card markup.
- Escape the final preview `src` and `alt` values and remove the inline `onerror` handler.
- Add metadata validation and a malicious fixture test covering preview-image injection cases.

## Details
`buildProjectCardHTML` previously derived preview image markup directly from contributor-controlled `projectName` and `projectPath` values inside an `innerHTML` template. This left the preview image `src` path as an exception to the escaping and URL-sanitizing rules used elsewhere in the card.

This change adds a strict preview path segment validator and a `getPreviewImagePath` helper. Preview paths are now generated only from safe single-folder segments, escaped before insertion into markup, and omitted when the metadata cannot produce a safe path. The image error behavior has also moved from inline `onerror` to an `addEventListener('error', ...)` handler attached after the card is created.

The metadata validator now rejects unsafe preview metadata before runtime, including double quotes, angle brackets, backticks, control characters, unsafe protocols, decoded path traversal, and unsafe preview path segments. A fixture-based validation script confirms malicious preview metadata is rejected.

## Validation
- `node --check index.js`
- `node --check scripts\\validate-metadata.js`
- `node --check scripts\\validate-metadata-security-fixture.js`
- `npm run validate:metadata-security`
- `git diff --check`
- targeted scan of current `projects.json` against the new preview safety rules

Note: full project path-existence validation was not run because this local checkout is sparse and does not include the full `public/` project tree.

Closes #7080