### PR TITLE
feat: add empty state for search and favorites

### DIFF
--- a/public/pageloader/pageloader.js
+++ b/public/pageloader/pageloader.js
@@ -347,7 +347,17 @@ function renderLoaders() {
       loader.type === currentFilter;
     return matchesSearch && matchesFilter;
   });
-
+  if(filteredLoaders.length==0){
+    if(currentFilter==="favorites" && favorites.length===0)
+    {
+      grid.innerHTML='<p> ❤️ No favorite loaders yet </p>'
+    }
+    else 
+    {
+      grid.innerHTML='<p> 🔍 No loaders found matching your search or filter </p>'
+    }
+    return;
+  }
   grid.innerHTML = filteredLoaders
     .map(
       (loader) => `


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #7658 

### Summary

Added an empty state for the Pageloader Gallery search functionality. Previously, when a search query or filter returned no matching loaders, the gallery became empty without any feedback. This update provides clear messages to improve user experience and reduce confusion.

### Type of Change

* [x] 🚀 New feature or UI/UX enhancement

---

## 🛠️ Changes Made

* Added a "No loaders found matching your search or filter" message when no loaders match the current search/filter criteria.
* Added a dedicated "No favorite loaders yet" message when the Favorites tab is selected and no favorite loaders exist.
* Prevented the gallery from appearing blank when no results are available.

---

## 🧪 Testing and Verification

### Local Validation

* [x] Tested locally and verified functionality.

### Browser Compatibility Check

* [x] Tested and verified in Google Chrome

### Responsive & Accessibility Checks

* [x] Verified responsive layout on Mobile viewports (using DevTools)
* [x] Verified responsive layout on Tablet viewports

---

## 📷 Screenshots / Video Recording

### Before

* Gallery became completely empty when no loaders matched the search query.

### After

* User-friendly empty state messages are displayed for both search results and favorites.

---


https://github.com/user-attachments/assets/c6d487a2-099f-408c-b360-9f214ca8161e


## 🤝 Contributor Checklist

* [x] My code follows the code style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] My changes generate no new warnings or console errors.
* [x] There are no unrelated changes or formatter noise in this PR.
