### PR TITLE
fix(mern-job-board): authenticate socket and join employers only to their own room

### DIFF
--- a/public/MERN_Job_Board/client/src/context/AuthContext.jsx
+++ b/public/MERN_Job_Board/client/src/context/AuthContext.jsx
@@ -32,10 +32,7 @@ export const AuthProvider = ({ children }) => {
     if (user) {
       socket.connect();
 
-      // Join employer room for private notifications
-      if (user.role === "employer") {
-        socket.emit("joinRoom", `employer_${user._id}`);
-      }
+      // Employer rooms are joined server-side from the authenticated socket handshake
 
       socket.on("onlineCount", (count) => setOnlineCount(count));
 

--- a/public/MERN_Job_Board/client/src/socket/socket.js
+++ b/public/MERN_Job_Board/client/src/socket/socket.js
@@ -6,6 +6,16 @@ const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || "http://localhost:5000";
 const socket = io(SOCKET_URL, {
   autoConnect: false,
   withCredentials: true,
+  // Send the stored JWT on every (re)connect so the server can authenticate the socket
+  auth: (cb) => {
+    let token = "";
+    try {
+      token = (JSON.parse(localStorage.getItem("jbUser")) || {}).token || "";
+    } catch {
+      token = "";
+    }
+    cb({ token });
+  },
 });
 
 export default socket;

--- a/public/MERN_Job_Board/server/index.js
+++ b/public/MERN_Job_Board/server/index.js
@@ -3,6 +3,8 @@ const http       = require("http");
 const { Server } = require("socket.io");
 const mongoose   = require("mongoose");
 const cors       = require("cors");
+const jwt        = require("jsonwebtoken");
+const User       = require("./models/User");
 require("dotenv").config();
 
 const app    = express();
@@ -18,6 +20,19 @@ const io = new Server(server, {
 
 // Make io accessible in routes
 app.set("io", io);
+
+// Authenticate the socket from the JWT handshake; anonymous connections are still allowed for public events
+io.use(async (socket, next) => {
+  const token = socket.handshake.auth?.token;
+  if (!token) return next();
+  try {
+    const { id } = jwt.verify(token, process.env.JWT_SECRET);
+    socket.data.user = await User.findById(id).select("-password");
+  } catch {
+    // Invalid token: continue as an anonymous connection
+  }
+  next();
+});
 
 // Middleware
 app.use(cors({ origin: process.env.CLIENT_URL || "http://localhost:5173" }));
@@ -40,9 +55,11 @@ io.on("connection", (socket) => {
   io.emit("onlineCount", onlineUsers);
   console.log(`⚡ User connected: ${socket.id} | Online: ${onlineUsers}`);
 
-  socket.on("joinRoom", (room) => {
-    socket.join(room);
-  });
+  // Join the authenticated employer to their own room only (server-derived, not client-supplied)
+  const authedUser = socket.data.user;
+  if (authedUser && authedUser.role === "employer") {
+    socket.join(`employer_${authedUser._id}`);
+  }
 
   socket.on("disconnect", () => {
     onlineUsers = Math.max(0, onlineUsers - 1);


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #7846

### Summary
The Socket.io server accepted a client-supplied `joinRoom` with no authentication, so any client could join `employer_<id>` (the id is public via `GET /api/jobs`) and receive an employer's private `newApplication` notifications. This PR authenticates the socket from the JWT handshake and joins each employer only to their own room, derived server-side. The open `joinRoom` handler is removed.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `server/index.js`: added a Socket.io `io.use` handshake authenticator that verifies the JWT from `socket.handshake.auth.token` (reusing `JWT_SECRET`) and attaches the user. Anonymous connections are still allowed so public events (`onlineCount`, `newJob`) keep working. On connection, an authenticated employer is joined only to `employer_<their own _id>`. The client-controlled `socket.on("joinRoom", ...)` handler is removed.
- `client/src/socket/socket.js`: send the stored JWT (`jbUser.token`) via the `auth` handshake callback on every (re)connect.
- `client/src/context/AuthContext.jsx`: removed the `socket.emit("joinRoom", ...)` call, since the room is now joined server-side from the verified token.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change and does not touch this project.

What I did verify:
- `node --check server/index.js` passes.
- `socket.js` and `AuthContext.jsx` parse cleanly (esbuild).
- `joinRoom` no longer appears anywhere in the project (server handler and client emit both removed).
- Auth flow reasoned end to end: on login the client stores `jbUser` (with `token`), connects, and the `auth` callback sends the token; the server verifies it, loads the user, and joins only that employer's own room. An unauthenticated socket can no longer join any employer room.

Not done: I did not run the full MERN stack (it needs MongoDB and a built client). A runtime test with two employer accounts (each should only receive their own application events) is recommended.

### Browser Compatibility Check
- N/A for markup, but a runtime smoke test of the real-time notifications is recommended.

### Responsive & Accessibility Checks
- N/A: no UI layout changes.

---

## 📷 Screenshots / Video Recording
N/A. No visual changes.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors (static checks; runtime smoke test recommended).
- [x] There are no unrelated changes or formatter noise in this PR.
