### PR TITLE
fix: fill the YouTube homepage video grid

### DIFF
--- a/public/youtube clone/styles/video.css
+++ b/public/youtube clone/styles/video.css
@@ -45,6 +45,13 @@
   box-sizing: border-box;
 }
 
+.video-grid-filler {
+  opacity: 0.42;
+  filter: grayscale(1);
+  pointer-events: none;
+  user-select: none;
+}
+
 @media (max-width: 750px) {
   .video-grid {
     grid-template-columns: 1fr 1fr;

--- a/public/youtube clone/youtube.js
+++ b/public/youtube clone/youtube.js
@@ -96,6 +96,58 @@ document.addEventListener('DOMContentLoaded', () => {
       filterBar.scrollBy({ left: 200, behavior: 'smooth' });
     });
   }
+
+  /* ── Video grid padding ────────────────────────────────────── */
+  const videoGrid = document.querySelector('.video-grid');
+
+  function syncVideoGridFillers() {
+    if (!videoGrid) return;
+
+    videoGrid.querySelectorAll('.video-grid-filler').forEach(filler => filler.remove());
+
+    const visibleCards = Array.from(videoGrid.querySelectorAll('.video-preview:not(.video-grid-filler)'));
+    if (visibleCards.length === 0) return;
+
+    const columnCount = getComputedStyle(videoGrid)
+      .gridTemplateColumns
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean).length;
+
+    if (columnCount <= 1) return;
+
+    const remainder = visibleCards.length % columnCount;
+    const fillerCount = remainder === 0 ? 0 : columnCount - remainder;
+
+    for (let i = 0; i < fillerCount; i += 1) {
+      const filler = visibleCards[0].cloneNode(true);
+      filler.classList.add('video-grid-filler');
+      filler.setAttribute('aria-hidden', 'true');
+      filler.setAttribute('tabindex', '-1');
+
+      const title = filler.querySelector('.video-title');
+      const author = filler.querySelector('.video-author');
+      const stats = filler.querySelector('.video-stats');
+      if (title) title.textContent = 'More videos coming soon';
+      if (author) author.textContent = ' ';
+      if (stats) stats.textContent = ' ';
+
+      videoGrid.appendChild(filler);
+    }
+  }
+
+  let fillerFrame = null;
+  function scheduleGridFillers() {
+    if (fillerFrame) cancelAnimationFrame(fillerFrame);
+    fillerFrame = requestAnimationFrame(() => {
+      fillerFrame = null;
+      syncVideoGridFillers();
+    });
+  }
+
+  scheduleGridFillers();
+  window.addEventListener('resize', scheduleGridFillers);
+  window.addEventListener('load', scheduleGridFillers);
 /* ── Sidebar navigation ─────────────────────────────────────── */
   document.querySelectorAll('.sidebar-link').forEach(link => {
     link.addEventListener('click', () => {


### PR DESCRIPTION
Summary
- Pad the YouTube homepage grid with placeholder cards so the final row stays visually balanced
- Recompute placeholders on resize so the layout stays aligned across breakpoints
- Keep the real video cards untouched while making the bottom row look intentional instead of incomplete

Validation
- git diff --check
- Browser smoke check on http://127.0.0.1:8000/public/youtube%20clone/index.html

Closes #8021