### PR TITLE
Fix GitHub projectPath repository validation

### DIFF
--- a/scripts/validate-metadata.js
+++ b/scripts/validate-metadata.js
@@ -12,7 +12,7 @@ const VALID_DIFFICULTIES = new Set(['beginner', 'intermediate', 'advanced']);
 const REQUIRED_KEYS = ['projectNo', 'projectName', 'techStack', 'difficulty', 'projectPath'];
 const UNSAFE_PROTOCOL_RE = /^(?:javascript|data|vbscript):/i;
 const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
-const EXPECTED_GITHUB_TREE_PREFIX = '/dhairyagothi/100_days_100_web_project/tree/';
+const EXPECTED_GITHUB_REPOSITORY = 'dhairyagothi/100_days_100_web_project';
 
 function formatProjectLabel(index, project = {}) {
   const day = project.projectNo || 'Unknown';
@@ -26,6 +26,20 @@ function addFieldError(errors, index, project, fieldName, message) {
 
 function isExternalHttpUrl(value) {
   return /^https?:\/\//i.test(value);
+}
+
+function isGitHubUrl(parsedUrl) {
+  const hostname = parsedUrl.hostname.toLowerCase();
+  return hostname === 'github.com' || hostname === 'www.github.com';
+}
+
+function getGitHubRepository(pathname) {
+  const [owner, repo] = pathname
+    .split('/')
+    .filter(Boolean)
+    .map(segment => segment.toLowerCase());
+
+  return owner && repo ? `${owner}/${repo}` : null;
 }
 
 function hasPathTraversal(value) {
@@ -55,12 +69,8 @@ function validateExternalUrl(projectPath, index, project, errors) {
     return;
   }
 
-  if (
-    parsedUrl.hostname.toLowerCase() === 'github.com' &&
-    parsedUrl.pathname.includes('/tree/') &&
-    !parsedUrl.pathname.startsWith(EXPECTED_GITHUB_TREE_PREFIX)
-  ) {
-    addFieldError(errors, index, project, 'projectPath', 'GitHub tree URLs must point to this repository');
+  if (isGitHubUrl(parsedUrl) && getGitHubRepository(parsedUrl.pathname) !== EXPECTED_GITHUB_REPOSITORY) {
+    addFieldError(errors, index, project, 'projectPath', 'GitHub URLs must point to this repository');
   }
 }
 

--- a/scripts/validate-projects-fixture.js
+++ b/scripts/validate-projects-fixture.js
@@ -19,6 +19,20 @@ fs.writeFileSync(validRegistryPath, JSON.stringify([
     techStack: ['html', 'css'],
     difficulty: 'beginner',
     projectPath: './public/valid-project/index.html'
+  },
+  {
+    projectNo: 2,
+    projectName: 'Valid Same Repository Blob URL',
+    techStack: ['html'],
+    difficulty: 'intermediate',
+    projectPath: 'https://github.com/dhairyagothi/100_days_100_web_project/blob/Main/index.html'
+  },
+  {
+    projectNo: 3,
+    projectName: 'Valid Same Repository Tree URL',
+    techStack: ['html'],
+    difficulty: 'advanced',
+    projectPath: 'https://github.com/dhairyagothi/100_days_100_web_project/tree/Main/public'
   }
 ], null, 2));
 
@@ -50,6 +64,20 @@ fs.writeFileSync(invalidRegistryPath, JSON.stringify([
     techStack: ['css'],
     difficulty: 'intermediate',
     projectPath: './public/missing/index.html'
+  },
+  {
+    projectNo: 5,
+    projectName: 'External GitHub Blob URL',
+    techStack: ['html'],
+    difficulty: 'advanced',
+    projectPath: 'https://github.com/octocat/Hello-World/blob/master/README'
+  },
+  {
+    projectNo: 6,
+    projectName: 'External GitHub Tree URL',
+    techStack: ['html'],
+    difficulty: 'advanced',
+    projectPath: 'https://github.com/octocat/Hello-World/tree/master'
   }
 ], null, 2));
 
@@ -75,7 +103,9 @@ const expectedMessages = [
   'must be one of: beginner, intermediate, advanced',
   'uses an unsafe URL protocol',
   'must not contain path traversal',
-  'local path "./public/missing/index.html" does not exist in the repository'
+  'local path "./public/missing/index.html" does not exist in the repository',
+  'Index 4 (Day 5 - External GitHub Blob URL): "projectPath" GitHub URLs must point to this repository',
+  'Index 5 (Day 6 - External GitHub Tree URL): "projectPath" GitHub URLs must point to this repository'
 ];
 
 if (invalidResult.status === 0) {


### PR DESCRIPTION
## Description

Closes #7569.

This PR tightens project registry validation for GitHub `projectPath` values. Previously, the validator only rejected off-repository GitHub URLs when the URL contained `/tree/`, so an external `/blob/` URL such as `https://github.com/octocat/Hello-World/blob/master/README` could pass validation.

## Changes Made

- Parse GitHub URLs by owner/repository instead of checking only for `/tree/`.
- Reject any `github.com` or `www.github.com` project URL that does not point to `dhairyagothi/100_days_100_web_project`.
- Keep same-repository GitHub `/blob/` and `/tree/` URLs valid.
- Add fixture coverage for valid same-repo GitHub URLs and invalid off-repo `/blob/` and `/tree/` URLs.

## Validation

- `npm run validate:projects-fixture`
- Targeted local checks confirmed:
  - same-repo GitHub blob/tree URLs pass
  - off-repo GitHub blob/tree URLs fail
  - non-GitHub external HTTP URLs keep existing behavior

## Note

This branch also contains the existing project registry validation restoration commit that the validator fix builds on.