### PR TITLE
Add role button and tabindex to color boxes in Color-Pelette

### DIFF
--- a/public/Color-Pelette/index.html
+++ b/public/Color-Pelette/index.html
@@ -17,11 +17,11 @@
 <body>
 
 <div class="palette" id="palette">
-    <div class="color-box" onclick="copyToClipboard(0)"> <div class="hex-code" id="hex0">#FFFFFF</div> </div>
-    <div class="color-box" onclick="copyToClipboard(1)"> <div class="hex-code" id="hex1">#FFFFFF</div> </div>
-    <div class="color-box" onclick="copyToClipboard(2)"> <div class="hex-code" id="hex2">#FFFFFF</div> </div>
-    <div class="color-box" onclick="copyToClipboard(3)"> <div class="hex-code" id="hex3">#FFFFFF</div> </div>
-    <div class="color-box" onclick="copyToClipboard(4)"> <div class="hex-code" id="hex4">#FFFFFF</div> </div>
+    <div class="color-box" role="button" tabindex="0" onclick="copyToClipboard(0)"> <div class="hex-code" id="hex0">#FFFFFF</div> </div>
+    <div class="color-box" role="button" tabindex="0" onclick="copyToClipboard(1)"> <div class="hex-code" id="hex1">#FFFFFF</div> </div>
+    <div class="color-box" role="button" tabindex="0" onclick="copyToClipboard(2)"> <div class="hex-code" id="hex2">#FFFFFF</div> </div>
+    <div class="color-box" role="button" tabindex="0" onclick="copyToClipboard(3)"> <div class="hex-code" id="hex3">#FFFFFF</div> </div>
+    <div class="color-box" role="button" tabindex="0" onclick="copyToClipboard(4)"> <div class="hex-code" id="hex4">#FFFFFF</div> </div>
 </div>
 
 <div class="controls">


### PR DESCRIPTION
Fixes #7935

Added `role="button"` and `tabindex="0"` to 5 clickable color box divs for keyboard accessibility.

GSSoC26 contribution