### PR TITLE
fix(zomato-clone): correct foodmodel import casing so server starts on Linux

### DIFF
--- a/public/zomato-clone/server/controllers/foodController.js
+++ b/public/zomato-clone/server/controllers/foodController.js
@@ -1,4 +1,4 @@
-const Food = require("../models/foodModel");
+const Food = require("../models/foodmodel");
 
 exports.createFood = async (req, res) => {
   const data = await Food.create(req.body);


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #7848

### Summary
`controllers/foodController.js` imported the model as `../models/foodModel`, but the tracked file is `models/foodmodel.js` (lowercase). On case-sensitive filesystems (Linux deploys, CI) this throws `Cannot find module`, crashing the server at startup and taking down the whole food CRUD API. This corrects the import casing to match the file.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `server/controllers/foodController.js`: `require("../models/foodModel")` to `require("../models/foodmodel")` so it matches the actual tracked filename on every platform.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change and does not touch this project.

What I did verify:
- `node --check server/controllers/foodController.js` passes.
- The import now matches the tracked filename exactly: `git ls-files` shows `models/foodmodel.js`, and the require is `../models/foodmodel`.
- All other relative requires in the server already match their file casing (checked `server.js`, `routes/foodRoutes.js`).

### Browser Compatibility Check
- N/A: server-side change, no browser-facing markup.

### Responsive & Accessibility Checks
- N/A: no UI changes.

---

## 📷 Screenshots / Video Recording
N/A. No visual changes.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
