### PR TITLE
Add form builder README

### DIFF
--- a/public/form-builder/README.md
+++ b/public/form-builder/README.md
@@ -1,0 +1,29 @@
+# FormForge
+
+A dark-themed drag-and-drop form builder that lets you assemble forms visually, edit field properties, preview the result, and export the generated HTML.
+
+## Features
+
+- Drag or click fields into the canvas
+- Edit labels, names, placeholders, and required state
+- Preview the form in a modal
+- Export the built form as HTML
+- Delete and re-order form fields by rebuilding the canvas state
+
+## How to Use
+
+1. Choose a field type from the sidebar.
+2. Add it to the canvas.
+3. Select the field to edit its properties.
+4. Preview or export the finished form.
+
+## Files
+
+- `index.html` - Page layout and controls
+- `style.css` - Styling
+- `script.js` - Builder logic and preview/export behavior
+
+## Notes
+
+- The UI uses Bootstrap and Font Awesome from CDNs.
+- Field state is kept entirely in the browser during editing.


### PR DESCRIPTION
Closes #7983.

## Summary
- Add a README for the FormForge form builder
- Document the drag-and-drop builder flow, preview, and export features

## Validation
- `git diff --check`
