### PR TITLE
Fix typos in Textutils meta description

### DIFF
--- a/public/Textutils/public/index.html
+++ b/public/Textutils/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="TextUtils is a utility which can be used to maipulate your text in teh way you want. "
+      content="TextUtils is a utility which can be used to manipulate your text in the way you want. "
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon-16x16.png" />
   


### PR DESCRIPTION
Fixes #7933

Fixed 'teh' ? 'the' and 'maipulate' ? 'manipulate' in meta description.

GSSoC26 contribution