### PR TITLE
fix(voting-application-backend): prevent role mass-assignment on signup

### DIFF
--- a/public/Voting_Application_Backend/server/.env.example
+++ b/public/Voting_Application_Backend/server/.env.example
@@ -1,0 +1,11 @@
+# MongoDB connection string used by the server
+MONGODB_URL_LOCAL=mongodb://localhost:27017/voting_app
+
+# Secret used to sign and verify JWT auth tokens
+JWT_SECRET=
+
+# Port the server listens on
+PORT=3000
+
+# Key to bootstrap the first admin via /user/signup (send as setupKey in the body)
+ADMIN_SETUP_KEY=

--- a/public/Voting_Application_Backend/server/routes/userRoutes.js
+++ b/public/Voting_Application_Backend/server/routes/userRoutes.js
@@ -16,25 +16,30 @@ const authLimiter = rateLimit({
 //POST route to add a person
 router.post('/signup', authLimiter, async(req, res)=>{
     try{
-        const data = req.body
-        const adminUser = await User.findOne({ role: 'admin' });
-        if (data.role === 'admin' && adminUser) {
-            return res.status(400).json({ error: 'Admin user already exists' });
-        }
+        const { name, age, email, mobile, address, aadharCardNumber, password, setupKey } = req.body;
 
         // Validate Aadhar Card Number must have exactly 12 digit
-        if (!/^\d{12}$/.test(data.aadharCardNumber)) {
+        if (!/^\d{12}$/.test(aadharCardNumber)) {
             return res.status(400).json({ error: 'Aadhar Card Number must be exactly 12 digits' });
         }
 
         // Check if a user with the same Aadhar Card Number already exists
-        const existingUser = await User.findOne({ aadharCardNumber: data.aadharCardNumber });
+        const existingUser = await User.findOne({ aadharCardNumber: aadharCardNumber });
         if (existingUser) {
             return res.status(400).json({ error: 'User with the same Aadhar Card Number already exists' });
         }
 
+        // Whitelist fields so role cannot be set from the request body
+        const userData = { name, age, email, mobile, address, aadharCardNumber, password };
+
+        // Allow the first admin only via the server-side ADMIN_SETUP_KEY; otherwise role defaults to voter
+        const adminExists = await User.findOne({ role: 'admin' });
+        if (!adminExists && process.env.ADMIN_SETUP_KEY && setupKey === process.env.ADMIN_SETUP_KEY) {
+            userData.role = 'admin';
+        }
+
         //Create a new User documnet using the Mongoose model
-        const newUser = new User(data);
+        const newUser = new User(userData);
 
         //Save the new user to the database
         const response = await newUser.save();


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #7828

### Summary
The Voting Application Backend built the signup user document straight from `req.body`, so a client could set `role: 'admin'`. On a fresh database the first such request became the election administrator. This PR whitelists the fields accepted from signup so `role` can no longer be set by the client, and keeps a secure way to bootstrap the first admin.

Note on admin bootstrap: public signups are now always created as `voter`. The first admin can be created only when no admin exists yet and the request includes `setupKey` matching the server-side `ADMIN_SETUP_KEY` environment variable. Existing deployments that relied on open admin signup must set `ADMIN_SETUP_KEY`.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `server/routes/userRoutes.js`: destructure and whitelist signup fields (`name`, `age`, `email`, `mobile`, `address`, `aadharCardNumber`, `password`) so `role` cannot be mass-assigned from the body; `role` now defaults to `voter` via the schema.
- `server/routes/userRoutes.js`: the first admin can be created only when no admin exists and the request `setupKey` matches the server-side `ADMIN_SETUP_KEY`.
- Added `server/.env.example` documenting `MONGODB_URL_LOCAL`, `JWT_SECRET`, `PORT`, and `ADMIN_SETUP_KEY`.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change and currently depends on a fixture/schema setup at the repo root. This PR only touches the Voting Application Backend sub-project and does not change `projects.json`.

What I did verify:
- `node --check server/routes/userRoutes.js` passes (syntax valid).
- Confirmed `role` is no longer read from the request body, and `new User(...)` is built only from the whitelisted fields.
- A full runtime test requires a MongoDB instance and the sub-project dependencies.

### Browser Compatibility Check
- N/A: server-side change, no browser-facing markup.

### Responsive & Accessibility Checks
- N/A: no UI changes.

---

## 📷 Screenshots / Video Recording
N/A. No visual changes.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
