### PR TITLE
fix(a11y): add aria-live region for dynamic filter/search results 

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,7 +295,7 @@
               id="filterAll"
               aria-label="Show all projects"
             >
-              All <span class="chip-count" id="allCount">Projects</span>
+              All <span class="chip-count" id="allCount" aria-live="polite">Projects</span>
             </button>
             <button
               class="chip"
@@ -393,7 +393,7 @@
 
         <div class="project-grid" id="projectGrid"></div>
 
-        <div class="no-results" id="noResults">
+        <div class="no-results" id="noResults" role="status" aria-live="assertive">
           <i class="fas fa-search" aria-hidden="true"></i>
           <p>No projects match your search.</p>
         </div>


### PR DESCRIPTION
### Description
Closes #7842

When dynamic search or filter changes occurred on the homepage, screen readers were not notified because the target containers lacked accessibility live region attributes. This PR resolves the accessibility issue by adding ARIA live regions so changes to search outcomes are announced dynamically.

### Changes Made
- Added `aria-live="polite"` to the dynamic project count element `#allCount` inside the "All" filter chip button to notify users when the total count of projects matches search or filter criteria.
- Added `role="status"` and `aria-live="assertive"` to the `#noResults` fallback text div to immediately announce when no projects match the search query.

### Verification and Testing
- Started the dev server locally (`serve`) and tested the interface in the browser.
- **Search filtering verification**: Searching for a nonexistent term successfully updates the DOM and displays the `#noResults` element, which is now marked as an assertive live region.
- **Category filtering verification**: Clicking various category filter chips dynamically updates the display and updates the project count, which is now set to announce changes politely.

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings/linter issues
- [x] Checked on a local server that the dynamic filtering and feedback states function correctly
