### PR TITLE
fix: improve youtube clone mobile responsiveness

### DIFF
--- a/public/youtube clone/index.html
+++ b/public/youtube clone/index.html
@@ -1,8 +1,6 @@
 <!DOCTYPE html>
 
-<html data-theme="dark">
-
-<html lang="en">
+<html lang="en" data-theme="dark">
 
   <head>
   <meta charset="UTF-8" />
@@ -183,6 +181,30 @@
         padding-top: calc(55px + 56px + 16px) !important;
       }
 
+      @media (max-width: 750px) {
+        .filter-bar {
+          left: 0;
+          right: 0;
+          height: 48px;
+          padding: 0 12px;
+          gap: 8px;
+        }
+
+        .filter-chip {
+          height: 30px;
+          padding: 0 10px;
+          font-size: 13px;
+        }
+
+        .filter-bar-arrow {
+          display: none;
+        }
+
+        main {
+          padding-top: calc(55px + 48px + 12px) !important;
+        }
+      }
+
       /* Sidebar icon label visibility */
       html[data-theme="dark"] .sidebar-link div {
         font-size: 10px;
@@ -197,8 +219,6 @@
 
 
     <a href="/" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 12px;border-radius:8px;background:linear-gradient(90deg,rgba(124,99,255,0.25),rgba(79,141,255,0.18));color:#fff;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter,system-ui,sans-serif;box-shadow:0 8px 20px rgba(12,18,40,0.5);">← Back to Home</a>
-
-<a href="/" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 16px;border-radius:8px;background:#1e293b;color:#3b82f6;border:1px solid #3b82f6;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;transition:all 0.2s ease;" onmouseover="this.style.background='#3b82f6';this.style.color='#fff'" onmouseout="this.style.background='#1e293b';this.style.color='#3b82f6'">← Back to Home</a>
 
 
     <header class="header">

--- a/public/youtube clone/styles/header.css
+++ b/public/youtube clone/styles/header.css
@@ -76,6 +76,74 @@
   font-size: 16px;
 }
 
+@media (max-width: 750px) {
+  .header {
+    padding-right: 8px;
+  }
+
+  .left-section {
+    padding-left: 8px;
+  }
+
+  .hamburger-menu {
+    margin-left: 8px;
+    margin-right: 12px;
+  }
+
+  .middle-section {
+    margin-left: 0;
+    margin-right: 8px;
+    max-width: none;
+    min-width: 0;
+  }
+
+  .search-bar {
+    min-width: 0;
+    font-size: 14px;
+    padding-left: 12px;
+  }
+
+  .search-bar::placeholder {
+    font-size: 14px;
+  }
+
+  .search-button {
+    width: 52px;
+    margin-right: 8px;
+  }
+
+  .voice-search-button {
+    display: none;
+  }
+
+  .right-section {
+    gap: 8px;
+    margin-right: 8px;
+  }
+
+  .create-button {
+    width: 40px;
+    padding: 0;
+    border-radius: 50%;
+    justify-content: center;
+  }
+
+  .create-button span {
+    display: none;
+  }
+
+  .notifications-container,
+  .avatar-container {
+    width: 36px;
+    height: 36px;
+  }
+
+  .badge {
+    top: 0;
+    left: 18px;
+  }
+}
+
 
 .search-button {
   display: flex;

--- a/public/youtube clone/styles/sidebar.css
+++ b/public/youtube clone/styles/sidebar.css
@@ -74,7 +74,7 @@ body.sidebar-expanded .sidebar-link {
   .sidebar {
     left: -240px;
     width: 240px;
-    height: calc(100vh - 50px);
+    height: calc(100vh - 55px);
   }
 
   body.sidebar-expanded .sidebar {

--- a/public/youtube clone/styles/video.css
+++ b/public/youtube clone/styles/video.css
@@ -47,7 +47,37 @@
 
 @media (max-width: 750px) {
   .video-grid {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: 1fr;
+    margin-left: 0;
+    width: 100%;
+    padding: 0 12px;
+    column-gap: 0;
+    row-gap: 28px;
+    box-sizing: border-box;
+  }
+
+  .video-info-grid {
+    grid-template-columns: 40px 1fr;
+    column-gap: 10px;
+  }
+
+  .profile-picture {
+    width: 32px;
+  }
+
+  .video-title {
+    font-size: 13px;
+    line-height: 18px;
+    overflow-wrap: anywhere;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .video-author,
+  .video-stats {
+    font-size: 11px;
   }
 }
 


### PR DESCRIPTION
## Summary\n- Make the YouTube clone header compress cleanly on mobile\n- Turn the filter chips row into a full-width mobile strip\n- Switch the video grid to a single readable column on small screens\n- Remove duplicate root markup and duplicate Back to Home CTA that were cluttering the page\n\n## Validation\n- git diff --check\n- Browser smoke check at 390px width confirmed the grid is one column, the filter bar starts at 0px, the filter arrow is hidden, and the page does not overflow horizontally\n\nCloses #7963