### PR TITLE
perf(#7417): prevent setInterval timer leak in recent projects cleanup

### DIFF
--- a/index.js
+++ b/index.js
@@ -696,8 +696,15 @@ function cleanupExpiredRecentProjects() {
   }
 }
 
-// Clean up every 5 minutes
-setInterval(cleanupExpiredRecentProjects, 5 * 60 * 1000);
+// Clean up every 5 minutes — clear previous interval to prevent timer leaks
+var recentProjectsTimer = null;
+function startRecentProjectsCleanup() {
+  if (recentProjectsTimer !== null) {
+    clearInterval(recentProjectsTimer);
+  }
+  recentProjectsTimer = setInterval(cleanupExpiredRecentProjects, 5 * 60 * 1000);
+}
+startRecentProjectsCleanup();
 
 const CATEGORY_LABEL = {
   beginner: "Beginner",


### PR DESCRIPTION
Closes #7417

Store setInterval ID and clear before re-creating to prevent
accumulating duplicate timers on re-initialization.