### PR TITLE
fix(a11y): resolve page load JS crash to fix keyboard navigation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1756,7 +1756,6 @@ document.addEventListener("DOMContentLoaded", async () => {
   initTechStackSearch();
   initClearAllFilters();
 
-  initStreak();
   updateGamifiedUI();
 
   try {


### PR DESCRIPTION
## Pull Request Description

### Related Issue
Closes #7841

### Summary
Fixed keyboard navigation support for project cards on the homepage by resolving a runtime JavaScript `ReferenceError`. 

Previously, an obsolete call to `initStreak()` was left in the `DOMContentLoaded` listener in `index.js` while its function definition had been removed in previous refactors. This caused a page-load crash that prevented the project grid from loading/rendering, meaning the project cards did not exist in the DOM and focus jumped directly from the search/filter inputs to the footer. Removing this obsolete call allows the project cards to render and receive standard focus/tab sequence correctly.

## Changes Made
- **Removed Obsolete Call:** Deleted the undefined `initStreak()` function call from the DOMContentLoaded handler in [index.js](<file:///Users/nishtha/Desktop/gssoc/100_days_100_web_project /100_days_100_web_project/index.js#L1759>).

---

## Testing and Verification

### Local Validation
- [x] Launched the local server (`npm run dev`) and loaded the homepage to verify that the console is free of JS ReferenceErrors.
- [x] Verified that project cards are rendered successfully.
- [x] Ran a local Puppeteer automated script to simulate tab sequences: focus correctly cycles from search filters into the card containers (`div.project-card`) and their inner interactive controls (`Demo`, `Code`, `Bookmark`), and then to the next card.

---

## Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
