### PR TITLE
Restore project registry validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,4 +139,4 @@ jobs:
       - name: Run Validation Script
         run: |
           echo "🏁 Starting PR Quality and Template Compliance checks..."
-          node scripts/validate-metadata.js
+          npm run validate:projects

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "generate-previews": "node scripts/generate-previews.js",
     "dev": "npx -y serve . -p 3000",
     "validate:projects": "node scripts/validate-projects.js",
+    "validate:projects-fixture": "node scripts/validate-projects-fixture.js",
     "lint": "eslint --no-config-lookup -c eslint.config.js .",
     "lint:all": "npx -y htmlhint '**/*.html' --ignore 'node_modules/**,**/node_modules/**'",
     "format": "prettier --config .prettierrc --write .",
@@ -47,7 +48,7 @@
     "stylelint-config-standard": "^40.0.0"
   },
   "lint-staged": {
-    "projects.json": "node scripts/validate-metadata.js",
+    "projects.json": "npm run validate:projects",
     "*.html": "npx htmlhint"
   }
 }

--- a/scripts/validate-metadata.js
+++ b/scripts/validate-metadata.js
@@ -1,8 +1,124 @@
 const fs = require('fs');
 const path = require('path');
 
-const projectsPath = path.join(__dirname, '..', 'projects.json');
-const rootDir = path.join(__dirname, '..');
+const projectsPath = process.argv[2]
+  ? path.resolve(process.argv[2])
+  : path.join(__dirname, '..', 'projects.json');
+const rootDir = process.argv[3]
+  ? path.resolve(process.argv[3])
+  : path.join(__dirname, '..');
+
+const VALID_DIFFICULTIES = new Set(['beginner', 'intermediate', 'advanced']);
+const REQUIRED_KEYS = ['projectNo', 'projectName', 'techStack', 'difficulty', 'projectPath'];
+const UNSAFE_PROTOCOL_RE = /^(?:javascript|data|vbscript):/i;
+const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+const EXPECTED_GITHUB_TREE_PREFIX = '/dhairyagothi/100_days_100_web_project/tree/';
+
+function formatProjectLabel(index, project = {}) {
+  const day = project.projectNo || 'Unknown';
+  const name = project.projectName || 'Unnamed';
+  return `Index ${index} (Day ${day} - ${name})`;
+}
+
+function addFieldError(errors, index, project, fieldName, message) {
+  errors.push(`${formatProjectLabel(index, project)}: "${fieldName}" ${message}`);
+}
+
+function isExternalHttpUrl(value) {
+  return /^https?:\/\//i.test(value);
+}
+
+function hasPathTraversal(value) {
+  return value
+    .replace(/\\/g, '/')
+    .split('/')
+    .some(segment => segment === '..');
+}
+
+function resolvesInsideRoot(resolvedPath) {
+  const relativePath = path.relative(rootDir, resolvedPath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+}
+
+function validateExternalUrl(projectPath, index, project, errors) {
+  let parsedUrl;
+
+  try {
+    parsedUrl = new URL(projectPath);
+  } catch (_error) {
+    addFieldError(errors, index, project, 'projectPath', 'must be a valid http(s) URL');
+    return;
+  }
+
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    addFieldError(errors, index, project, 'projectPath', 'must use http or https');
+    return;
+  }
+
+  if (
+    parsedUrl.hostname.toLowerCase() === 'github.com' &&
+    parsedUrl.pathname.includes('/tree/') &&
+    !parsedUrl.pathname.startsWith(EXPECTED_GITHUB_TREE_PREFIX)
+  ) {
+    addFieldError(errors, index, project, 'projectPath', 'GitHub tree URLs must point to this repository');
+  }
+}
+
+function validateLocalPath(projectPath, index, project, errors) {
+  let relPath = projectPath.split('?')[0].split('#')[0];
+
+  try {
+    relPath = decodeURIComponent(relPath);
+  } catch (_error) {
+    addFieldError(errors, index, project, 'projectPath', `failed to decode URI component for "${relPath}"`);
+    return;
+  }
+
+  if (hasPathTraversal(relPath)) {
+    addFieldError(errors, index, project, 'projectPath', 'must not contain path traversal');
+  }
+
+  const resolvedPath = path.resolve(rootDir, relPath);
+
+  if (!resolvesInsideRoot(resolvedPath)) {
+    addFieldError(errors, index, project, 'projectPath', 'must resolve inside the repository root');
+    return;
+  }
+
+  if (!fs.existsSync(resolvedPath)) {
+    addFieldError(errors, index, project, 'projectPath', `local path "${relPath}" does not exist in the repository`);
+  }
+}
+
+function validateProjectPath(projectPath, index, project, errors) {
+  const rawPath = projectPath.trim();
+
+  if (rawPath !== projectPath) {
+    addFieldError(errors, index, project, 'projectPath', 'must not contain leading or trailing whitespace');
+  }
+
+  if (rawPath.startsWith('//')) {
+    addFieldError(errors, index, project, 'projectPath', 'must not use a protocol-relative URL');
+    return;
+  }
+
+  if (UNSAFE_PROTOCOL_RE.test(rawPath)) {
+    addFieldError(errors, index, project, 'projectPath', 'uses an unsafe URL protocol');
+    return;
+  }
+
+  if (isExternalHttpUrl(rawPath)) {
+    validateExternalUrl(rawPath, index, project, errors);
+    return;
+  }
+
+  if (URL_SCHEME_RE.test(rawPath)) {
+    addFieldError(errors, index, project, 'projectPath', 'must use http(s) or a local relative path');
+    return;
+  }
+
+  validateLocalPath(rawPath, index, project, errors);
+}
 
 try {
   const data = fs.readFileSync(projectsPath, 'utf8');
@@ -18,76 +134,70 @@ try {
   const seenProjectPaths = new Set();
 
   projects.forEach((project, index) => {
-    const requiredKeys = ['projectNo', 'projectName', 'techStack', 'difficulty', 'projectPath'];
-    
-    // 1. Validate required fields presence
-    requiredKeys.forEach(key => {
+    if (project === null || typeof project !== 'object' || Array.isArray(project)) {
+      errors.push(`Index ${index}: project entry must be an object`);
+      return;
+    }
+
+    REQUIRED_KEYS.forEach(key => {
       if (project[key] === undefined || project[key] === null || project[key] === '') {
-        errors.push(`Index ${index}: Missing or empty required field "${key}"`);
+        addFieldError(errors, index, project, key, 'is missing or empty');
       }
     });
 
-    // 2. Validate field types and duplicate detection
     if (project.projectNo !== undefined && project.projectNo !== null) {
       if (typeof project.projectNo !== 'number') {
-        errors.push(`Index ${index}: "projectNo" must be a number, got "${typeof project.projectNo}"`);
+        addFieldError(errors, index, project, 'projectNo', `must be a number, got "${typeof project.projectNo}"`);
+      } else if (!Number.isInteger(project.projectNo) || project.projectNo <= 0) {
+        addFieldError(errors, index, project, 'projectNo', 'must be a positive integer');
+      } else if (seenProjectNos.has(project.projectNo)) {
+        addFieldError(errors, index, project, 'projectNo', `duplicates day number "${project.projectNo}"`);
       } else {
-        // Detect duplicate projectNo values
-        if (seenProjectNos.has(project.projectNo)) {
-          errors.push(`Index ${index} (Day ${project.projectNo} - ${project.projectName || 'Unnamed'}): Duplicate projectNo "${project.projectNo}"`);
-        } else {
-          seenProjectNos.add(project.projectNo);
-        }
+        seenProjectNos.add(project.projectNo);
       }
     }
 
     if (project.projectName !== undefined && project.projectName !== null && project.projectName !== '') {
       if (typeof project.projectName !== 'string') {
-        errors.push(`Index ${index}: "projectName" must be a string, got "${typeof project.projectName}"`);
+        addFieldError(errors, index, project, 'projectName', `must be a string, got "${typeof project.projectName}"`);
+      } else if (project.projectName.trim() === '') {
+        addFieldError(errors, index, project, 'projectName', 'must not be blank');
       }
     }
 
     if (project.techStack !== undefined && project.techStack !== null) {
       if (!Array.isArray(project.techStack)) {
-        errors.push(`Index ${index}: "techStack" must be an array, got "${typeof project.techStack}"`);
+        addFieldError(errors, index, project, 'techStack', `must be an array, got "${typeof project.techStack}"`);
+      } else if (project.techStack.length === 0) {
+        addFieldError(errors, index, project, 'techStack', 'must contain at least one token');
+      } else {
+        project.techStack.forEach((token, tokenIndex) => {
+          if (typeof token !== 'string' || token.trim() === '') {
+            addFieldError(errors, index, project, `techStack[${tokenIndex}]`, 'must be a non-empty string');
+          }
+        });
       }
     }
 
     if (project.difficulty !== undefined && project.difficulty !== null && project.difficulty !== '') {
       if (typeof project.difficulty !== 'string') {
-        errors.push(`Index ${index}: "difficulty" must be a string, got "${typeof project.difficulty}"`);
+        addFieldError(errors, index, project, 'difficulty', `must be a string, got "${typeof project.difficulty}"`);
+      } else if (!VALID_DIFFICULTIES.has(project.difficulty)) {
+        addFieldError(errors, index, project, 'difficulty', 'must be one of: beginner, intermediate, advanced');
       }
     }
 
     if (project.projectPath !== undefined && project.projectPath !== null && project.projectPath !== '') {
       if (typeof project.projectPath !== 'string') {
-        errors.push(`Index ${index}: "projectPath" must be a string, got "${typeof project.projectPath}"`);
+        addFieldError(errors, index, project, 'projectPath', `must be a string, got "${typeof project.projectPath}"`);
       } else {
-        // Detect duplicate projectPath values
         if (seenProjectPaths.has(project.projectPath)) {
-          errors.push(`Index ${index} (Day ${project.projectNo || 'Unknown'} - ${project.projectName || 'Unnamed'}): Duplicate projectPath "${project.projectPath}"`);
+          addFieldError(errors, index, project, 'projectPath', `duplicates path "${project.projectPath}"`);
         } else {
           seenProjectPaths.add(project.projectPath);
         }
 
-        // Validate local path existence (or allow external URLs)
-        const isExternalUrl = project.projectPath.startsWith('http://') || project.projectPath.startsWith('https://');
-        if (!isExternalUrl) {
-          let relPath = project.projectPath;
-          // Strip query parameters and hashes
-          relPath = relPath.split('?')[0].split('#')[0];
-          // Decode URI encoded components (e.g. %20 -> space)
-          try {
-            relPath = decodeURIComponent(relPath);
-          } catch (e) {
-            errors.push(`Index ${index}: Failed to decode URI component for projectPath "${relPath}"`);
-          }
-
-          const resolvedPath = path.resolve(rootDir, relPath);
-          if (!fs.existsSync(resolvedPath)) {
-            errors.push(`Index ${index} (Day ${project.projectNo || 'Unknown'} - ${project.projectName || 'Unnamed'}): Local path "${relPath}" does not exist in the repository`);
-          }
-        }
+        validateProjectPath(project.projectPath, index, project, errors);
       }
     }
   });
@@ -105,4 +215,3 @@ try {
   console.error('Validation failed with unexpected error:', error.message);
   process.exit(1);
 }
-

--- a/scripts/validate-projects-fixture.js
+++ b/scripts/validate-projects-fixture.js
@@ -1,0 +1,94 @@
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const validatorPath = path.join(__dirname, 'validate-projects.js');
+const fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'project-registry-'));
+const validEntryPath = path.join(fixtureRoot, 'public', 'valid-project', 'index.html');
+const validRegistryPath = path.join(fixtureRoot, 'valid-projects.json');
+const invalidRegistryPath = path.join(fixtureRoot, 'invalid-projects.json');
+
+fs.mkdirSync(path.dirname(validEntryPath), { recursive: true });
+fs.writeFileSync(validEntryPath, '<!doctype html><title>Valid Project</title>');
+
+fs.writeFileSync(validRegistryPath, JSON.stringify([
+  {
+    projectNo: 1,
+    projectName: 'Valid Project',
+    techStack: ['html', 'css'],
+    difficulty: 'beginner',
+    projectPath: './public/valid-project/index.html'
+  }
+], null, 2));
+
+fs.writeFileSync(invalidRegistryPath, JSON.stringify([
+  {
+    projectNo: 1,
+    projectName: 'Original Project',
+    techStack: ['html'],
+    difficulty: 'beginner',
+    projectPath: './public/valid-project/index.html'
+  },
+  {
+    projectNo: 1,
+    projectName: 'Duplicate Day',
+    techStack: ['javascript'],
+    difficulty: 'expert',
+    projectPath: 'javascript:alert(1)'
+  },
+  {
+    projectNo: 3,
+    projectName: 'Escaped Path',
+    techStack: ['html'],
+    difficulty: 'advanced',
+    projectPath: '../outside.html'
+  },
+  {
+    projectNo: 4,
+    projectName: 'Missing File',
+    techStack: ['css'],
+    difficulty: 'intermediate',
+    projectPath: './public/missing/index.html'
+  }
+], null, 2));
+
+function runValidator(registryPath) {
+  return spawnSync(process.execPath, [validatorPath, registryPath, fixtureRoot], {
+    encoding: 'utf8'
+  });
+}
+
+const validResult = runValidator(validRegistryPath);
+
+if (validResult.status !== 0) {
+  console.error('Expected valid project registry fixture to pass validation.');
+  console.error(validResult.stdout);
+  console.error(validResult.stderr);
+  process.exit(1);
+}
+
+const invalidResult = runValidator(invalidRegistryPath);
+const invalidOutput = `${invalidResult.stdout}\n${invalidResult.stderr}`;
+const expectedMessages = [
+  'duplicates day number "1"',
+  'must be one of: beginner, intermediate, advanced',
+  'uses an unsafe URL protocol',
+  'must not contain path traversal',
+  'local path "./public/missing/index.html" does not exist in the repository'
+];
+
+if (invalidResult.status === 0) {
+  console.error('Expected invalid project registry fixture to fail validation.');
+  process.exit(1);
+}
+
+const missingMessages = expectedMessages.filter(message => !invalidOutput.includes(message));
+
+if (missingMessages.length > 0) {
+  console.error('Invalid project registry fixture did not trigger expected validation errors.');
+  missingMessages.forEach(message => console.error(`- Missing: ${message}`));
+  process.exit(1);
+}
+
+console.log('Success: project registry validation fixtures passed.');

--- a/scripts/validate-projects.js
+++ b/scripts/validate-projects.js
@@ -1,0 +1,1 @@
+require('./validate-metadata');


### PR DESCRIPTION
## Summary
- Restore `npm run validate:projects` by adding the missing `scripts/validate-projects.js` wrapper.
- Make CI and lint-staged use the same local registry validation command.
- Harden `projects.json` validation for malformed days, paths, difficulty values, URL schemes, traversal, and missing files.

## Details
The local validation script pointed to `scripts/validate-projects.js`, but that file did not exist. CI called `scripts/validate-metadata.js` directly, so local contributor checks and CI were not using the same entry point.

This change keeps `scripts/validate-metadata.js` as the single validation logic source and adds `scripts/validate-projects.js` as the canonical wrapper used by `npm run validate:projects`. CI now calls `npm run validate:projects`, and `lint-staged` uses the same command for `projects.json` changes.

The validator now produces field-specific messages with index, day number, and project name context. It validates positive unique `projectNo` values, required metadata, allowed difficulty values, duplicate project paths, non-empty tech stack tokens, external URL schemes, GitHub tree URL repository scope, decoded local path traversal, repository-root containment, and local path existence.

A fixture script exercises the wrapper with one valid registry and one invalid registry covering duplicate day numbers, invalid difficulty, unsafe URL schemes, traversal, and missing local files.

## Validation
- `node --check scripts\\validate-metadata.js`
- `node --check scripts\\validate-projects.js`
- `node --check scripts\\validate-projects-fixture.js`
- `npm run validate:projects-fixture`
- `git diff --check`

Note: full `npm run validate:projects` was not run locally because this checkout is sparse and does not include the full `public/` project tree required for file-existence checks.

Closes #7078