### PR TITLE
Journal mobile responsiveness fix

### DIFF
--- a/public/Journal-Platform/index.html
+++ b/public/Journal-Platform/index.html
@@ -51,7 +51,7 @@
 
         <div class="mood-filter-container">
           <span class="filter-label">Filter by mood:</span>
-          <div class="mood-filter-badges">
+        <div class="mood-filter-badges mood-filters">
             <button class="mood-filter-badge active" data-mood="all">All</button>
             <button class="mood-filter-badge" data-mood="happy" title="Happy">🌟</button>
             <button class="mood-filter-badge" data-mood="calm" title="Calm">🍃</button>
@@ -153,7 +153,7 @@
             </div>
 
             <!-- Delete and Save Buttons -->
-            <div class="entry-actions">
+            <div class="entry-actions action-buttons">
               <button id="btn-delete-entry" class="btn-danger-outline" title="Delete Entry">
                 <i data-lucide="trash-2"></i>
               </button>
@@ -166,7 +166,7 @@
         </header>
 
         <!-- Markdown Formatting Helpers Toolbar -->
-        <div class="editor-toolbar">
+        <div class="editor-toolbar toolbar">
           <div class="toolbar-group">
             <button class="toolbar-btn" data-command="bold" title="Bold (**bold**)"><i data-lucide="bold"></i></button>
             <button class="toolbar-btn" data-command="italic" title="Italic (*italic*)"><i

--- a/public/Journal-Platform/style.css
+++ b/public/Journal-Platform/style.css
@@ -6,6 +6,23 @@
   font-family: 'Inter', sans-serif;
   -webkit-font-smoothing: antialiased;
 }
+html,
+body {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+button {
+  max-width: 100%;
+}
+
+.toolbar,
+.mood-filters,
+.action-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
 
 /* --- Theme Definitions --- */
 :root {
@@ -672,6 +689,7 @@ body.theme-vintage-library .btn-primary {
 
 .mood-selector {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
 }
 
@@ -1263,9 +1281,12 @@ body.theme-vintage-library .btn-primary {
   .sidebar {
     width: 100%;
     height: auto;
-    max-height: 40vh;
+    max-height: 45vh;
+    min-width: 0;
     border-right: none;
     border-bottom: 1px solid var(--border-color);
+    overflow-y: auto;
+    flex-shrink: 0;
   }
   
   .entries-list-container {
@@ -1287,8 +1308,140 @@ body.theme-vintage-library .btn-primary {
   .editor-toolbar {
     padding: 8px 20px;
   }
+
+  .toolbar-separator {
+    display: none;
+  }
+
+  .workspace-tabs {
+    margin-left: 0;
+    width: 100%;
+    justify-content: center;
+    margin-top: 4px;
+  }
+
+  .mood-filter-badges {
+    overflow-x: visible;
+  }
   
   .sticker-canvas {
     padding: 20px;
+  }
+
+  .workspace {
+    flex-direction: column;
+    height: auto;
+    flex-grow: 1;
+    min-height: 0;
+  }
+}
+
+/* @media (max-width: 480px) {
+
+  .header-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .mood-selector-wrapper,
+  .entry-actions {
+    width: 100%;
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .btn-success {
+    flex: 1;
+    min-width: 120px;
+  }
+  .editor-toolbar {
+    justify-content: center;
+  }
+
+  .workspace-tabs {
+    margin-left: 0;
+    width: 100%;
+    justify-content: center;
+    margin-top: 8px;
+  }
+  .entry-title-input {
+    font-size: 22px;
+  }
+  .sidebar {
+    max-height: 30vh;
+  }
+  .btn-primary,
+  .btn-success {
+    width: 100%;
+  }
+} */
+ @media (max-width: 480px) {
+  html,
+  body {
+    overflow-x: hidden;
+  }
+
+  .sidebar {
+    max-height: 35vh;
+  }
+
+  .sheet-header {
+    padding: 12px 16px;
+  }
+
+  .entry-title-input {
+    font-size: 22px;
+  }
+
+  .header-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .mood-selector-wrapper {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    width: 100%;
+  }
+
+  .mood-selector {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .entry-actions {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+
+  .btn-success {
+    flex: 1;
+  }
+
+  .editor-toolbar {
+    justify-content: center;
+    padding: 8px 12px;
+  }
+
+  .workspace-tabs {
+    width: 100%;
+    margin-left: 0;
+    justify-content: center;
+  }
+
+  .welcome-screen {
+    padding: 16px;
+  }
+
+  .welcome-card {
+    padding: 24px;
+  }
+
+  .modal-content {
+    width: 100%;
+    max-width: 400px;
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #7574

### Summary
Fixed mobile responsiveness issues in the Journly application to ensure a consistent and usable experience on smaller devices such as the iPhone SE (375×667). Updated layouts, spacing, and responsive behavior to prevent overflow, overlap, and viewport clipping.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature or UI/UX enhancement
- [x] ♻️ Code refactoring / clean-up

---

## 🛠️ Changes Made
Fixed horizontal overflow issues on small-screen devices.
Updated layout structure to adapt properly to narrow viewports.
Improved responsiveness of mood selector components.
Fixed toolbar controls overflowing their containers.
Adjusted action buttons to wrap or stack appropriately.
Improved spacing and alignment across journal editor sections.
Added responsive breakpoints for mobile devices.
Ensured all controls remain accessible without clipping.
Optimized component sizing for better usability on smaller screens.

---

## 🧪 Testing and Verification

### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [x] Tested and verified in **Mozilla Firefox**
- [x] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [x] Verified responsive layout on Mobile viewports (using DevTools)
- [x] Verified responsive layout on Tablet viewports
- [x] Keyboard navigation and focus outlines checked
- [x] Semantic HTML and ARIA labels checked
---

## 📷 Screenshots / Video Recording
<img width="1920" height="999" alt="Journly _ Private Digital Journal - Brave 09-06-2026 21_32_04" src="https://github.com/user-attachments/assets/b067756f-25dd-48f0-b70f-729e690e631e" />


---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
