### PR TITLE
Fix broken favicon link in Love-Calculator (double .png extension)

### DIFF
--- a/public/Love-Calculator/index.html
+++ b/public/Love-Calculator/index.html
@@ -10,7 +10,7 @@
     <!-- Link to external CSS -->
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
-    <link rel="icon" href="favv.png.png"  />
+    <link rel="icon" href="favv.png"  />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
 </head>
 


### PR DESCRIPTION
Fixes #7911

Changed `favv.png.png` to `favv.png` in the favicon link tag.