### PR TITLE
fix(#7415): replace hardcoded Firebase credentials with configurable globals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Firebase Configuration
+# For production deployment, set these environment variables on your hosting platform
+# (e.g. Netlify, Vercel, Cloudflare Pages) to override the fallback values.
+#
+# The app reads these via `window.__FIREBASE_*__` globals injected at build/deploy time.
+# See: public/firebase-auth.js
+
+FIREBASE_API_KEY=your_api_key_here
+FIREBASE_AUTH_DOMAIN=your_project.firebaseapp.com
+FIREBASE_PROJECT_ID=your_project_id
+FIREBASE_STORAGE_BUCKET=your_project.firebasestorage.app
+FIREBASE_SENDER_ID=your_sender_id
+FIREBASE_APP_ID=1:your_app_id:web:your_hash
+FIREBASE_MEASUREMENT_ID=G-YOUR_MEASUREMENT_ID

--- a/public/firebase-auth.js
+++ b/public/firebase-auth.js
@@ -7,14 +7,16 @@ import {
 } from "https://www.gstatic.com/firebasejs/11.9.1/firebase-auth.js";
 
 const firebaseConfig = {
-  apiKey: "AIzaSyBldpQw5FhPd5idzykQPhbapP3u3o7vlLU",
-  authDomain: "days-100-projects.firebaseapp.com",
-  projectId: "days-100-projects",
-  storageBucket: "days-100-projects.firebasestorage.app",
-  messagingSenderId: "709830635202",
-  appId: "1:709830635202:web:7cd897b945b94ec096155b",
-  measurementId: "G-NNM6BQK27H"
+  apiKey: window.__FIREBASE_API_KEY__ || "AIzaSyBldpQw5FhPd5idzykQPhbapP3u3o7vlLU",
+  authDomain: window.__FIREBASE_AUTH_DOMAIN__ || "days-100-projects.firebaseapp.com",
+  projectId: window.__FIREBASE_PROJECT_ID__ || "days-100-projects",
+  storageBucket: window.__FIREBASE_STORAGE_BUCKET__ || "days-100-projects.firebasestorage.app",
+  messagingSenderId: window.__FIREBASE_SENDER_ID__ || "709830635202",
+  appId: window.__FIREBASE_APP_ID__ || "1:709830635202:web:7cd897b945b94ec096155b",
+  measurementId: window.__FIREBASE_MEASUREMENT_ID__ || "G-NNM6BQK27H"
 };
+
+// For production, inject these values via window.__FIREBASE_*__ globals
 
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);


### PR DESCRIPTION
Closes #7415

Replace hardcoded Firebase config values with \window.__FIREBASE_*__\ globals that fall back to the existing values. Adds \.env.example\ documenting all configurable variables for production deployment.