### PR TITLE
Add game over and victory popups to Simon Says Game

### DIFF
--- a/public/Simon_Says_Game/index.html
+++ b/public/Simon_Says_Game/index.html
@@ -61,8 +61,15 @@
       <div class="btn green" id="green"></div>
       <div class="btn purple" id="purple"></div>
     </div>
+  </div>  
+<div id="game-modal" class="modal hidden">
+  <div class="modal-content">
+    <h2 id="modal-title"></h2>
+    <p id="modal-score"></p>
+    <p id="modal-highscore"></p>
+    <button id="modal-btn">Play Again</button>
   </div>
-</div>  
+</div>
 <script src="script.js"></script>
 </body>
 </html>

--- a/public/Simon_Says_Game/script.js
+++ b/public/Simon_Says_Game/script.js
@@ -14,6 +14,11 @@ let sequenceInterval = null; // store Simon sequence interval
 const screens = document.querySelectorAll('.screen');
 const h2 = document.querySelector("h2");
 const highScoreText = document.getElementById("highscore");
+const modal = document.getElementById("game-modal");
+const modalTitle = document.getElementById("modal-title");
+const modalScore = document.getElementById("modal-score");
+const modalHighScore = document.getElementById("modal-highscore");
+const modalBtn = document.getElementById("modal-btn");
 const strictToggle = document.getElementById("strict-toggle");
 const themeToggle = document.getElementById("theme-toggle");
 const startBtn = document.getElementById("start-btn");
@@ -54,6 +59,18 @@ function startGame() {
 }
 
 function levelUp() {
+  if (level === 20) {
+    updateHighScore();
+    
+    showModal(
+      "🎉 Congratulations!",
+      level,
+      "Play Again"
+    );
+    
+    resetGame();
+    return;
+  }
   userSeq = [];
   level++;
   flashSpeed = Math.max(250, 600 - level * 30);
@@ -165,10 +182,14 @@ function stopGame() {
 }
 
 function gameOver() {
-  board.classList.add("shake");
-  board.addEventListener("animationend", () => board.classList.remove("shake"), { once: true });
-  h2.innerHTML = `💀 Game Over! Score: <b>${level}</b>`;
   updateHighScore();
+
+  showModal(
+    "💀 Game Over!",
+    level,
+    "Restart"
+  );
+
   resetGame();
 }
 
@@ -193,6 +214,20 @@ function btnPress() {
 
   checkAns(userSeq.length - 1);
 }
+
+function showModal(title, score, buttonText) {
+  modalTitle.innerText = title;
+  modalScore.innerText = `Final Score: ${score}`;
+  modalHighScore.innerText = `Highest Score: ${highScore}`;
+  modalBtn.innerText = buttonText;
+
+  modal.classList.remove("hidden");
+}
+
+modalBtn.addEventListener("click", () => {
+  modal.classList.add("hidden");
+  startGame();
+});
 
 function resetGame() {
   started = false;

--- a/public/Simon_Says_Game/style.css
+++ b/public/Simon_Says_Game/style.css
@@ -390,3 +390,45 @@ body.dark .instructions{
   .btn { width: 100px; height: 100px; }
   .controls { gap: 12px; }
 }
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.7);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: white;
+  padding: 30px;
+  border-radius: 16px;
+  text-align: center;
+  min-width: 300px;
+}
+
+.modal-content h2 {
+  margin-bottom: 15px;
+}
+
+.modal-content button {
+  margin-top: 15px;
+  padding: 12px 24px;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  background: #ff6b6b;
+  color: white;
+  font-weight: bold;
+}
+
+body.dark .modal-content {
+  background: #16213e;
+  color: white;
+}


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #7858 

### Summary
This PR adds dedicated Game Over and Victory popups to the Simon Says Game.

- Displays a Game Over modal with final score, highest score, and restart option.
- Displays a Victory modal when the player reaches the maximum level (20).
- Reuses a common modal component for both end-game states.
- Improves user feedback and overall gameplay experience by providing clear end-state actions.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added reusable modal popup component for end-game states.
- Added Game Over popup displaying final score, highest score, and restart action.
- Added Victory popup when the player reaches level 20.
- Added Play Again functionality from the modal.
- Added modal styling with dark mode support.
- Integrated modal triggers into existing game over and victory logic.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [ ] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [x] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
<img width="959" height="506" alt="Screenshot 2026-06-11 215850" src="https://github.com/user-attachments/assets/68a66978-156c-40f4-a05c-8a78ac079a99" />
<img width="959" height="509" alt="Screenshot 2026-06-11 220013" src="https://github.com/user-attachments/assets/5560d014-db48-4d37-89c7-b1f101af1c95" />

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
