### PR TITLE
fix: resolve dark theme dropdown visibility for Tag and Color selects…

### DIFF
--- a/public/notes-app/style.css
+++ b/public/notes-app/style.css
@@ -1038,21 +1038,20 @@ button {
 .note-modal textarea,
 .note-modal select {
   width: 100%;
-
   border: 1px solid var(--line);
-
   border-radius: 18px;
-
   outline: 0;
-
-  background:
-    rgba(255, 255, 255, 0.04);
-
+  background: var(--panel-solid);
   color: var(--text);
-
   transition:
     border-color var(--transition),
     background var(--transition);
+}
+
+/* Fix: dropdown options inherit theme colors */
+.note-modal select option {
+  background: var(--panel-solid);
+  color: var(--text);
 }
 
 .note-modal input,


### PR DESCRIPTION
… in notes app

## 📝 Pull Request Description

### Related Issue
Closes #7503 

### Summary
In dark theme, the Tag and Color `<select>` dropdowns in the Notes App were rendering with an invisible/unreadable appearance — light-colored options on  a light background. This fix ensures dropdown options correctly inherit the dark theme colors.

### Type of Change
- [ X ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Changed `select` background from `rgba(255, 255, 255, 0.04)` (semi-transparent) to `var(--panel-solid)` — browsers cannot pass transparent backgrounds down to native `<option>` elements, causing OS default colors to override the theme
- Added `.note-modal select option` CSS rule explicitly setting dark background and light text color using existing CSS variables (`--panel-solid`, `--text`), ensuring both dark and light themes are covered automatically

---

## 🧪 Testing and Verification

### Local Validation
- [ X ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [ X ] Tested and verified in **Google Chrome**
- [ X ] Tested and verified in **Mozilla Firefox**
- [ X ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ X ] Verified responsive layout on Mobile viewports (using DevTools)
- [ X ] Verified responsive layout on Tablet viewports
- [ X ] Keyboard navigation and focus outlines checked
- [ X ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
Before

https://github.com/user-attachments/assets/10ca13ef-cca9-48fa-81c4-a45e06b1d58b

After

https://github.com/user-attachments/assets/50d279b0-329c-4c47-83cc-f6ed37de0a7c



---

## 🤝 Contributor Checklist
- [ X ] My code follows the code style guidelines of this project.
- [ X ] I have performed a self-review of my own code.
- [ X ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [ X ] My changes generate no new warnings or console errors.
- [ X ] There are no unrelated changes or formatter noise in this PR.
