### PR TITLE
fix(#7412): replace new Function() with safe recursive-descent parser in Calculator

### DIFF
--- a/public/Vanilla-JavaScript-Calculator-master/script.js
+++ b/public/Vanilla-JavaScript-Calculator-master/script.js
@@ -81,23 +81,20 @@ class Calculator {
     try {
       const formatted = this.formatExpression(this.expression);
       
-      // Security: Validate the expression contains only math characters before execution
-      if (/[^0-9+\-*/().^\se]/.test(formatted)) {
+      // Security: Strict validation — only allow digits, basic operators, parens, spaces, dots
+      if (!/^[\d+\-*/().%\s^]+$/.test(formatted)) {
         throw new Error("Invalid characters in expression");
       }
       
-      // Safely evaluate without giving access to local scope
-      let result = new Function('return ' + formatted)();
-      if (!isFinite(result) || isNaN(result)) {
+      // Safe math evaluation using a simple recursive-descent parser
+      let result = this.safeEval(formatted);
+      if (result === null || !isFinite(result) || isNaN(result)) {
         this.setError();
         return;
       }
-      // Round to avoid floating point noise
       result = parseFloat(result.toPrecision(12));
       
-      // ========== HISTORY ==========
       addToHistory(this.expression, result);
-      // ================================================
       
       this.latestAnswer = result;
       this.expression = result.toString();
@@ -110,11 +107,80 @@ class Calculator {
     }
   }
 
+  // Safe recursive-descent parser — no eval/Function constructor
+  safeEval(expr) {
+    var tokens = expr.match(/\d+\.?\d*|[+\-*/()^]|%\s/g) || [];
+    if (tokens.length === 0) return null;
+    var pos = 0;
+
+    function peek() { return tokens[pos]; }
+    function consume() { return tokens[pos++]; }
+
+    function parsePrimary() {
+      var tok = peek();
+      if (tok === '(') {
+        consume();
+        var val = parseExpr();
+        if (peek() === ')') consume();
+        return val;
+      }
+      if (tok === '-') {
+        consume();
+        return -parsePrimary();
+      }
+      var num = parseFloat(tok);
+      if (!isNaN(num)) { consume(); return num; }
+      return null;
+    }
+
+    function parsePower() {
+      var left = parsePrimary();
+      if (left === null) return null;
+      while (peek() === '^') {
+        consume();
+        var right = parsePrimary();
+        if (right === null) return null;
+        left = Math.pow(left, right);
+      }
+      return left;
+    }
+
+    function parseMulDiv() {
+      var left = parsePower();
+      if (left === null) return null;
+      while (peek() === '*' || peek() === '/') {
+        var op = consume();
+        var right = parsePower();
+        if (right === null) return null;
+        if (op === '*') left *= right;
+        else left /= right;
+      }
+      return left;
+    }
+
+    function parseExpr() {
+      var left = parseMulDiv();
+      if (left === null) return null;
+      while (peek() === '+' || peek() === '-') {
+        var op = consume();
+        var right = parseMulDiv();
+        if (right === null) return null;
+        if (op === '+') left += right;
+        else left -= right;
+      }
+      return left;
+    }
+
+    var result = parseExpr();
+    if (result === null || pos !== tokens.length) return null;
+    return result;
+  }
+
   formatExpression(expression) {
     return expression
       .replace(/÷/g, '/')
       .replace(/×/g, '*')
-      .replace(/\^(\-?\d+\.?\d*)/g, (match, exp) => `**(${exp})`)
+      .replace(/\^/g, '^')
       .replace(/(\d)\(/g, '$1*(')
       .replace(/\)(\d)/g, ')*$1');
   }

--- a/public/pacman/js/game.js
+++ b/public/pacman/js/game.js
@@ -355,15 +355,17 @@ function score(s, type) {
   ) {
     erasePacman();
     eraseGhost(type);
-    $("#board").append('<span class="combo">' + SCORE_GHOST_COMBO + "</span>");
-    $("#board span.combo").css(
-      "top",
-      eval("GHOST_" + type.toUpperCase() + "_POSITION_Y - 10") + "px",
-    );
-    $("#board span.combo").css(
-      "left",
-      eval("GHOST_" + type.toUpperCase() + "_POSITION_X - 10") + "px",
-    );
+    $('#board').append('<span class="combo">' + SCORE_GHOST_COMBO + '</span>');
+
+    var ghostPosY, ghostPosX;
+    switch (type) {
+      case 'blinky': ghostPosY = GHOST_BLINKY_POSITION_Y - 10; ghostPosX = GHOST_BLINKY_POSITION_X - 10; break;
+      case 'pinky':  ghostPosY = GHOST_PINKY_POSITION_Y - 10;  ghostPosX = GHOST_PINKY_POSITION_X - 10;  break;
+      case 'inky':   ghostPosY = GHOST_INKY_POSITION_Y - 10;   ghostPosX = GHOST_INKY_POSITION_X - 10;   break;
+      case 'clyde':  ghostPosY = GHOST_CLYDE_POSITION_Y - 10;  ghostPosX = GHOST_CLYDE_POSITION_X - 10;  break;
+    }
+    $('#board span.combo').css('top', ghostPosY + 'px');
+    $('#board span.combo').css('left', ghostPosX + 'px');
     SCORE_GHOST_COMBO = SCORE_GHOST_COMBO * 2;
   } else if (type && type === "fruit") {
     $("#board").append('<span class="fruits">' + s + "</span>");

--- a/public/pacman/js/pacman.js
+++ b/public/pacman/js/pacman.js
@@ -303,8 +303,34 @@ function testGhostsPacman() {
   testGhostPacman("clyde");
 }
 function testGhostPacman(ghost) {
-  eval("var positionX = GHOST_" + ghost.toUpperCase() + "_POSITION_X");
-  eval("var positionY = GHOST_" + ghost.toUpperCase() + "_POSITION_Y");
+  var ghostKey = ghost.toUpperCase();
+  var positionX, positionY, state;
+
+  // Access ghost state via direct references instead of eval()
+  switch (ghostKey) {
+    case 'BLINKY':
+      positionX = GHOST_BLINKY_POSITION_X;
+      positionY = GHOST_BLINKY_POSITION_Y;
+      state = GHOST_BLINKY_STATE;
+      break;
+    case 'PINKY':
+      positionX = GHOST_PINKY_POSITION_X;
+      positionY = GHOST_PINKY_POSITION_Y;
+      state = GHOST_PINKY_STATE;
+      break;
+    case 'INKY':
+      positionX = GHOST_INKY_POSITION_X;
+      positionY = GHOST_INKY_POSITION_Y;
+      state = GHOST_INKY_STATE;
+      break;
+    case 'CLYDE':
+      positionX = GHOST_CLYDE_POSITION_X;
+      positionY = GHOST_CLYDE_POSITION_Y;
+      state = GHOST_CLYDE_STATE;
+      break;
+    default:
+      return;
+  }
 
   if (
     positionX <= PACMAN_POSITION_X + PACMAN_GHOST_GAP &&
@@ -312,7 +338,6 @@ function testGhostPacman(ghost) {
     positionY <= PACMAN_POSITION_Y + PACMAN_GHOST_GAP &&
     positionY >= PACMAN_POSITION_Y - PACMAN_GHOST_GAP
   ) {
-    eval("var state = GHOST_" + ghost.toUpperCase() + "_STATE");
     if (state === 0) {
       killPacman();
     } else if (state === 1) {


### PR DESCRIPTION
Closes #7412

Replace unsafe new Function() constructor with a custom recursive-descent
math parser that strictly validates and evaluates only numeric expressions.