### PR TITLE
feat: add edit alarm functionality

### DIFF
--- a/public/digital_clock/digitalclock.js
+++ b/public/digital_clock/digitalclock.js
@@ -7,6 +7,7 @@ let alarms = JSON.parse(localStorage.getItem('clock_alarms')) || [];
 let worldClocks = JSON.parse(localStorage.getItem('clock_worldClocks')) || [];
 let historyLogs = JSON.parse(localStorage.getItem('clock_historyLogs')) || [];
 
+let editingAlarmId = null;
 let ringingAlarm = null;
 let lastCheckedMinute = '';
 let ringInterval = null;
@@ -288,7 +289,29 @@ function addNewAlarm() {
     showToast('Please select a time');
     return;
   }
+if(editingAlarmId!=null)
+{
+  const alarm = alarms.find((a) => a.id === editingAlarmId);
+  if(alarm){
+    alarm.time = timeInput.value;
+    alarm.label = labelInput.value || 'Alarm';
+    alarm.snooze = parseInt(document.getElementById('alarm-snooze').value) ;
 
+  }
+  editingAlarmId=null;
+
+    document.getElementById('add-alarm-btn').textContent = 'Add Alarm';
+
+    timeInput.value = '';
+    labelInput.value = '';
+
+    saveAlarms();
+    renderAlarmsList();
+    updateAlarmSummary();
+
+    showToast('Alarm updated');
+    return;
+}
   const alarm = {
     id: Date.now(),
     time: timeInput.value,
@@ -806,6 +829,8 @@ function renderAlarmsList() {
             <input type="checkbox" ${alarm.enabled ? 'checked' : ''} onchange="toggleAlarmEnabled(${alarm.id}, this.checked)" />
             <span class="toggle-slider"></span>
           </label>
+
+          <button class='edit-btn' onclick="editingAlarm(${alarm.id})" title="Edit">✏️</button>
           <button class="remove-btn" onclick="deleteAlarm(${alarm.id})" title="Delete">&times;</button>
         </div>
       </div>
@@ -814,6 +839,16 @@ function renderAlarmsList() {
     .join('');
 }
 
+function editingAlarm(id){
+  const alarm=alarms.find((a)=>a.id===id);
+  if(!alarm) return;
+
+    document.getElementById("alarm-time").value = alarm.time;
+    document.getElementById("alarm-label").value = alarm.label;
+    document.getElementById("alarm-snooze").value = alarm.snooze;
+    editingAlarmId=id;
+    document.getElementById("add-alarm-btn").textContent="Save Changes";
+}
 function toggleAlarmEnabled(id, enabled) {
   const alarm = alarms.find((a) => a.id === id);
   if (alarm) {


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #7466 

### Summary

Implemented the **Edit Alarm** functionality in the Digital Clock project. Users can now modify an existing alarm's time, label, and snooze duration without deleting and recreating the alarm.

### Type of Change

* [x] 🚀 New feature or UI/UX enhancement

---

## 🛠️ Changes Made

* Added an Edit (✏️) button for each alarm entry.
* Implemented edit mode using `editingAlarmId`.
* Pre-filled the alarm form with existing alarm details when Edit is clicked.
* Updated alarm information instead of creating duplicate alarms.
* Dynamically changed the action button text between **Add Alarm** and **Save Changes**.
* Reset the form and edit state after a successful update.
* Preserved existing alarm functionality such as enable/disable, delete, and snooze options.

---

## 🧪 Testing and Verification

### Local Validation

* [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check

* [x] Tested and verified in **Google Chrome**
* [ ] Tested and verified in **Mozilla Firefox**
* [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks

* [x] Verified responsive layout on Mobile viewports (using DevTools)
* [ ] Verified responsive layout on Tablet viewports
* [x] Keyboard navigation and focus outlines checked
* [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording

### Before

* Users could only create, enable/disable, and delete alarms.
* Editing an existing alarm required deleting and recreating it.

### After

* Added an Edit button for each alarm.
* Users can modify alarm details directly from the form and save changes successfully.

(Attach screenshots or screen recording here)

https://github.com/user-attachments/assets/b495360c-92a7-4f00-9126-9d0ce41714e0


---

## 🤝 Contributor Checklist

* [x] My code follows the code style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] My changes generate no new warnings or console errors.
* [x] There are no unrelated changes or formatter noise in this PR.

