### PR TITLE
fix(#7414): sanitize project preview path in index.js to prevent traversal

### DIFF
--- a/index.js
+++ b/index.js
@@ -315,6 +315,11 @@ function sanitizeUrl(url) {
   return "#";
 }
 
+function sanitizeProjectPath(name) {
+  // Strip directory traversal and special characters for preview URL
+  return name.replace(/\s+/g, '_').replace(/\.\.\//g, '').replace(/[<>"|?*]/g, '');
+}
+
 function buildProjectCardHTML({
   day,
   name,
@@ -401,7 +406,7 @@ function buildProjectCardHTML({
             </div>
 
             <div class="card-preview-image-container" style="margin: 12px 0; border-radius: 8px; overflow: hidden; aspect-ratio: 16/9; background: #1a1a1a;">
-                <img src="./${url && url.startsWith('./') ? url.split('/')[2] : name.replace(/\s+/g, '_')}/preview.png" alt="${safeName} preview" onerror="this.parentNode.style.display='none';" style="width: 100%; height: 100%; object-fit: cover;">
+                <img src="./${url && url.startsWith('./') ? url.split('/')[2] : sanitizeProjectPath(name)}/preview.png" alt="${safeName} preview" onerror="this.parentNode.style.display='none';" style="width: 100%; height: 100%; object-fit: cover;">
             </div>
 
             <h3 class="card-name">${safeName}</h3>


### PR DESCRIPTION
Closes #7414

Add sanitizeProjectPath() helper to strip ../ sequences and special characters from the project preview image URL construction.