### PR TITLE
Remove duplicate DOCTYPE declaration in Virtual_Piano

### DIFF
--- a/public/Virtual_Piano/index.html
+++ b/public/Virtual_Piano/index.html
@@ -1,6 +1,4 @@
 <!DOCTYPE html>
-
-<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">


### PR DESCRIPTION
Fixes #7925

Removed the duplicate `<!DOCTYPE html>` on line 3 (same pattern as Candy_Crush_Game fix #7922).