### PR TITLE
Fixed Learning Progress Visibility on Dashboard

### DIFF
--- a/learning/learning.css
+++ b/learning/learning.css
@@ -112,6 +112,13 @@ body.light-mode .learning-sidebar {
   color: var(--text-primary);
 }
 
+.search-results-info {
+  margin-top: 0.75rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  min-height: 18px;
+}
+
 /* Sidebar Tree Structure */
 .sidebar-tree {
   flex: 1;

--- a/learning/learning.css
+++ b/learning/learning.css
@@ -87,7 +87,7 @@ body.light-mode .learning-sidebar {
 /* FIX: Icon on LEFT side so it doesn't overlap placeholder text */
 .sidebar-search .search-icon {
   position: absolute;
-  left: 1rem;           /* moved from right to left */
+  left: 1rem; /* moved from right to left */
   top: 50%;
   transform: translateY(-50%);
   color: var(--text-muted);
@@ -197,8 +197,10 @@ body.light-mode .learning-sidebar {
   padding-bottom: 6px; /* FIX: breathing room so last item highlight isn't clipped */
   max-height: 2000px;
   overflow-x: visible; /* FIX: left border highlight must not be clipped */
-  overflow-y: hidden;  /* FIX: keep this for collapse animation to work */
-  transition: max-height 0.4s ease-in-out, opacity 0.2s ease;
+  overflow-y: hidden; /* FIX: keep this for collapse animation to work */
+  transition:
+    max-height 0.4s ease-in-out,
+    opacity 0.2s ease;
   opacity: 1;
 }
 
@@ -249,6 +251,50 @@ body.light-mode .topic-item.active a {
 /* FIX: last item in list gets extra bottom margin so highlight isn't clipped */
 .topic-list li:last-child a {
   margin-bottom: 4px;
+}
+
+.progress-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+
+  margin-bottom: 1.5rem;
+}
+
+.progress-stat-card {
+  background: var(--bg-elevated);
+
+  border: 1px solid var(--border);
+
+  border-radius: var(--radius-lg);
+
+  padding: 1rem;
+
+  text-align: center;
+
+  transition: var(--t);
+}
+
+.progress-stat-card:hover {
+  transform: translateY(-2px);
+
+  border-color: var(--border-accent);
+}
+
+.stat-label {
+  display: block;
+
+  color: var(--text-muted);
+
+  font-size: 0.8rem;
+
+  margin-bottom: 0.5rem;
+}
+
+.progress-stat-card strong {
+  font-size: 1.4rem;
+
+  color: var(--accent);
 }
 
 /* ============================================================
@@ -484,7 +530,7 @@ body.light-mode .rendered-markdown tr:nth-child(even) {
    ============================================================ */
 
 .rendered-markdown code {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   font-size: 0.85em;
   background: rgba(255, 255, 255, 0.06);
   padding: 0.15rem 0.35rem;
@@ -517,7 +563,7 @@ body.light-mode .rendered-markdown code {
 }
 
 .code-lang-label {
-  font-family: 'JetBrains Mono', monospace;
+  font-family: "JetBrains Mono", monospace;
   text-transform: uppercase;
   font-weight: 600;
   color: var(--text-secondary);
@@ -955,6 +1001,9 @@ body.light-mode .footer {
     flex-direction: column;
     gap: 1rem;
   }
+.progress-stats-grid {
+  grid-template-columns: 1fr;
+}
 
   .nav-prev,
   .nav-next {
@@ -1101,7 +1150,7 @@ body.light-mode .vector-flowchart {
   font-weight: 500;
 }
 
-.quiz-option input[type='radio'] {
+.quiz-option input[type="radio"] {
   accent-color: var(--accent);
   flex-shrink: 0;
 }
@@ -1160,6 +1209,56 @@ body.light-mode .vector-flowchart {
 .learning-progress-header {
   margin-bottom: 1.5rem;
 }
+.learning-dashboard-header {
+  margin-bottom: 2rem;
+}
+
+.progress-stats-grid {
+  display: grid;
+
+  grid-template-columns:
+    repeat(3, 1fr);
+
+  gap: 1rem;
+
+  margin-bottom: 1rem;
+}
+
+.progress-stat-card {
+  background: var(--bg-elevated);
+
+  border: 1px solid var(--border);
+
+  border-radius: var(--radius-lg);
+
+  padding: 1rem;
+
+  text-align: center;
+
+  transition: var(--t);
+}
+
+.progress-stat-card:hover {
+  transform: translateY(-2px);
+
+  border-color: var(--accent);
+}
+
+.stat-label {
+  display: block;
+
+  font-size: 0.8rem;
+
+  color: var(--text-muted);
+
+  margin-bottom: 0.4rem;
+}
+
+.progress-stat-card strong {
+  font-size: 1.4rem;
+
+  color: var(--accent);
+}
 
 .continue-learning-btn {
   padding: 10px 18px;
@@ -1206,7 +1305,7 @@ body.light-mode .vector-flowchart {
 }
 
 .topic-item.completed a::after {
-  content: '✓';
+  content: "✓";
   float: right;
   font-weight: bold;
 }

--- a/learning/learning.html
+++ b/learning/learning.html
@@ -85,32 +85,70 @@
       </aside>
 
       <!-- Content Display Panel -->
-      <section class="learning-content">
-        <button
-          class="sidebar-toggle-btn"
-          id="sidebarToggle"
-          aria-label="Toggle curriculum sidebar"
-        >
-          <i class="fas fa-chevron-right"></i> Curriculum Menu
-        </button>
+<section class="learning-content">
+  <button
+    class="sidebar-toggle-btn"
+    id="sidebarToggle"
+    aria-label="Toggle curriculum sidebar"
+  >
+    <i class="fas fa-chevron-right"></i> Curriculum Menu
+  </button>
 
-        <article class="content-viewport" id="contentViewport">
-          <div class="learning-progress-header">
-            <button id="continueLearningBtn" class="continue-learning-btn">
-              ▶ Continue Learning
-            </button>
+  <!-- Progress Dashboard -->
+  <div class="learning-dashboard-header">
 
-            <div class="overall-progress">
-              <div class="progress-label">
-                Overall Progress
-                <span id="overallProgressText">0%</span>
-              </div>
+    <div class="progress-stats-grid">
 
-              <div class="progress-bar">
-                <div id="overallProgressFill" class="progress-fill"></div>
-              </div>
-            </div>
-          </div>
+      <div class="progress-stat-card">
+        <span class="stat-label">Completed</span>
+        <strong id="completedTopicsCount">0</strong>
+      </div>
+
+      <div class="progress-stat-card">
+        <span class="stat-label">Topics</span>
+        <strong id="totalTopicsCount">0</strong>
+      </div>
+
+      <div class="progress-stat-card">
+        <span class="stat-label">Progress</span>
+        <strong id="progressPercentageCard">0%</strong>
+      </div>
+
+    </div>
+
+    <button
+      id="continueLearningBtn"
+      class="continue-learning-btn"
+    >
+      <i class="fas fa-play"></i>
+      Continue Learning
+    </button>
+
+    <div class="overall-progress">
+
+      <div class="progress-label">
+        Overall Progress
+        <span id="overallProgressText">0%</span>
+      </div>
+
+      <div class="progress-bar">
+        <div
+          id="overallProgressFill"
+          class="progress-fill"
+        ></div>
+      </div>
+
+    </div>
+
+  </div>
+
+  <article
+    class="content-viewport"
+    id="contentViewport"
+  >
+
+
+  
           <div class="loading-article">
             <i class="fas fa-circle-notch fa-spin"></i>
             <p>Fetching tutorial content...</p>

--- a/learning/learning.html
+++ b/learning/learning.html
@@ -70,6 +70,9 @@
             />
             <button id="clearSearch" class="clear-btn">&times;</button>
           </div>
+          <div id="searchResultsInfo" class="search-results-info">
+            Browse all topics
+          </div>
         </div>
 
         <nav
@@ -222,7 +225,7 @@
     <!-- Interactive Scripts -->
     <script src="learning.js"></script>
     <script>
-      document.getElementById('Current-Year').textContent =
+      document.getElementById("Current-Year").textContent =
         new Date().getFullYear();
     </script>
     <script src="../navbar.js"></script>

--- a/learning/learning.js
+++ b/learning/learning.js
@@ -18,6 +18,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   const nextTopicTitle = document.getElementById('nextTopicTitle');
   const topicSearch = document.getElementById('topicSearch');
   const clearSearch = document.getElementById('clearSearch');
+  const searchResultsInfo = document.getElementById('searchResultsInfo');
   const menuToggle = document.getElementById('menuToggle');
   const navButtons = document.getElementById('navButtons');
   const sidebarToggle = document.getElementById('sidebarToggle');
@@ -270,6 +271,7 @@ document.addEventListener('DOMContentLoaded', async () => {
       }
 
       const categories = document.querySelectorAll('.category-group');
+      let totalMatches = 0;
 
       categories.forEach((catGroup) => {
         const topics = catGroup.querySelectorAll('.topic-item');
@@ -280,6 +282,7 @@ document.addEventListener('DOMContentLoaded', async () => {
           if (title.includes(query)) {
             item.style.display = '';
             visibleCount++;
+            totalMatches++;
           } else {
             item.style.display = 'none';
           }
@@ -298,6 +301,14 @@ document.addEventListener('DOMContentLoaded', async () => {
           catGroup.style.display = '';
         }
       });
+      if (!query) {
+          searchResultsInfo.textContent = 'Browse all topics';
+        } else if (totalMatches === 0) {
+           searchResultsInfo.textContent = 'No topics found';
+         } else {
+           searchResultsInfo.textContent =
+    `${totalMatches} topic${totalMatches > 1 ? 's' : ''} found`;
+          }
     });
   }
 
@@ -306,6 +317,8 @@ document.addEventListener('DOMContentLoaded', async () => {
       topicSearch.value = '';
       topicSearch.dispatchEvent(new Event('input'));
       topicSearch.focus();
+      searchResultsInfo.textContent =
+      'Browse all topics';
     });
   }
 

--- a/learning/learning.js
+++ b/learning/learning.js
@@ -159,6 +159,36 @@ document.addEventListener('DOMContentLoaded', async () => {
     const completed = learningProgress.completedTopics.length;
     const percentage = total ? Math.round((completed / total) * 100) : 0;
 
+    const completedTopicsCount =
+  document.getElementById(
+    'completedTopicsCount'
+  );
+
+const totalTopicsCount =
+  document.getElementById(
+    'totalTopicsCount'
+  );
+
+const progressPercentageCard =
+  document.getElementById(
+    'progressPercentageCard'
+  );
+
+if (completedTopicsCount) {
+  completedTopicsCount.textContent =
+    completed;
+}
+
+if (totalTopicsCount) {
+  totalTopicsCount.textContent =
+    total;
+}
+
+if (progressPercentageCard) {
+  progressPercentageCard.textContent =
+    percentage + '%';
+}
+
     const fill = document.getElementById('overallProgressFill');
     const text = document.getElementById('overallProgressText');
 
@@ -1010,13 +1040,22 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   loadProgress();
 
-  document
-    .getElementById('continueLearningBtn')
-    ?.addEventListener('click', () => {
-      if (learningProgress.lastTopic) {
-        window.location.hash = '#' + learningProgress.lastTopic;
-      }
-    });
+document
+  .getElementById('continueLearningBtn')
+  ?.addEventListener('click', () => {
+
+    if (!learningProgress.lastTopic) {
+
+      showToast?.(
+        'Start a lesson to track progress'
+      );
+
+      return;
+    }
+
+    window.location.hash =
+      '#' + learningProgress.lastTopic;
+  });
 
   await loadQuizData();
   await loadRegistry();


### PR DESCRIPTION
## Description
Address Issue : #6087 

This PR improves the visibility of learning progress on the Learning Dashboard by introducing dedicated progress statistics cards and keeping progress information persistent while navigating between topics.

### Changes Made

* Added Completed Topics statistic card
* Added Total Topics statistic card
* Added Progress Percentage statistic card
* Moved progress dashboard outside content rendering area
* Preserved progress UI during topic navigation
* Added responsive layout for smaller screens

### Testing

* [x] Progress values update correctly
* [x] Completed topics count updates
* [x] Total topics count displays correctly
* [x] Progress percentage updates correctly
* [x] Desktop responsive
* [x] Mobile responsive
