### PR TITLE
Remove duplicate 'Back to Home' button in Stock-Profit-Calculator

### DIFF
--- a/public/Stock-Profit-Calculator/index.html
+++ b/public/Stock-Profit-Calculator/index.html
@@ -11,8 +11,6 @@
 
     <!-- Dark Mode Toggle -->
     <button id="darkModeToggle" class="dark-mode-toggle" aria-label="Toggle Dark Mode">🌙</button>
-<a href="/" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 12px;border-radius:8px;background:white;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;box-shadow:0 8px 20px rgba(0, 0, 0);">← Back to Home</a>
-
 <a href="/" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 16px;border-radius:8px;background:#1e293b;color:#3b82f6;border:1px solid #3b82f6;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;transition:all 0.2s ease;" onmouseover="this.style.background='#3b82f6';this.style.color='#fff'" onmouseout="this.style.background='#1e293b';this.style.color='#3b82f6'">← Back to Home</a>
 
 


### PR DESCRIPTION
Fixes #7927

Removed duplicate `Back to Home` button (line 14) that overlapped the properly styled version on line 16.