### PR TITLE
fix(voting-application-backend): whitelist candidate update fields and run validators

### DIFF
--- a/public/Voting_Application_Backend/server/routes/candidateRoutes.js
+++ b/public/Voting_Application_Backend/server/routes/candidateRoutes.js
@@ -110,12 +110,17 @@ router.put('/:candidateID', jwtAuthMiddleware, async(req,res)=> {
         if(!await checkAdminRole(req.user.id))
             return res.status(403).json({message: 'user does not  has not admin role'});
         const candidateID = req.params.candidateID //extract id from the url parameter
-        const updatedCandidateData = req.body; //updated data from the candidate
+        // Only candidate metadata is editable here; voteCount and votes are managed by the voting flow
+        const { name, party, age } = req.body;
+        const updatedCandidateData = {};
+        if (name !== undefined) updatedCandidateData.name = name;
+        if (party !== undefined) updatedCandidateData.party = party;
+        if (age !== undefined) updatedCandidateData.age = age;
 
         const response = await Candidate.findByIdAndUpdate(candidateID, updatedCandidateData, {
             new: true, //return the updated document
-            runValidation: true //run mongoose validation
-        }) 
+            runValidators: true //run mongoose validation
+        })
 
         if(!response) {
             return res.status(404).json({error: 'Candidate not found'});


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #7851

### Summary
The candidate-update route wrote the raw request body into `findByIdAndUpdate`, letting an admin overwrite `voteCount`/`votes` and rewrite the tally, and it misspelled the validators option (`runValidation` instead of `runValidators`), so schema validation never ran. This PR whitelists the editable metadata fields and enables validators.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `server/routes/candidateRoutes.js` (PUT `/:candidateID`): build the update object from a whitelist of metadata fields (`name`, `party`, `age`) instead of assigning `req.body` directly, so `voteCount` and `votes` can no longer be set through this endpoint.
- Corrected the Mongoose option `runValidation` to `runValidators` so validators run on updates.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change and does not touch this project.

What I did verify:
- `node --check server/routes/candidateRoutes.js` passes.
- The raw `req.body` assignment is gone; only `name`/`party`/`age` are applied, matching the Candidate schema's metadata fields.
- The option is now `runValidators: true`.

### Browser Compatibility Check
- N/A: server-side change, no browser-facing markup.

### Responsive & Accessibility Checks
- N/A: no UI changes.

---

## 📷 Screenshots / Video Recording
N/A. No visual changes.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
