### PR TITLE
fix: Remove duplicate 'Hangman Game' entry in projects.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ The website features:
 | 147 | Chronosphere | intermediate | [View Demo](https://100-days-100-web-project.vercel.app/public/Chronosphere/index.html) |
 | 151 | Mini Carrom Game | intermediate | [View Demo](https://100-days-100-web-project.vercel.app/public/mini carrom/index.html) |
 | 152 | Physics Ball Simulation | advanced | [View Demo](https://100-days-100-web-project.vercel.app/public/PhysicsBallSimulation/index.html) |
-| 155 | Hangman Game | advanced | [View Demo](https://100-days-100-web-project.vercel.app/public/hangman-react-ts/HangmanGame/index.html) |
+| 155 | Hangman Game (React TS) | advanced | [View Demo](https://100-days-100-web-project.vercel.app/public/hangman-react-ts/HangmanGame/index.html) |
 | 159 | Dining Philosophers Simulation | intermediate | [View Demo](https://100-days-100-web-project.vercel.app/public/Dining Philosophers Simulation/index.html) |
 | 168 | Color Sort Puzzle game | advanced | [View Demo](https://100-days-100-web-project.vercel.app/public/color%20sort%20puzzle/index.html) |
 | 179 | Cyber Type Battle | intermediate | [View Demo](https://100-days-100-web-project.vercel.app/public/CYBER TYPE BATTLE/index.html) |

--- a/projects.json
+++ b/projects.json
@@ -1862,7 +1862,7 @@
   },
   {
     "projectNo": 155,
-    "projectName": "Hangman Game",
+    "projectName": "Hangman Game (React TS)",
     "projectType": "Game",
     "projectDesc": "Advanced Hangman implementation using React and TypeScript architecture.",
     "techStack": [


### PR DESCRIPTION
# Description

Fixes #7838

This PR resolves the issue where there are two duplicate entries named **"Hangman Game"** in `projects.json`. 

- **Day 94**: Vanilla JavaScript Hangman game (`./public/HangmanGame/index.html`) -> Retained the name **"Hangman Game"**.
- **Day 155**: React & TypeScript Hangman game (`./public/hangman-react-ts/HangmanGame/index.html`) -> Renamed to **"Hangman Game (React TS)"** to distinguish it and prevent duplication/confusion.

Additionally, the corresponding entry has been updated in the `README.md` project catalog.

## Changes Made
- Modified `projectName` for Project 155 in `projects.json` to `"Hangman Game (React TS)"`.
- Modified Project 155 entry in `README.md` to match the new name `"Hangman Game (React TS)"`.

## Verification
- Verified JSON syntax validity.
- Confirmed that only the two specific lines have been updated (avoiding any unnecessary file formatting).
