### PR TITLE
feat(learning): add learning streak tracker and improve dashboard layout

### DIFF
--- a/learning/learning.css
+++ b/learning/learning.css
@@ -264,46 +264,27 @@ body.light-mode .topic-item.active a {
 
 .progress-stats-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
-
-  margin-bottom: 1.5rem;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 12px;
+  margin-bottom: 1rem;
 }
-
 .progress-stat-card {
-  background: var(--bg-elevated);
-
+  padding: 0.9rem 0.75rem;
+  border-radius: var(--radius-md);
   border: 1px solid var(--border);
-
-  border-radius: var(--radius-lg);
-
-  padding: 1rem;
-
+  background: var(--bg-elevated);
   text-align: center;
+  min-height: 85px;
 
-  transition: var(--t);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 .progress-stat-card:hover {
   transform: translateY(-2px);
 
   border-color: var(--border-accent);
-}
-
-.stat-label {
-  display: block;
-
-  color: var(--text-muted);
-
-  font-size: 0.8rem;
-
-  margin-bottom: 0.5rem;
-}
-
-.progress-stat-card strong {
-  font-size: 1.4rem;
-
-  color: var(--accent);
 }
 
 /* ============================================================
@@ -1293,50 +1274,20 @@ body.light-mode .vector-flowchart {
   margin-bottom: 2rem;
 }
 
-.progress-stats-grid {
-  display: grid;
-
-  grid-template-columns: repeat(3, 1fr);
-
-  gap: 1rem;
-
-  margin-bottom: 1rem;
-}
-
-.progress-stat-card {
-  background: var(--bg-elevated);
-
-  border: 1px solid var(--border);
-
-  border-radius: var(--radius-lg);
-
-  padding: 1rem;
-
-  text-align: center;
-
-  transition: var(--t);
-}
 
 .progress-stat-card:hover {
   transform: translateY(-2px);
 
   border-color: var(--accent);
 }
-
 .stat-label {
-  display: block;
-
-  font-size: 0.8rem;
-
-  color: var(--text-muted);
-
-  margin-bottom: 0.4rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
 }
-
 .progress-stat-card strong {
   font-size: 1.4rem;
-
-  color: var(--accent);
+  font-weight: 700;
 }
 
 .continue-learning-btn {
@@ -1620,4 +1571,24 @@ body.light-mode .vector-flowchart {
 
 .recommended-topic-btn:hover {
   opacity: .9;
+}
+
+.streak-card {
+  border: 1px solid rgba(255,140,0,.25);
+}
+
+.streak-card strong {
+  color: #f97316;
+}
+
+@media (max-width: 768px) {
+  .progress-stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .progress-stats-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/learning/learning.html
+++ b/learning/learning.html
@@ -145,6 +145,11 @@
               <span class="stat-label">Progress</span>
               <strong id="progressPercentageCard">0%</strong>
             </div>
+            <div class="progress-stat-card streak-card">
+              <span class="stat-label"> 🔥 Streak </span>
+
+              <strong id="currentStreakCount"> 0 </strong>
+            </div>
           </div>
 
           <button id="continueLearningBtn" class="continue-learning-btn">

--- a/learning/learning.js
+++ b/learning/learning.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', async () => {
   let quizData = {};
   const STORAGE_KEY = 'learningProgress';
   const BOOKMARKS_KEY = 'learningBookmarks';
+  const STREAK_KEY = 'learningStreak';
 
   let bookmarks = [];
 
@@ -226,6 +227,74 @@ function toggleBookmark(topic) {
   function saveProgress() {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(learningProgress));
   }
+  function updateLearningStreak() {
+
+  const today =
+    new Date()
+      .toISOString()
+      .split('T')[0];
+
+  let streak =
+    JSON.parse(
+      localStorage.getItem(
+        STREAK_KEY
+      )
+    ) || {
+      current: 0,
+      best: 0,
+      lastVisit: null
+    };
+
+  if (streak.lastVisit === today) {
+    return streak;
+  }
+
+  const yesterday =
+    new Date(
+      Date.now() -
+      86400000
+    )
+      .toISOString()
+      .split('T')[0];
+
+  if (
+    streak.lastVisit === yesterday
+  ) {
+    streak.current++;
+  } else {
+    streak.current = 1;
+  }
+
+  streak.best = Math.max(
+    streak.best,
+    streak.current
+  );
+
+  streak.lastVisit = today;
+
+  localStorage.setItem(
+    STREAK_KEY,
+    JSON.stringify(streak)
+  );
+
+  return streak;
+}
+
+function renderStreak() {
+
+  const streak =
+    updateLearningStreak();
+
+  const current =
+    document.getElementById(
+      'currentStreakCount'
+    );
+
+  if (current) {
+    current.textContent =
+      streak.current;
+  }
+}
 
   function markTopicCompleted(topicId) {
     if (!learningProgress.completedTopics.includes(topicId)) {
@@ -1325,6 +1394,7 @@ list.appendChild(item);
   }
 
 loadProgress();
+renderStreak();
 
 loadBookmarks();
 


### PR DESCRIPTION
## 🚀 Description

Issue : #6087 

This PR enhances the Learning Dashboard by introducing a Learning Streak Tracker and improving the dashboard statistics layout.

### ✨ Features Added

#### 🔥 Learning Streak Tracker
- Tracks consecutive learning days using localStorage
- Displays current streak directly on the dashboard
- Automatically updates when users revisit and continue learning
- Encourages consistent learning habits

#### 🎨 Dashboard UI Improvements
- Optimized statistics card sizing
- Aligned all dashboard metrics in a single row
- Improved spacing and responsiveness
- Better visual hierarchy for learning progress data

### 📈 Dashboard Metrics
The dashboard now displays:

- Completed Topics
- Total Topics
- Progress Percentage
- Learning Streak

### 🛠 Technical Details
- Uses browser localStorage for streak persistence
- Responsive grid layout for desktop and mobile devices
- Maintains compatibility with existing progress tracking functionality

### 📸 Screenshots

(Add screenshots here)

### ✅ Checklist

- [x] Tested locally
- [x] Responsive design maintained
- [x] No console errors
- [x] Existing functionality unaffected
- [x] Follows project coding standards