### PR TITLE
Add missing alt attributes to images in zomato-clone

### DIFF
--- a/public/zomato-clone/public/index.html
+++ b/public/zomato-clone/public/index.html
@@ -332,7 +332,7 @@
 <!-- NIGHTLIFE -->
 <section style="padding:32px 5%;">
   <div class="option-card">
-    <img src="https://b.zmtcdn.com/webFrontend/d9d80ef91cb552e3fdfadb3d4f4379761647365057.jpeg?output-format=webp&fit=around|402:360&crop=402:360;*,*" />
+    <img src="https://b.zmtcdn.com/webFrontend/d9d80ef91cb552e3fdfadb3d4f4379761647365057.jpeg?output-format=webp&fit=around|402:360&crop=402:360;*,*" alt="Nightlife and Clubs" />
     <div class="info">
       <div class="title">Nightlife and Clubs</div>
       <div class="description">Explore the city's top nightlife outlets</div>
@@ -373,19 +373,19 @@
   </div>
   <div class="collections-grid">
     <div class="coll-card">
-      <img src="https://b.zmtcdn.com/data/collections/77c1b9704985885cbe2cb094e9983eab_1682080540.jpg?output-format=webp" />
+      <img src="https://b.zmtcdn.com/data/collections/77c1b9704985885cbe2cb094e9983eab_1682080540.jpg?output-format=webp" alt="Winners of Zomato Restaurant Awards" />
       <div class="coll-overlay"><div class="coll-title">Winners of Zomato Restaurant Awards</div><div class="coll-places">32 Places ›</div></div>
     </div>
     <div class="coll-card">
-      <img src="https://b.zmtcdn.com/data/collections/16e3a8b363d4592a72b2c4f486c63fb8_1678096853.jpg?output-format=webp" />
+      <img src="https://b.zmtcdn.com/data/collections/16e3a8b363d4592a72b2c4f486c63fb8_1678096853.jpg?output-format=webp" alt="22 Best Insta-worthy Places" />
       <div class="coll-overlay"><div class="coll-title">22 Best Insta-worthy Places</div><div class="coll-places">22 Places ›</div></div>
     </div>
     <div class="coll-card">
-      <img src="https://b.zmtcdn.com/data/collections/8dd5adbf91d78c8d11796c6b230539ef_1674568824.jpg?output-format=webp" />
+      <img src="https://b.zmtcdn.com/data/collections/8dd5adbf91d78c8d11796c6b230539ef_1674568824.jpg?output-format=webp" alt="21 Romantic Dining Places" />
       <div class="coll-overlay"><div class="coll-title">21 Romantic Dining Places</div><div class="coll-places">21 Places ›</div></div>
     </div>
     <div class="coll-card">
-      <img src="https://b.zmtcdn.com/data/collections/a1bafc59f9aa67998b9f8de61b9abbd4_1680160970.png?output-format=webp" />
+      <img src="https://b.zmtcdn.com/data/collections/a1bafc59f9aa67998b9f8de61b9abbd4_1680160970.png?output-format=webp" alt="18 Thrilling Live Cricket Screenings" />
       <div class="coll-overlay"><div class="coll-title">18 Thrilling Live Cricket Screenings</div><div class="coll-places">18 Places ›</div></div>
     </div>
   </div>
@@ -496,8 +496,8 @@
     </div>
     <div class="footer-col">
       <h4>Download App</h4>
-      <img src="https://b.zmtcdn.com/data/webuikit/23e930757c3df49840c482a8638bf5c31556001144.png" style="height:36px;border-radius:6px;margin-bottom:10px;display:block" />
-      <img src="https://b.zmtcdn.com/data/webuikit/9f0c85a5e33adb783fa0aef667075f9e1556003622.png" style="height:36px;border-radius:6px;display:block" />
+      <img src="https://b.zmtcdn.com/data/webuikit/23e930757c3df49840c482a8638bf5c31556001144.png" style="height:36px;border-radius:6px;margin-bottom:10px;display:block" alt="Download on App Store" />
+      <img src="https://b.zmtcdn.com/data/webuikit/9f0c85a5e33adb783fa0aef667075f9e1556003622.png" style="height:36px;border-radius:6px;display:block" alt="Get it on Google Play" />
     </div>
   </div>
   <div class="footer-bottom">


### PR DESCRIPTION
Fixes #7929

Added descriptive `alt` attributes to 7 `<img>` tags that were missing them: Nightlife section, 4 collection cards, and 2 app store download buttons.