### PR TITLE
feat: Checks and avoids saving duplicate gradient

### DIFF
--- a/public/GradientPaletteGenerator/script.js
+++ b/public/GradientPaletteGenerator/script.js
@@ -312,24 +312,34 @@ const persistSaved = (gradients) => {
 /** Save the current gradient to favorites */
 const saveGradient = () => {
   const saved = loadSaved();
+  const css = buildGradientCSS();
+
+  const alreadyExists = saved.some(
+    (gradient) => gradient.css === css
+  );
+
+  if (alreadyExists) {
+    showToast('This gradient is already saved');
+    return;
+  }
+
   const gradient = {
     id: Date.now(),
     type: state.type,
     angle: state.angle,
     colors: [...state.colors],
-    css: buildGradientCSS(),
+    css,
   };
 
   saved.unshift(gradient);
 
-  // Limit to 20 saved gradients
   if (saved.length > 20) {
     saved.pop();
   }
 
   persistSaved(saved);
   renderSavedGrid();
-  showToast("Gradient saved! 💾");
+  showToast('Gradient saved! 💾');
 };
 
 /**


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #7644 
This PR prevents saving duplicate gradient palettes to save memory space in the local storage and avoid multiple same gradient palettes, showing in the saved gradients

### Summary
Checks if the same css of gradient palette exists earlier and stops saving it again to avoid duplication.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Changes the logic in the SaveGradient function
- Adds a check and shows a Toast notification if the gradient is already saved earlier

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
