### PR TITLE
fix: remove duplicate contributors navbar script

### DIFF
--- a/contributors/contributor.html
+++ b/contributors/contributor.html
@@ -199,11 +199,12 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
-    <script src="../index.js"></script>
-
     <!-- ── LOAD NAVBAR INJECTION SCRIPT LAST ── -->
     <script src="../navbar.js" defer></script>
+    <script>
+      window.REPO_OWNER = "dhairyagothi";
+      window.REPO_NAME = "100_days_100_web_project";
+    </script>
     <script src="contributor.js"></script>
-    <script src="../index.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary\n- Remove the duplicate `index.js` include from the contributors page\n- Keep only the repo identifiers needed by the contributor loader\n- Let the shared navbar initialize once instead of being re-bound by duplicate script execution\n\n## Validation\n- git diff --check\n- Browser smoke check on the contributors page at 390px width confirmed the navbar opens cleanly, the page does not overflow horizontally, and the JS error is gone\n\nCloses #4988