### PR TITLE
Fix keyboard focus styling for navigation links

### DIFF
--- a/public/Blog Page/style.css
+++ b/public/Blog Page/style.css
@@ -57,6 +57,14 @@ body{
 .nav-links a:hover::after{
     width:100%;
 }
+.nav-links a:focus-visible::after {
+    width: 100%;
+}
+
+.nav-links a:focus-visible {
+    outline: 2px solid #22c55e;
+    outline-offset: 4px;
+}
 
 .nav-right{
     display: flex;


### PR DESCRIPTION
Description

This PR improves keyboard accessibility for navigation links by adding visible focus styles for users navigating with the keyboard.
Changes Made

Added :focus-visible styling for navigation links.
Added a visible outline to indicate keyboard focus.
Matched focus behavior with existing hover effects.
Improved accessibility and user experience for keyboard users.
Testing
Navigated through links using the Tab key.
Verified that focused links display a visible outline.
Confirmed existing hover effects continue to work correctly. 