### PR TITLE
Enhancement: Replaced native browser alert on Clear with a theme-matching custom modal.

### DIFF
--- a/public/typewriter/typewriter.css
+++ b/public/typewriter/typewriter.css
@@ -869,3 +869,147 @@ body::after {
     justify-content: center;
   }
 }
+
+/* ==========================================================================
+   CLEAR CONFIRMATION MODAL
+   ========================================================================== */
+
+.clear-modal-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.72);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 99999;
+  align-items: center;
+  justify-content: center;
+  animation: modalFadeIn 0.2s ease;
+}
+
+.clear-modal-overlay.is-open {
+  display: flex;
+}
+
+@keyframes modalFadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.clear-modal-box {
+  background: linear-gradient(
+    145deg,
+    var(--key-bg-a, #1a1a1a),
+    var(--key-bg-b, #111111)
+  );
+  border: 1px solid rgba(59, 130, 246, 0.25);
+  border-radius: 20px;
+  padding: 40px 36px 32px;
+  max-width: 420px;
+  width: 90%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  box-shadow:
+    0 32px 80px rgba(0, 0, 0, 0.6),
+    0 0 0 1px rgba(255, 255, 255, 0.04);
+  animation: modalSlideUp 0.28s cubic-bezier(0.34, 1.56, 0.64, 1);
+  font-family: "Courier Prime", "Courier New", monospace;
+}
+
+/* Light theme override */
+body.light-theme .clear-modal-box {
+  background: linear-gradient(145deg, #f0f4f8, #e2e8f0);
+  border-color: rgba(59, 130, 246, 0.3);
+  box-shadow:
+    0 32px 80px rgba(0, 0, 0, 0.2),
+    0 0 0 1px rgba(0, 0, 0, 0.06);
+}
+
+@keyframes modalSlideUp {
+  from { opacity: 0; transform: translateY(28px) scale(0.95); }
+  to   { opacity: 1; transform: translateY(0)    scale(1);    }
+}
+
+.clear-modal-icon {
+  font-size: 2.8rem;
+  line-height: 1;
+  filter: drop-shadow(0 4px 12px rgba(239, 68, 68, 0.4));
+}
+
+.clear-modal-title {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--text-color, #f8fafc);
+  text-align: center;
+  letter-spacing: 0.01em;
+}
+
+.clear-modal-desc {
+  font-size: 0.88rem;
+  color: rgba(248, 250, 252, 0.55);
+  text-align: center;
+  line-height: 1.6;
+  max-width: 320px;
+}
+
+body.light-theme .clear-modal-desc {
+  color: rgba(15, 23, 42, 0.55);
+}
+
+.clear-modal-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 6px;
+  width: 100%;
+}
+
+.clear-modal-btn {
+  flex: 1;
+  height: 44px;
+  border-radius: 12px;
+  font-size: 0.88rem;
+  font-weight: 700;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s ease;
+  font-family: "Courier Prime", "Courier New", monospace;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+}
+
+.clear-modal-btn--cancel {
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--text-color, #f8fafc);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+.clear-modal-btn--cancel:hover {
+  background: rgba(255, 255, 255, 0.13);
+  border-color: rgba(255, 255, 255, 0.22);
+}
+
+body.light-theme .clear-modal-btn--cancel {
+  background: rgba(0, 0, 0, 0.06);
+  color: #1e293b;
+  border-color: rgba(0, 0, 0, 0.14);
+}
+body.light-theme .clear-modal-btn--cancel:hover {
+  background: rgba(0, 0, 0, 0.11);
+}
+
+.clear-modal-btn--confirm {
+  background: linear-gradient(135deg, #ef4444, #b91c1c);
+  color: #fff;
+  box-shadow: 0 4px 16px rgba(239, 68, 68, 0.35);
+}
+.clear-modal-btn--confirm:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 22px rgba(239, 68, 68, 0.5);
+}
+.clear-modal-btn--confirm:active {
+  transform: translateY(1px);
+}
+

--- a/public/typewriter/typewriter.html
+++ b/public/typewriter/typewriter.html
@@ -372,6 +372,21 @@
     </div>
     <div class="toast-container" id="pdfToast"></div>
 
+    <!-- ── Clear Confirmation Modal ───────────────────────────────────── -->
+    <div id="clearModal" class="clear-modal-overlay" role="dialog" aria-modal="true" aria-labelledby="clearModalTitle">
+      <div class="clear-modal-box">
+        <div class="clear-modal-icon">🗑️</div>
+        <h2 class="clear-modal-title" id="clearModalTitle">Clear All Pages?</h2>
+        <p class="clear-modal-desc">This will permanently erase every word typed across all pages. This cannot be undone.</p>
+        <div class="clear-modal-actions">
+          <button id="clearModalCancel" class="clear-modal-btn clear-modal-btn--cancel">Cancel</button>
+          <button id="clearModalConfirm" class="clear-modal-btn clear-modal-btn--confirm">
+            <i class="fas fa-trash-alt" aria-hidden="true"></i> Yes, Clear All
+          </button>
+        </div>
+      </div>
+    </div>
+
     <script src="typewriter.js"></script>
     <script
       src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"

--- a/public/typewriter/typewriter.js
+++ b/public/typewriter/typewriter.js
@@ -434,7 +434,31 @@ function showPdfToast(msg, isSuccess = true) {
   }, 3000);
 }
 
-// Carriage Bar Reset Button
+// Carriage Bar Reset Button — custom UI modal (replaces native confirm())
+const clearModal        = document.getElementById("clearModal");
+const clearModalCancel  = document.getElementById("clearModalCancel");
+const clearModalConfirm = document.getElementById("clearModalConfirm");
+
+function openClearModal()  { clearModal.classList.add("is-open");    }
+function closeClearModal() { clearModal.classList.remove("is-open"); }
+
+function executeClearAll() {
+  pagesContainer.innerHTML = `
+    <div class="paper-sheet page active-page">
+      <span class="typewriterText" contenteditable="false"></span>
+    </div>
+  `;
+  currentPage = 0;
+  paperContent = "";
+  cursorPos = 0;
+  userInput.value = "";
+  pageCounter.innerText = "Page 1";
+  updateCopyButtonState();
+  updateCounters();
+  showPdfToast("All pages cleared!");
+  playHeavyKey();
+}
+
 const clearPaperBtn = document.getElementById("clearPaperBtn");
 if (clearPaperBtn) {
   clearPaperBtn.addEventListener("click", () => {
@@ -443,22 +467,20 @@ if (clearPaperBtn) {
       showPdfToast("Paper is already clean!");
       return;
     }
-    if (confirm("Are you sure you want to clear all typed paper pages?")) {
-      pagesContainer.innerHTML = `
-                <div class="paper-sheet page active-page">
-                    <span class="typewriterText" contenteditable="false"></span>
-                </div>
-            `;
-      currentPage = 0;
-      paperContent = "";
-      cursorPos = 0;
-      userInput.value = "";
-      pageCounter.innerText = "Page 1";
-      updateCopyButtonState();
-      updateCounters();
-      showPdfToast("All pages cleared!");
-      playHeavyKey();
-    }
+    openClearModal();
+  });
+}
+
+if (clearModalCancel)  clearModalCancel.addEventListener("click", closeClearModal);
+if (clearModalConfirm) clearModalConfirm.addEventListener("click", () => {
+  closeClearModal();
+  executeClearAll();
+});
+
+// Close modal when clicking the backdrop
+if (clearModal) {
+  clearModal.addEventListener("click", (e) => {
+    if (e.target === clearModal) closeClearModal();
   });
 }
 


### PR DESCRIPTION
## 📝 Pull Request Description

- Clicking the Clear button triggers a raw native browser alert() dialog, unstyled, non-themeable, and visually out of place against the vintage typewriter UI.
- It breaks immersion and looks inconsistent across different browsers and operating systems.

### Related Issue
Closes #7435 

### Summary
Provide a short, reviewer-friendly summary of what changed and why.

- Replaced the native browser alert box that appeared when clicking the 'Clear' button with a fully custom, theme-aware confirmation popup. 
- The new popup matches the typewriter app's dark aesthetic with a blurred backdrop overlay, a slide-up animation, and two clearly labelled buttons : 'Cancel' and 'Yes, Clear All' , preserving the exact same functionality as the original alert.  
- The modal also automatically adapts to the light theme when toggled, and clicking outside the pop-up closes it without taking any action.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [X] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made

Detailed description of change 1
-

> typewriter.html : Added the Modal Structure

- A new hidden modal block was added to the page just before the script tag. It contains:
- A backdrop overlay (div#clearModal) that covers the entire screen when active.
- A modal card (div.clear-modal-box) containing:
- A 🗑️ icon at the top.
- A heading : "Clear All Pages?"
- A descriptive warning : "This will permanently erase every word typed across all pages. This cannot be undone."
- Two action buttons : a Cancel button and a Yes, Clear All button (with a trash icon from Font Awesome).
- Proper accessibility attributes (role="dialog", aria-modal="true", aria-labelledby) were also added.
 
Detailed description of change 2
-

> typewriter.css : Styled the Modal for Both Themes

- A complete modal styling section was appended at the bottom of the stylesheet:
- Overlay: Fixed, full-screen, with a dark semi-transparent background and backdrop-filter: blur(8px), giving the frosted glass effect consistent with the app's aesthetic.
- Show/Hide: The overlay defaults to display: none and becomes display: flex when the class is-open is toggled by JavaScript, keeping it lightweight.
- Animations: A modalFadeIn keyframe fades the overlay in, and a modalSlideUp keyframe slides the card up from below with a subtle spring bounce using cubic-bezier.
- Modal Card (Dark Mode): Uses the app's existing CSS variables (--key-bg-a, --key-bg-b, --text-color) so the card background and text automatically match the dark keyboard aesthetic.
- Modal Card (Light Mode): A body.light-theme override switches the card to a soft grey palette and adjusts the text and border colours accordingly, no extra JavaScript needed.
- Cancel Button: Subtle ghost style with a low-opacity white border that brightens on hover.
- Confirm Button: Bold red gradient (#ef4444 → #b91c1c) with a glowing red box-shadow that intensifies on hover and presses down on click, making the destructive action feel deliberate and weighty.

Detailed description of change 3
-

> typewriter.js : Replaced confirm() with Modal Logic

- The original confirm() call was completely removed and replaced with the following structure:  
- References to the three new DOM elements (clearModal, clearModalCancel, clearModalConfirm) are captured.
- openClearModal() : adds the is-open class to show the modal.
- closeClearModal() : removes the is-open class to hide it.
- executeClearAll() : the extracted clear logic that resets the pages container back to a single blank sheet, resets all state variables (currentPage, paperContent, cursorPos), clears the text input, resets the page counter, updates the word/character counters, shows the "All pages cleared!" toast, and plays the heavy key sound, exactly as the original code did.
- Clear button click : checks if there is any text first; if the paper is empty, it shows the "Paper is already clean!" toast and returns early (same as before). If there is content, it calls openClearModal() instead of confirm().
- Cancel button click : calls closeClearModal(), nothing else happens.
- Confirm button click : calls closeClearModal() first, then executeClearAll().
- Backdrop click : clicking anywhere on the dark overlay outside the card also calls closeClearModal(), giving the user an intuitive escape route.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [X] Tested and verified in **Google Chrome**
- [X] Tested and verified in **Mozilla Firefox**
- [X] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [X] Keyboard navigation and focus outlines checked
- [X] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
*Please attach screenshots or screen recordings showing before vs after behavior if this PR includes visual changes.*

<img width="3416" height="1902" alt="yess 2026-06-09 at 2 06 47 AM" src="https://github.com/user-attachments/assets/c277732a-59fc-4b87-9161-cba4d1d5fc49" />

---

## 🤝 Contributor Checklist
- [X] My code follows the code style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation / README files accordingly.
- [X] My changes generate no new warnings or console errors.
- [X] There are no unrelated changes or formatter noise in this PR.