### PR TITLE
fix: add keyboard focus styling to navigation links

### DIFF
--- a/contributors/contributor.css
+++ b/contributors/contributor.css
@@ -70,7 +70,13 @@ body {
 #navbar-container {
   z-index: 9999;
 }
-
+.nav-links .tooltip a:hover,
+.nav-links .tooltip a:focus-visible {
+  background: rgba(0, 0, 0, 0.04);
+  color: inherit;
+  outline: 2px solid rgba(212, 175, 55, 0.8);
+  outline-offset: 2px;
+}
 /* Header */
 .contributor-header {
   text-align: center;


### PR DESCRIPTION
## Summary

Adds focus-visible styles to navigation links in the Contributors page.

## Changes Made

- Added :focus-visible styling for navigation links.
- Matched keyboard focus appearance with hover state.
- Added visible focus outline for accessibility.

## Why

Previously, navigation links only provided hover feedback.
Keyboard users navigating with the Tab key did not receive
equivalent visual feedback.

Closes #7878