### PR TITLE
fix(flask_auth_app): disable Flask debug mode by default

### DIFF
--- a/public/flask_auth_app/.env.example
+++ b/public/flask_auth_app/.env.example
@@ -1,3 +1,6 @@
 # Flask Secret Key
 # Generate with: python -c "import secrets; print(secrets.token_hex(24))"
 FLASK_SECRET_KEY=your_secret_key_here
+
+# Set to "true" to enable Flask debug mode for local development only. Never enable in production.
+FLASK_DEBUG=false

--- a/public/flask_auth_app/app.py
+++ b/public/flask_auth_app/app.py
@@ -150,4 +150,5 @@ with app.app_context():
     db.create_all()
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    debug_mode = os.environ.get("FLASK_DEBUG", "false").lower() == "true"
+    app.run(debug=debug_mode)


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #7834

### Summary
`flask_auth_app` started the Flask server with `debug=True` hardcoded, which exposes the Werkzeug interactive debugger (arbitrary code execution) on any unhandled exception. This PR makes debug mode default to off and opt-in through the `FLASK_DEBUG` environment variable for local development.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `app.py`: replaced `app.run(debug=True)` with `app.run(debug=debug_mode)`, where `debug_mode` is read from the `FLASK_DEBUG` environment variable and defaults to off.
- `.env.example`: documented the new `FLASK_DEBUG` variable with a warning never to enable it in production.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change. This PR only touches the `flask_auth_app` sub-project and does not change `projects.json`.

What I did verify:
- `python -m py_compile app.py` passes (no syntax errors).
- With no `FLASK_DEBUG` set, `debug_mode` evaluates to `False`, so the debugger stays off by default.
- `os` is already imported, so no new import is required.

### Browser Compatibility Check
- N/A: server-side change, no browser-facing markup.

### Responsive & Accessibility Checks
- N/A: no UI changes.

---

## 📷 Screenshots / Video Recording
N/A. No visual changes.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
