### PR TITLE
Add DocNow README

### DIFF
--- a/public/DocNow/README.md
+++ b/public/DocNow/README.md
@@ -1,0 +1,29 @@
+# DocNow
+
+DocNow is a lightweight browser note board for cards, links, reminders, references, and work items. It supports search, filtering, editing, deletion, and a simple theme toggle.
+
+## Features
+
+- Create and edit note cards
+- Categorize cards by type
+- Search across titles and content
+- Filter by category
+- Toggle between light and dark themes
+- Persist cards in local storage
+
+## How to Use
+
+1. Click **New** to create a card.
+2. Fill in the title, content, and optional URL.
+3. Use filters or search to find cards later.
+4. Edit or delete cards as needed.
+
+## Files
+
+- `index.html` - App shell and modal UI
+- `docstyle.css` - Styling
+
+## Notes
+
+- Card data is stored locally in the browser.
+- The app runs fully on the client side with no backend.


### PR DESCRIPTION
Closes #7967.

## Summary
- Add a README for DocNow
- Document card creation, search/filtering, theme toggle, and storage behavior

## Validation
- `git diff --check`
