### PR TITLE
fix(netflix-clone): move Back-to-Home button so it no longer hides the Netflix logo (#7761)

### DIFF
--- a/public/Netflix_Cloning/Index.html
+++ b/public/Netflix_Cloning/Index.html
@@ -38,7 +38,7 @@
     <a
       href="/"
       class="project-back-button"
-      style="position:fixed;left:18px;top:18px;padding:8px 16px;border-radius:8px;background:#1e293b;color:#3b82f6;border:1px solid #3b82f6;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;transition:all 0.2s ease;" onmouseover="this.style.background='#3b82f6';this.style.color='#fff'" onmouseout="this.style.background='#1e293b';this.style.color='#3b82f6'"
+      style="position:fixed;left:18px;bottom:18px;padding:8px 16px;border-radius:8px;background:#1e293b;color:#3b82f6;border:1px solid #3b82f6;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;transition:all 0.2s ease;" onmouseover="this.style.background='#3b82f6';this.style.color='#fff'" onmouseout="this.style.background='#1e293b';this.style.color='#3b82f6'"
       >Back to Home</a
     >
 


### PR DESCRIPTION
## Description
On the Netflix Clone (`public/Netflix_Cloning/Index.html`), the fixed **Back to Home** button was positioned at the top-left (`top:18px; left:18px; z-index:9999`) — directly on top of the navbar's Netflix logo, hiding it completely (see screenshot in the issue).

**Fix:** moved the button to the **bottom-left** (`top:18px` → `bottom:18px`). The Netflix logo is now fully visible in the top-left, and the button no longer overlaps the navbar.

## Related Issue
Fixes #7761

## Type of change
- [x] Bug fix (non-breaking)