### PR TITLE
fix: align doc validation with registry paths

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -751,7 +751,7 @@
       "css"
     ],
     "difficulty": "beginner",
-    "projectPath": "./public/zomato-clone/zomato.html"
+    "projectPath": "./public/zomato-clone/public/index.html"
   },
   {
     "projectNo": 65,

--- a/public/eisenhower-matrix-tool/README.md
+++ b/public/eisenhower-matrix-tool/README.md
@@ -1,0 +1,29 @@
+# Eisenhower Task Matrix
+
+The Eisenhower Task Matrix helps you sort tasks by urgency and importance in a drag-and-drop board, making it easier to focus on what matters most.
+
+## Features
+
+- Create tasks from a simple input bar
+- Assign tasks to one of four quadrants
+- Drag tasks between quadrants
+- Persist tasks in local storage
+- Track counts per quadrant
+
+## How to Use
+
+1. Type a task into the input box.
+2. Pick a quadrant and click **Add Task**.
+3. Drag tasks to another quadrant as priorities change.
+4. Use the matrix to identify what to do, schedule, delegate, or eliminate.
+
+## Files
+
+- `index.html` - Task board layout
+- `app.js` - Task storage and drag-and-drop logic
+- `styles.css` - Visual styling
+
+## Notes
+
+- The app stores the task list in the browser.
+- Drag-and-drop updates are reflected immediately in the board counts.

--- a/scripts/validate-docs.js
+++ b/scripts/validate-docs.js
@@ -3,6 +3,7 @@ const path = require('path');
 
 // Target directory paths relative to this script location
 const PUBLIC_DIR = path.resolve(__dirname, '../public');
+const PROJECTS_PATH = path.resolve(__dirname, '../projects.json');
 const MAX_SIZE_MB = 2;
 const MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024;
 
@@ -10,6 +11,87 @@ const MAX_SIZE_BYTES = MAX_SIZE_MB * 1024 * 1024;
 const args = process.argv.slice(2);
 const projectIdx = args.indexOf('--project');
 const targetProject = projectIdx !== -1 ? args[projectIdx + 1] : null;
+
+let PROJECTS_BY_FOLDER = new Map();
+
+function decodeLocalPath(value) {
+  let relPath = String(value || '').trim().split('?')[0].split('#')[0];
+
+  try {
+    relPath = decodeURIComponent(relPath);
+  } catch (_error) {
+    // Keep the original value if it was already plain text.
+  }
+
+  return relPath.replace(/\\/g, '/');
+}
+
+function isExternalUrl(value) {
+  return /^https?:\/\//i.test(String(value || '').trim());
+}
+
+function parseGithubTreePath(value) {
+  const match = String(value || '')
+    .trim()
+    .match(/\/tree\/[^/]+\/(.+?)(?:\?|#|$)/i);
+
+  return match ? decodeLocalPath(match[1]) : null;
+}
+
+function getFolderKeyFromProjectPath(projectPath) {
+  if (typeof projectPath !== 'string') return null;
+
+  const trimmed = projectPath.trim();
+
+  const githubTreePath = parseGithubTreePath(trimmed);
+  if (githubTreePath) {
+    if (!githubTreePath.startsWith('public/')) return null;
+    const relativeToPublic = githubTreePath.slice('public/'.length);
+    const [folderName] = relativeToPublic.split('/');
+    return folderName || null;
+  }
+
+  if (!trimmed.startsWith('./') || isExternalUrl(trimmed)) return null;
+
+  let localPath = decodeLocalPath(trimmed);
+  if (localPath.startsWith('./')) {
+    localPath = localPath.slice(2);
+  }
+  if (!localPath.startsWith('public/')) return null;
+
+  const relativeToPublic = localPath.slice('public/'.length);
+  const [folderName] = relativeToPublic.split('/');
+  return folderName || null;
+}
+
+function loadProjectsRegistry() {
+  if (!fs.existsSync(PROJECTS_PATH)) {
+    throw new Error(`Cannot find projects registry at ${PROJECTS_PATH}`);
+  }
+
+  const payload = fs.readFileSync(PROJECTS_PATH, 'utf8');
+  const projects = JSON.parse(payload);
+
+  if (!Array.isArray(projects)) {
+    throw new Error('projects.json must be a JSON array');
+  }
+
+  const folderMap = new Map();
+  for (const project of projects) {
+    if (!project || typeof project !== 'object') continue;
+
+    const folderKey =
+      getFolderKeyFromProjectPath(project.projectPath) ||
+      (isExternalUrl(project.projectPath) && typeof project.projectName === 'string'
+        ? project.projectName.trim()
+        : null);
+    if (!folderKey || folderMap.has(folderKey)) continue;
+
+    folderMap.set(folderKey, project);
+  }
+
+  PROJECTS_BY_FOLDER = folderMap;
+}
 
 /**
  * Recursively steps through folders to catch any asset exceeding size threshold
@@ -33,6 +115,32 @@ function checkAssetSizes(currentPath, issueLog) {
     }
 }
 
+function getConfiguredEntryPoint(projectName) {
+    const registryEntry = PROJECTS_BY_FOLDER.get(projectName);
+
+    if (!registryEntry || typeof registryEntry.projectPath !== 'string') {
+        return null;
+    }
+
+    const rawPath = registryEntry.projectPath.trim();
+    const githubTreePath = parseGithubTreePath(rawPath);
+    if (githubTreePath || isExternalUrl(rawPath)) {
+        return {
+            type: 'external',
+            projectPath: rawPath,
+        };
+    }
+
+    const localPath = decodeLocalPath(rawPath);
+    const resolvedPath = path.resolve(path.join(__dirname, '..'), localPath);
+
+    return {
+        type: 'local',
+        projectPath: rawPath,
+        resolvedPath,
+    };
+}
+
 /**
  * Validates a targeted project folder against the 3 core criteria
  */
@@ -53,8 +161,15 @@ function validateProjectFolder(projectName) {
     }
 
     // Rule 3: Valid Entry Point Check
-    if (!fs.existsSync(path.join(projectPath, 'index.html'))) {
-        projectIssues.push(`❌ Valid Entry Point: Missing "index.html"`);
+    const configuredEntryPoint = getConfiguredEntryPoint(projectName);
+    if (configuredEntryPoint && configuredEntryPoint.type === 'local') {
+        if (!fs.existsSync(configuredEntryPoint.resolvedPath)) {
+            projectIssues.push(
+                `❌ Valid Entry Point: Missing configured "${configuredEntryPoint.projectPath}"`,
+            );
+        }
+    } else if (!configuredEntryPoint && !fs.existsSync(path.join(projectPath, 'index.html'))) {
+        projectIssues.push(`❌ Valid Entry Point: Missing fallback "index.html"`);
     }
 
     // Rule 2: Asset Size Audit
@@ -71,6 +186,8 @@ function validateProjectFolder(projectName) {
 }
 
 function main() {
+    loadProjectsRegistry();
+
     if (!fs.existsSync(PUBLIC_DIR)) {
         console.error(`❌ Root Directory Error: Cannot find "/public" folder at ${PUBLIC_DIR}`);
         process.exit(1);
@@ -117,5 +234,4 @@ function main() {
     }
 }
 
-main();
 main();


### PR DESCRIPTION
## Summary\n- Make scripts/validate-docs.js resolve entry points from projects.json instead of assuming every project uses index.html\n- Preserve a fallback check for projects that are not registered yet\n- Fix the Zomato-clone registry path to point at the real nested public entry point\n\n## Validation\n- git diff --check\n- node scripts/validate-docs.js --project zomato-clone\n\nCloses #7964\nCloses #7965\nCloses #7962