### PR TITLE
Feat: Added the Confirm modal on Deleting a Saved Gradient

### DIFF
--- a/public/GradientPaletteGenerator/script.js
+++ b/public/GradientPaletteGenerator/script.js
@@ -338,9 +338,15 @@ const saveGradient = () => {
  */
 const deleteSaved = (id) => {
   const saved = loadSaved().filter((g) => g.id !== id);
-  persistSaved(saved);
-  renderSavedGrid();
-  showToast("Gradient deleted");
+  showConfirmModal({
+    title: 'Clear this gradient?',
+    message: `This will permanently delete this saved gradient.`,
+    onConfirm: () => {
+      persistSaved(saved);
+      renderSavedGrid();
+      showToast('Gradient deleted');
+    }
+  });
 };
 
 /** Clear all saved gradients */

--- a/public/GradientPaletteGenerator/script.js
+++ b/public/GradientPaletteGenerator/script.js
@@ -34,13 +34,12 @@ const dom = {
   copyClipboard: document.getElementById("copy-clipboard"),
 };
 
-
 const modal = {
-  root: document.getElementById('confirm-modal'),
-  title: document.getElementById('modal-title'),
-  message: document.getElementById('modal-message'),
-  cancel: document.getElementById('modal-cancel'),
-  confirm: document.getElementById('modal-confirm'),
+  root: document.getElementById("confirm-modal"),
+  title: document.getElementById("modal-title"),
+  message: document.getElementById("modal-message"),
+  cancel: document.getElementById("modal-cancel"),
+  confirm: document.getElementById("modal-confirm"),
 };
 
 // ===== Utility Functions =====
@@ -339,13 +338,13 @@ const saveGradient = () => {
 const deleteSaved = (id) => {
   const saved = loadSaved().filter((g) => g.id !== id);
   showConfirmModal({
-    title: 'Clear this gradient?',
+    title: "Clear this gradient?",
     message: `This will permanently delete this saved gradient.`,
     onConfirm: () => {
       persistSaved(saved);
       renderSavedGrid();
-      showToast('Gradient deleted');
-    }
+      showToast("Gradient deleted");
+    },
   });
 };
 
@@ -354,18 +353,18 @@ const clearAllSaved = () => {
   const saved = loadSaved();
 
   if (saved.length === 0) {
-    showToast('Nothing to clear');
+    showToast("Nothing to clear");
     return;
   }
 
   showConfirmModal({
-    title: 'Clear all gradients?',
+    title: "Clear all gradients?",
     message: `This will permanently delete ${saved.length} saved gradients.`,
     onConfirm: () => {
       persistSaved([]);
       renderSavedGrid();
-      showToast('All gradients cleared');
-    }
+      showToast("All gradients cleared");
+    },
   });
 };
 
@@ -439,17 +438,17 @@ const renderSavedGrid = () => {
 };
 
 const showConfirmModal = ({ title, message, onConfirm }) => {
-  modal.title.textContent = title || 'Confirm Action';
-  modal.message.textContent = message || '';
+  modal.title.textContent = title || "Confirm Action";
+  modal.message.textContent = message || "";
 
-  modal.root.classList.remove('hidden');
+  modal.root.classList.remove("hidden");
 
   const closeModal = () => {
-    modal.root.classList.add('hidden');
-    modal.confirm.removeEventListener('click', handleConfirm);
-    modal.cancel.removeEventListener('click', closeModal);
-    modal.overlay.removeEventListener('click', closeModal);
-    document.removeEventListener('keydown', handleEsc);
+    modal.root.classList.add("hidden");
+    modal.confirm.removeEventListener("click", handleConfirm);
+    modal.cancel.removeEventListener("click", closeModal);
+    modal.overlay.removeEventListener("click", closeModal);
+    document.removeEventListener("keydown", handleEsc);
   };
 
   const handleConfirm = () => {
@@ -458,18 +457,17 @@ const showConfirmModal = ({ title, message, onConfirm }) => {
   };
 
   const handleEsc = (e) => {
-    if (e.code === 'Escape') closeModal();
+    if (e.code === "Escape") closeModal();
   };
 
   // IMPORTANT: cache overlay once (add this in DOM refs)
-  modal.overlay = modal.root.querySelector('.modal__overlay');
+  modal.overlay = modal.root.querySelector(".modal__overlay");
 
-  modal.confirm.addEventListener('click', handleConfirm);
-  modal.cancel.addEventListener('click', closeModal);
-  modal.overlay.addEventListener('click', closeModal);
-  document.addEventListener('keydown', handleEsc);
+  modal.confirm.addEventListener("click", handleConfirm);
+  modal.cancel.addEventListener("click", closeModal);
+  modal.overlay.addEventListener("click", closeModal);
+  document.addEventListener("keydown", handleEsc);
 };
-
 
 // ===== Event Listeners =====
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #7642 
This PR adds a Confirm modal after the delete button is clicked on a particular saved gradient. It is used to confirm if the user wants to actually delete it permanently before proceeding.

### Summary
Adds a confirm/delete modal before deleting a specific saved color gradient palette.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added the onConfirm function for a specific saved gradient to the deleteSaved function
- Shows the Modal and reuses the modal used in Clear All function

---

## 📷 Screenshots / Video Recording
<img width="1179" height="447" alt="Screenshot 2026-06-10 160335" src="https://github.com/user-attachments/assets/2ac85fbe-cd74-4354-9f94-dc52de2626a6" />


---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
