### PR TITLE
fix(#7411): replace eval() with switch statements in pacman ghost logic

### DIFF
--- a/public/pacman/js/game.js
+++ b/public/pacman/js/game.js
@@ -355,15 +355,17 @@ function score(s, type) {
   ) {
     erasePacman();
     eraseGhost(type);
-    $("#board").append('<span class="combo">' + SCORE_GHOST_COMBO + "</span>");
-    $("#board span.combo").css(
-      "top",
-      eval("GHOST_" + type.toUpperCase() + "_POSITION_Y - 10") + "px",
-    );
-    $("#board span.combo").css(
-      "left",
-      eval("GHOST_" + type.toUpperCase() + "_POSITION_X - 10") + "px",
-    );
+    $('#board').append('<span class="combo">' + SCORE_GHOST_COMBO + '</span>');
+
+    var ghostPosY, ghostPosX;
+    switch (type) {
+      case 'blinky': ghostPosY = GHOST_BLINKY_POSITION_Y - 10; ghostPosX = GHOST_BLINKY_POSITION_X - 10; break;
+      case 'pinky':  ghostPosY = GHOST_PINKY_POSITION_Y - 10;  ghostPosX = GHOST_PINKY_POSITION_X - 10;  break;
+      case 'inky':   ghostPosY = GHOST_INKY_POSITION_Y - 10;   ghostPosX = GHOST_INKY_POSITION_X - 10;   break;
+      case 'clyde':  ghostPosY = GHOST_CLYDE_POSITION_Y - 10;  ghostPosX = GHOST_CLYDE_POSITION_X - 10;  break;
+    }
+    $('#board span.combo').css('top', ghostPosY + 'px');
+    $('#board span.combo').css('left', ghostPosX + 'px');
     SCORE_GHOST_COMBO = SCORE_GHOST_COMBO * 2;
   } else if (type && type === "fruit") {
     $("#board").append('<span class="fruits">' + s + "</span>");

--- a/public/pacman/js/pacman.js
+++ b/public/pacman/js/pacman.js
@@ -303,8 +303,34 @@ function testGhostsPacman() {
   testGhostPacman("clyde");
 }
 function testGhostPacman(ghost) {
-  eval("var positionX = GHOST_" + ghost.toUpperCase() + "_POSITION_X");
-  eval("var positionY = GHOST_" + ghost.toUpperCase() + "_POSITION_Y");
+  var ghostKey = ghost.toUpperCase();
+  var positionX, positionY, state;
+
+  // Access ghost state via direct references instead of eval()
+  switch (ghostKey) {
+    case 'BLINKY':
+      positionX = GHOST_BLINKY_POSITION_X;
+      positionY = GHOST_BLINKY_POSITION_Y;
+      state = GHOST_BLINKY_STATE;
+      break;
+    case 'PINKY':
+      positionX = GHOST_PINKY_POSITION_X;
+      positionY = GHOST_PINKY_POSITION_Y;
+      state = GHOST_PINKY_STATE;
+      break;
+    case 'INKY':
+      positionX = GHOST_INKY_POSITION_X;
+      positionY = GHOST_INKY_POSITION_Y;
+      state = GHOST_INKY_STATE;
+      break;
+    case 'CLYDE':
+      positionX = GHOST_CLYDE_POSITION_X;
+      positionY = GHOST_CLYDE_POSITION_Y;
+      state = GHOST_CLYDE_STATE;
+      break;
+    default:
+      return;
+  }
 
   if (
     positionX <= PACMAN_POSITION_X + PACMAN_GHOST_GAP &&
@@ -312,7 +338,6 @@ function testGhostPacman(ghost) {
     positionY <= PACMAN_POSITION_Y + PACMAN_GHOST_GAP &&
     positionY >= PACMAN_POSITION_Y - PACMAN_GHOST_GAP
   ) {
-    eval("var state = GHOST_" + ghost.toUpperCase() + "_STATE");
     if (state === 0) {
       killPacman();
     } else if (state === 1) {


### PR DESCRIPTION
Closes #7411

Replace unsafe eval() calls with direct switch/case assignments for ghost position and state access in both pacman.js and game.js.