### PR TITLE
fix: Standardize projectType values in projects.json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -2287,7 +2287,7 @@
   {
     "projectNo": 185,
     "projectName": "GitHub Repository Analyser",
-    "projectType": "tool",
+    "projectType": "Tool",
     "projectDesc": "A modern tool to quickly analyse a github repo , provides detail stats about repo.",
     "techStack": [
       "tool",
@@ -2359,7 +2359,7 @@
   {
     "projectNo": 190,
     "projectName": "Endless train game",
-    "projectType": "game",
+    "projectType": "Game",
     "projectDesc": "A game with train moving on rails and switching tails and earning coins.",
     "techStack": [
       "html",
@@ -2388,7 +2388,7 @@
   {
     "projectNo": 192,
     "projectName": "Interactive Story Player",
-    "projectType": "UI / Animation",
+    "projectType": "UI",
     "projectDesc": "A dynamic, choice-driven storytelling application where users shape their own narrative paths.",
     "techStack": [
       "ui",
@@ -2428,7 +2428,7 @@
   {
     "projectNo": 195,
     "projectName": "Complaint Management System",
-    "projectType": "Web Application",
+    "projectType": "Tool",
     "projectDesc": "A professional portal for submitting, tracking, and managing complaints efficiently with a premium modern UI.",
     "techStack": [
       "html",
@@ -2469,7 +2469,7 @@
   {
     "projectNo": 198,
     "projectName": "Theme-Toggler",
-    "projectType": "UI / Animation",
+    "projectType": "UI",
     "projectDesc": "A responsive theme toggler that switches between multiple premium themes (including Cyberpunk and Dracula) with smooth transitions.",
     "techStack": [
       "html",
@@ -2499,7 +2499,7 @@
   {
     "projectNo": 200,
     "projectName": "Dual-Genre Movie Matcher",
-    "projectType": "Web Application",
+    "projectType": "Tool",
     "projectDesc": "A web app to search the perfect movie. Comes with dark and light theme toggle.",
     "techStack": [
       "html",
@@ -2553,7 +2553,7 @@
   {
     "projectNo": 204,
     "projectName": "Movie Search App",
-    "projectType": "Web Application",
+    "projectType": "API",
     "projectDesc": "A responsive movie search application powered by the OMDb API that allows users to search movies and view detailed information including posters, ratings, genres, cast, runtime, and plot.",
     "techStack": [
       "html",
@@ -2567,7 +2567,7 @@
   {
     "projectNo": 205,
     "projectName": "Escape the Matrix Game",
-    "projectType": "Web Application",
+    "projectType": "Game",
     "projectDesc": "An immersive, interactive web-based survival and puzzle game challenging players to hack their way out of a simulated reality.",
     "techStack": [
       "html",
@@ -2594,7 +2594,7 @@
   {
     "projectNo": 207,
     "projectName": "AI Semiconductor Circuit Builder",
-    "projectType": "Web Application",
+    "projectType": "AI",
     "projectDesc": "An immersive, interactive web-based survival and puzzle game challenging players to hack their way out of a simulated reality.",
     "techStack": [
       "html",
@@ -2703,7 +2703,7 @@
   {
     "projectNo": 215,
     "projectName": "Mood-Based Music Recommender",
-    "projectType": "Web App",
+    "projectType": "Tool",
     "projectDesc": "An interactive web application that recommends music based on the user's current mood. Features a premium Spotify-inspired UI, smooth animations, and dynamic themes.",
     "techStack": [
       "html",
@@ -2759,7 +2759,7 @@
   {
     "projectNo": 219,
     "projectName": "The Cube - 3D Rubik's Cube Simulator",
-    "projectType": "Web Application",
+    "projectType": "Simulation",
     "projectDesc": "An interactive 3D Rubik's Cube simulator built with Three.js that allows users to solve, scramble, customize, and track performance across multiple cube sizes with smooth animations and touch support.",
     "techStack": [
       "html",
@@ -2788,7 +2788,7 @@
   {
     "projectNo": 221,
     "projectName": "AI Tools Hub",
-    "projectType": "Web Application",
+    "projectType": "AI",
     "projectDesc": "A modern platform for discovering and exploring AI tools across coding, design, writing, productivity, presentations, and media categories.",
     "techStack": [
       "html",
@@ -2801,18 +2801,20 @@
   {
     "projectNo": 222,
     "projectName": "Bus Game",
-    "projectType": "game",
+    "projectType": "Game",
     "projectDesc": "A modern bus game with lane and vehicles",
-    "techStack": ["javascript", "html", "css"],
+    "techStack": [
+      "javascript",
+      "html",
+      "css"
+    ],
     "difficulty": "advanced",
-    "projectPath": "./public/bus_game/index.html" 
-    },
-
-    
+    "projectPath": "./public/bus_game/index.html"
+  },
   {
     "projectNo": 223,
     "projectName": "HTML & CSS Animation",
-    "projectType": "Web Application",
+    "projectType": "Animation",
     "projectDesc": "Collection of HTML/CSS animations demonstrating keyframe effects and transitions.",
     "techStack": [
       "html",
@@ -2821,11 +2823,11 @@
     ],
     "difficulty": "beginner",
     "projectPath": "./public/Html_css_animation/index.html"
-    },
+  },
   {
     "projectNo": 224,
     "projectName": "Bubble Game",
-    "projectType": "Web Application",
+    "projectType": "Game",
     "projectDesc": "An interactive bubble-clicking game where players must quickly hit bubbles matching the target number before the timer runs out. Score points by selecting the correct bubbles and test your speed and accuracy.",
     "techStack": [
       "html",
@@ -2838,7 +2840,7 @@
   {
     "projectNo": 225,
     "projectName": "Harryy Potter Spellbook",
-    "projectType": "Web Application",
+    "projectType": "API",
     "projectDesc": "A magical, interactive web application built with vanilla web technologies. This project fetches live data from the Harry Potter API and features an interactive Spell Caster that dynamically alters the UI using CSS animations and state changes based on the spells you cast.",
     "techStack": [
       "html",

--- a/schema/projects.schema.json
+++ b/schema/projects.schema.json
@@ -15,7 +15,25 @@
     "properties": {
       "projectNo": { "type": "number" },
       "projectName": { "type": "string" },
-      "projectType": { "type": "string" },
+      "projectType": {
+        "type": "string",
+        "enum": [
+          "Game",
+          "Tool",
+          "Clone",
+          "UI",
+          "Animation",
+          "API",
+          "Website",
+          "Backend",
+          "AI",
+          "E-Commerce",
+          "Productivity",
+          "Simulation",
+          "Authentication",
+          "Form"
+        ]
+      },
       "projectDesc": { "type": "string" },
       "techStack": { "type": "array", "items": { "type": "string" } },
       "difficulty": { "type": "string", "enum": ["beginner", "intermediate", "advanced"] },

--- a/scripts/validate-metadata.js
+++ b/scripts/validate-metadata.js
@@ -9,7 +9,23 @@ const rootDir = process.argv[3]
   : path.join(__dirname, '..');
 
 const VALID_DIFFICULTIES = new Set(['beginner', 'intermediate', 'advanced']);
-const REQUIRED_KEYS = ['projectNo', 'projectName', 'techStack', 'difficulty', 'projectPath'];
+const VALID_PROJECT_TYPES = new Set([
+  'Game',
+  'Tool',
+  'Clone',
+  'UI',
+  'Animation',
+  'API',
+  'Website',
+  'Backend',
+  'AI',
+  'E-Commerce',
+  'Productivity',
+  'Simulation',
+  'Authentication',
+  'Form'
+]);
+const REQUIRED_KEYS = ['projectNo', 'projectName', 'projectType', 'techStack', 'difficulty', 'projectPath'];
 const UNSAFE_PROTOCOL_RE = /^(?:javascript|data|vbscript):/i;
 const URL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
 const EXPECTED_GITHUB_REPOSITORY = 'dhairyagothi/100_days_100_web_project';
@@ -186,6 +202,14 @@ try {
             addFieldError(errors, index, project, `techStack[${tokenIndex}]`, 'must be a non-empty string');
           }
         });
+      }
+    }
+
+    if (project.projectType !== undefined && project.projectType !== null && project.projectType !== '') {
+      if (typeof project.projectType !== 'string') {
+        addFieldError(errors, index, project, 'projectType', `must be a string, got "${typeof project.projectType}"`);
+      } else if (!VALID_PROJECT_TYPES.has(project.projectType)) {
+        addFieldError(errors, index, project, 'projectType', `must be one of: ${Array.from(VALID_PROJECT_TYPES).join(', ')}`);
       }
     }
 

--- a/scripts/validate-projects-fixture.js
+++ b/scripts/validate-projects-fixture.js
@@ -16,6 +16,7 @@ fs.writeFileSync(validRegistryPath, JSON.stringify([
   {
     projectNo: 1,
     projectName: 'Valid Project',
+    projectType: 'Tool',
     techStack: ['html', 'css'],
     difficulty: 'beginner',
     projectPath: './public/valid-project/index.html'
@@ -23,6 +24,7 @@ fs.writeFileSync(validRegistryPath, JSON.stringify([
   {
     projectNo: 2,
     projectName: 'Valid Same Repository Blob URL',
+    projectType: 'Tool',
     techStack: ['html'],
     difficulty: 'intermediate',
     projectPath: 'https://github.com/dhairyagothi/100_days_100_web_project/blob/Main/index.html'
@@ -30,6 +32,7 @@ fs.writeFileSync(validRegistryPath, JSON.stringify([
   {
     projectNo: 3,
     projectName: 'Valid Same Repository Tree URL',
+    projectType: 'Tool',
     techStack: ['html'],
     difficulty: 'advanced',
     projectPath: 'https://github.com/dhairyagothi/100_days_100_web_project/tree/Main/public'
@@ -40,6 +43,7 @@ fs.writeFileSync(invalidRegistryPath, JSON.stringify([
   {
     projectNo: 1,
     projectName: 'Original Project',
+    projectType: 'Tool',
     techStack: ['html'],
     difficulty: 'beginner',
     projectPath: './public/valid-project/index.html'
@@ -47,6 +51,7 @@ fs.writeFileSync(invalidRegistryPath, JSON.stringify([
   {
     projectNo: 1,
     projectName: 'Duplicate Day',
+    projectType: 'Game',
     techStack: ['javascript'],
     difficulty: 'expert',
     projectPath: 'javascript:alert(1)'
@@ -54,6 +59,7 @@ fs.writeFileSync(invalidRegistryPath, JSON.stringify([
   {
     projectNo: 3,
     projectName: 'Escaped Path',
+    projectType: 'UI',
     techStack: ['html'],
     difficulty: 'advanced',
     projectPath: '../outside.html'
@@ -61,6 +67,7 @@ fs.writeFileSync(invalidRegistryPath, JSON.stringify([
   {
     projectNo: 4,
     projectName: 'Missing File',
+    projectType: 'Animation',
     techStack: ['css'],
     difficulty: 'intermediate',
     projectPath: './public/missing/index.html'
@@ -68,6 +75,7 @@ fs.writeFileSync(invalidRegistryPath, JSON.stringify([
   {
     projectNo: 5,
     projectName: 'External GitHub Blob URL',
+    projectType: 'API',
     techStack: ['html'],
     difficulty: 'advanced',
     projectPath: 'https://github.com/octocat/Hello-World/blob/master/README'
@@ -75,9 +83,18 @@ fs.writeFileSync(invalidRegistryPath, JSON.stringify([
   {
     projectNo: 6,
     projectName: 'External GitHub Tree URL',
+    projectType: 'Website',
     techStack: ['html'],
     difficulty: 'advanced',
     projectPath: 'https://github.com/octocat/Hello-World/tree/master'
+  },
+  {
+    projectNo: 7,
+    projectName: 'Invalid Project Type',
+    projectType: 'Web Application',
+    techStack: ['html'],
+    difficulty: 'beginner',
+    projectPath: './public/valid-project/index.html'
   }
 ], null, 2));
 
@@ -105,7 +122,8 @@ const expectedMessages = [
   'must not contain path traversal',
   'local path "./public/missing/index.html" does not exist in the repository',
   'Index 4 (Day 5 - External GitHub Blob URL): "projectPath" GitHub URLs must point to this repository',
-  'Index 5 (Day 6 - External GitHub Tree URL): "projectPath" GitHub URLs must point to this repository'
+  'Index 5 (Day 6 - External GitHub Tree URL): "projectPath" GitHub URLs must point to this repository',
+  'must be one of: Game, Tool, Clone, UI, Animation, API, Website, Backend, AI, E-Commerce, Productivity, Simulation, Authentication, Form'
 ];
 
 if (invalidResult.status === 0) {


### PR DESCRIPTION

## Description
The `projectType` field in `projects.json` has had inconsistent casing, naming conventions, and double categories (e.g., `tool` vs `Tool`, `game` vs `Game`, `Web Application` / `Web App` vs existing allowed categories), causing duplicate segments to appear on the Category Breakdown doughnut chart on the Stats page.

This PR standardizes `projectType` values across all 226 projects to follow a consistent title-cased vocabulary, updates the JSON Schema to enforce it, and updates the project metadata validation script to check for invalid types.

## Related Issues
Closes #7837

## Proposed Changes
1. **`projects.json`**:
   - Normalized 16 entries with non-standardized `projectType` values (e.g., `tool` -> `Tool`, `game` -> `Game`, `Web Application`/`Web App` -> `Tool`/`API`/`AI`/`Simulation`/`Animation`, `UI / Animation` -> `UI`).
2. **`schema/projects.schema.json`**:
   - Added an `enum` constraint to `projectType` specifying the list of allowed categories.
3. **`scripts/validate-metadata.js`**:
   - Added `projectType` to `REQUIRED_KEYS`.
   - Implemented validation checking to verify `projectType` is a string and belongs to the allowed set: `Game`, `Tool`, `Clone`, `UI`, `Animation`, `API`, `Website`, `Backend`, `AI`, `E-Commerce`, `Productivity`, `Simulation`, `Authentication`, `Form`.
4. **`scripts/validate-projects-fixture.js`**:
   - Updated mock project fixtures to contain the required `projectType` property.
   - Added a test case featuring an invalid `projectType` to ensure the validation script correctly identifies and catches incorrect categories.

## How Has This Been Tested?
1. **Automated Tests**:
   - Ran `npm run validate:projects-fixture` successfully to verify validation logic and correct error raising behavior.
2. **Manual Verification**:
   - Verified programmatically that all 226 entries in `projects.json` conform to the schema list.
   - Verified rendering on the Category Breakdown doughnut chart of the local `stats.html` server (resolved 14 distinct categories perfectly without duplicates).
