### PR TITLE
Remove duplicate DOCTYPE declaration in Candy_Crush_Game

### DIFF
--- a/public/Candy_Crush_Game/index.html
+++ b/public/Candy_Crush_Game/index.html
@@ -1,6 +1,4 @@
 <!DOCTYPE html>
-
-<!DOCTYPE html>
 <html lang="en">
     <head>
         <meta charset="UTF-8">


### PR DESCRIPTION
Fixes #7921

Removed the duplicate `<!DOCTYPE html>` on line 3 (it was preceded by a blank line after the first valid declaration).