### PR TITLE
fix: Add missing meta description to stats.html and 404.html

### DIFF
--- a/404.html
+++ b/404.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="description" content="Page not found - return to 100 Days 100 Web Projects, a collection of 100+ creative web experiments.">
     <title>404 — Page Not Found | 100 Days 100 Web Projects</title>
     <link rel="icon" href="./public/favv.png" type="image/x-icon"/>
     <link rel="stylesheet" href="style.css" />

--- a/stats.html
+++ b/stats.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="Real-time stats dashboard for 100 Days 100 Web Projects – category breakdown, project status, and contributor metrics.">
 <title>Project Stats — 100 Days 100 Web Projects</title>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA==" crossorigin="anonymous" referrerpolicy="no-referrer" />


### PR DESCRIPTION
## Description
This PR resolves the missing meta description tags in both `stats.html` and `404.html` to improve SEO and social sharing previews. 

No extraneous formatting or indentation changes have been made to either file, keeping the diff clean and focused.

## Related Issue
Closes #7839

## Proposed Changes
- Added description meta tag in [stats.html](file:///Users/nishtha/Desktop/gssoc/100_days_100_web_project%20/100_days_100_web_project/stats.html):
  ```html
  <meta name="description" content="Real-time stats dashboard for 100 Days 100 Web Projects – category breakdown, project status, and contributor metrics.">
  ```

- Added description meta tag in [404.html](file:///Users/nishtha/Desktop/gssoc/100_days_100_web_project%20/100_days_100_web_project/404.html):
  ```html
  <meta name="description" content="Page not found - return to 100 Days 100 Web Projects, a collection of 100+ creative web experiments.">
  ```

