### PR TITLE
Add endless train README

### DIFF
--- a/public/endless_train_game/README.md
+++ b/public/endless_train_game/README.md
@@ -1,0 +1,30 @@
+# Endless Train Runner
+
+Endless Train Runner is a side-scrolling endless runner where you dodge obstacles, collect coins, grab powerups, and try to beat your best score across the rails.
+
+## Features
+
+- Three-lane movement
+- Coins and score tracking
+- Powerups like shield, magnet, slow motion, and boost
+- Lives system with game-over flow
+- Persistent best score stored in local storage
+
+## How to Play
+
+1. Start the game from the menu.
+2. Move left and right between tracks.
+3. Dodge obstacles and collect coins.
+4. Use powerups to extend your run.
+5. Try to beat your previous best score.
+
+## Files
+
+- `index.html` - UI, HUD, and screens
+- `train.css` - Visual styling
+- `train.js` - Core game loop and gameplay logic
+
+## Notes
+
+- The game uses a canvas-based render loop.
+- Progress and best score are stored in the browser.


### PR DESCRIPTION
Closes #7974.

## Summary
- Add a README for the Endless Train Runner game
- Document lanes, coins, powerups, and best-score tracking

## Validation
- `git diff --check`
