### PR TITLE
feat: add tweet character counter with circular progress

### DIFF
--- a/public/Twitter-clone/index.html
+++ b/public/Twitter-clone/index.html
@@ -6,6 +6,29 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Home / X</title>
     <link rel="stylesheet" href="src/output.css">
+    <style>
+        .tweet-composer-ring {
+            width: 3rem;
+            height: 3rem;
+        }
+
+        .tweet-composer-ring circle {
+            fill: none;
+            stroke-width: 2.5;
+        }
+
+        .tweet-composer-track {
+            stroke: rgba(148, 163, 184, 0.22);
+        }
+
+        .tweet-composer-progress {
+            stroke: #60a5fa;
+            stroke-linecap: round;
+            transform: rotate(-90deg);
+            transform-origin: 50% 50%;
+            transition: stroke 160ms ease, stroke-dashoffset 160ms ease;
+        }
+    </style>
 </head>
 
 <body class=" bg-black ">
@@ -61,11 +84,54 @@
                 <div class="cursor-pointer">Following</div>
             </div>
             <div>
-                <div class="mt-14 flex items-center p-3 border border-gray-500">
-                    <img class="h-10 pr-2"
-                        src="https://www.bing.com/th/id/OIP.6cECdI45_I2-tWe4AggXMQAAAA?w=180&h=180&c=8&rs=1&qlt=90&o=6&dpr=1.3&pid=3.1&rm=2"
-                        alt=""><input class="w-xl p-3 outline-none focus:outline-none focus:ring-0 " type="text"
-                        placeholder="What's Happening?">
+                <div class="mt-14 border border-gray-500 p-3">
+                    <div class="flex items-start gap-3">
+                        <img class="h-10 w-10 shrink-0 rounded-4xl object-cover"
+                            src="https://www.bing.com/th/id/OIP.6cECdI45_I2-tWe4AggXMQAAAA?w=180&h=180&c=8&rs=1&qlt=90&o=6&dpr=1.3&pid=3.1&rm=2"
+                            alt="">
+                        <div class="min-w-0 flex-1">
+                            <label for="tweet-composer" class="sr-only">Compose a post</label>
+                            <textarea id="tweet-composer" rows="3" spellcheck="false"
+                                class="w-full resize-none border-0 bg-transparent p-0 text-xl outline-none placeholder:text-gray-500 focus:outline-none"
+                                placeholder="What's Happening?"></textarea>
+                            <div class="mt-5 flex flex-wrap items-center justify-between gap-4">
+                                <div class="flex items-center gap-2 text-blue-400">
+                                    <button type="button"
+                                        class="rounded-full p-2 transition hover:bg-white/10"
+                                        aria-label="Add media">
+                                        <img class="h-5 w-5" src="assets/view.svg" alt="">
+                                    </button>
+                                    <button type="button"
+                                        class="rounded-full p-2 transition hover:bg-white/10"
+                                        aria-label="Add emoji">
+                                        <img class="h-5 w-5" src="assets/creator.svg" alt="">
+                                    </button>
+                                    <button type="button"
+                                        class="rounded-full p-2 transition hover:bg-white/10"
+                                        aria-label="Add more options">
+                                        <img class="h-5 w-5" src="assets/more.svg" alt="">
+                                    </button>
+                                </div>
+                                <div class="flex items-center gap-3">
+                                    <div class="flex items-center gap-2">
+                                        <div class="relative h-12 w-12">
+                                            <svg class="tweet-composer-ring" viewBox="0 0 36 36" aria-hidden="true">
+                                                <circle class="tweet-composer-track" cx="18" cy="18" r="14"></circle>
+                                                <circle id="tweet-composer-progress" class="tweet-composer-progress"
+                                                    cx="18" cy="18" r="14"></circle>
+                                            </svg>
+                                            <span id="tweet-composer-remaining"
+                                                class="absolute inset-0 flex items-center justify-center text-[11px] font-bold text-gray-300">280</span>
+                                        </div>
+                                        <span class="text-sm text-gray-400">chars left</span>
+                                    </div>
+                                    <button id="tweet-post-button" type="button"
+                                        class="rounded-4xl bg-blue-400 px-6 py-2 font-bold text-black transition hover:bg-blue-500 disabled:cursor-not-allowed disabled:bg-blue-400/40 disabled:text-black/50"
+                                        disabled>Post</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
                 </div>
                 <div class="w-xl border border-gray-500">
                     <div class="border border-gray-500 border-t-0 text-center text-blue-400 p-3 cursor-pointer">Show 1,897 posts</div>
@@ -375,6 +441,63 @@
 
         </div>
     </div>
+    <script>
+        (() => {
+            const composer = document.getElementById('tweet-composer');
+            const progress = document.getElementById('tweet-composer-progress');
+            const remaining = document.getElementById('tweet-composer-remaining');
+            const postButton = document.getElementById('tweet-post-button');
+
+            if (!composer || !progress || !remaining || !postButton) {
+                return;
+            }
+
+            const MAX_CHARS = 280;
+            const WARN_THRESHOLD = 20;
+            const CIRCUMFERENCE = 2 * Math.PI * 14;
+
+            progress.style.strokeDasharray = `${CIRCUMFERENCE}`;
+            progress.style.strokeDashoffset = `${CIRCUMFERENCE}`;
+
+            const setState = (mode) => {
+                if (mode === 'danger') {
+                    progress.setAttribute('stroke', '#f87171');
+                    progress.style.stroke = '#f87171';
+                    remaining.className = 'absolute inset-0 flex items-center justify-center text-[11px] font-bold text-red-300';
+                } else if (mode === 'warn') {
+                    progress.setAttribute('stroke', '#facc15');
+                    progress.style.stroke = '#facc15';
+                    remaining.className = 'absolute inset-0 flex items-center justify-center text-[11px] font-bold text-yellow-300';
+                } else {
+                    progress.setAttribute('stroke', '#60a5fa');
+                    progress.style.stroke = '#60a5fa';
+                    remaining.className = 'absolute inset-0 flex items-center justify-center text-[11px] font-bold text-gray-300';
+                }
+            };
+
+            const updateComposer = () => {
+                const count = composer.value.length;
+                const charsLeft = MAX_CHARS - count;
+                const clampedProgress = Math.min(count, MAX_CHARS) / MAX_CHARS;
+
+                progress.style.strokeDashoffset = `${CIRCUMFERENCE * (1 - clampedProgress)}`;
+                remaining.textContent = `${charsLeft}`;
+
+                if (charsLeft < 0) {
+                    setState('danger');
+                } else if (charsLeft <= WARN_THRESHOLD) {
+                    setState('warn');
+                } else {
+                    setState('normal');
+                }
+
+                postButton.disabled = count === 0 || charsLeft < 0;
+            };
+
+            composer.addEventListener('input', updateComposer);
+            updateComposer();
+        })();
+    </script>
 </body>
 
 </html>

--- a/public/Twitter-clone/src/output.css
+++ b/public/Twitter-clone/src/output.css
@@ -7,10 +7,11 @@
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
-    --color-red-500: oklch(63.7% 0.237 25.331);
+    --color-red-300: oklch(80.8% 0.114 19.571);
+    --color-yellow-300: oklch(90.5% 0.182 98.111);
     --color-blue-400: oklch(70.7% 0.165 254.624);
     --color-blue-500: oklch(62.3% 0.214 259.815);
-    --color-blue-800: oklch(42.4% 0.199 265.638);
+    --color-gray-300: oklch(87.2% 0.01 258.338);
     --color-gray-400: oklch(70.7% 0.022 261.325);
     --color-gray-500: oklch(55.1% 0.027 264.364);
     --color-gray-900: oklch(21% 0.034 264.665);
@@ -32,6 +33,8 @@
     --radius-xl: 0.75rem;
     --radius-2xl: 1rem;
     --radius-4xl: 2rem;
+    --default-transition-duration: 150ms;
+    --default-transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
   }
@@ -185,6 +188,17 @@
   }
 }
 @layer utilities {
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border-width: 0;
+  }
   .absolute {
     position: absolute;
   }
@@ -196,6 +210,9 @@
   }
   .sticky {
     position: sticky;
+  }
+  .inset-0 {
+    inset: calc(var(--spacing) * 0);
   }
   .top-0 {
     top: calc(var(--spacing) * 0);
@@ -224,8 +241,8 @@
       max-width: 96rem;
     }
   }
-  .mt-0 {
-    margin-top: calc(var(--spacing) * 0);
+  .mt-5 {
+    margin-top: calc(var(--spacing) * 5);
   }
   .mt-10 {
     margin-top: calc(var(--spacing) * 10);
@@ -233,14 +250,8 @@
   .mt-14 {
     margin-top: calc(var(--spacing) * 14);
   }
-  .mb-10 {
-    margin-bottom: calc(var(--spacing) * 10);
-  }
   .mb-20 {
     margin-bottom: calc(var(--spacing) * 20);
-  }
-  .ml-8 {
-    margin-left: calc(var(--spacing) * 8);
   }
   .ml-12 {
     margin-left: calc(var(--spacing) * 12);
@@ -254,17 +265,8 @@
   .flex {
     display: flex;
   }
-  .table {
-    display: table;
-  }
-  .h-2 {
-    height: calc(var(--spacing) * 2);
-  }
   .h-5 {
     height: calc(var(--spacing) * 5);
-  }
-  .h-6 {
-    height: calc(var(--spacing) * 6);
   }
   .h-8 {
     height: calc(var(--spacing) * 8);
@@ -275,11 +277,20 @@
   .h-10 {
     height: calc(var(--spacing) * 10);
   }
+  .h-12 {
+    height: calc(var(--spacing) * 12);
+  }
   .h-14 {
     height: calc(var(--spacing) * 14);
   }
-  .w-6 {
-    width: calc(var(--spacing) * 6);
+  .w-5 {
+    width: calc(var(--spacing) * 5);
+  }
+  .w-10 {
+    width: calc(var(--spacing) * 10);
+  }
+  .w-12 {
+    width: calc(var(--spacing) * 12);
   }
   .w-96 {
     width: calc(var(--spacing) * 96);
@@ -293,23 +304,35 @@
   .w-xl {
     width: var(--container-xl);
   }
+  .min-w-0 {
+    min-width: calc(var(--spacing) * 0);
+  }
   .flex-1 {
     flex: 1;
   }
-  .border-collapse {
-    border-collapse: collapse;
+  .shrink-0 {
+    flex-shrink: 0;
+  }
+  .transform {
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
   .cursor-pointer {
     cursor: pointer;
   }
-  .resize {
-    resize: both;
+  .resize-none {
+    resize: none;
   }
   .flex-col {
     flex-direction: column;
   }
+  .flex-wrap {
+    flex-wrap: wrap;
+  }
   .items-center {
     align-items: center;
+  }
+  .items-start {
+    align-items: flex-start;
   }
   .justify-around {
     justify-content: space-around;
@@ -319,18 +342,6 @@
   }
   .justify-center {
     justify-content: center;
-  }
-  .justify-evenly {
-    justify-content: space-evenly;
-  }
-  .justify-start {
-    justify-content: flex-start;
-  }
-  .justify-items-stretch {
-    justify-items: stretch;
-  }
-  .gap-0 {
-    gap: calc(var(--spacing) * 0);
   }
   .gap-1 {
     gap: calc(var(--spacing) * 1);
@@ -350,9 +361,6 @@
   .gap-6 {
     gap: calc(var(--spacing) * 6);
   }
-  .gap-10 {
-    gap: calc(var(--spacing) * 10);
-  }
   .gap-14 {
     gap: calc(var(--spacing) * 14);
   }
@@ -365,38 +373,11 @@
   .gap-27 {
     gap: calc(var(--spacing) * 27);
   }
-  .gap-30 {
-    gap: calc(var(--spacing) * 30);
-  }
-  .gap-31 {
-    gap: calc(var(--spacing) * 31);
-  }
-  .gap-32 {
-    gap: calc(var(--spacing) * 32);
-  }
-  .gap-33 {
-    gap: calc(var(--spacing) * 33);
-  }
-  .gap-34 {
-    gap: calc(var(--spacing) * 34);
-  }
   .gap-36 {
     gap: calc(var(--spacing) * 36);
   }
   .gap-40 {
     gap: calc(var(--spacing) * 40);
-  }
-  .gap-42 {
-    gap: calc(var(--spacing) * 42);
-  }
-  .gap-43 {
-    gap: calc(var(--spacing) * 43);
-  }
-  .gap-44 {
-    gap: calc(var(--spacing) * 44);
-  }
-  .gap-45 {
-    gap: calc(var(--spacing) * 45);
   }
   .gap-46 {
     gap: calc(var(--spacing) * 46);
@@ -404,32 +385,14 @@
   .gap-48 {
     gap: calc(var(--spacing) * 48);
   }
-  .gap-50 {
-    gap: calc(var(--spacing) * 50);
-  }
-  .gap-55 {
-    gap: calc(var(--spacing) * 55);
-  }
   .gap-58 {
     gap: calc(var(--spacing) * 58);
-  }
-  .gap-60 {
-    gap: calc(var(--spacing) * 60);
   }
   .gap-63 {
     gap: calc(var(--spacing) * 63);
   }
-  .gap-65 {
-    gap: calc(var(--spacing) * 65);
-  }
   .gap-70 {
     gap: calc(var(--spacing) * 70);
-  }
-  .gap-80 {
-    gap: calc(var(--spacing) * 80);
-  }
-  .rounded {
-    border-radius: 0.25rem;
   }
   .rounded-2xl {
     border-radius: var(--radius-2xl);
@@ -437,12 +400,19 @@
   .rounded-4xl {
     border-radius: var(--radius-4xl);
   }
+  .rounded-full {
+    border-radius: calc(infinity * 1px);
+  }
   .rounded-xl {
     border-radius: var(--radius-xl);
   }
   .border {
     border-style: var(--tw-border-style);
     border-width: 1px;
+  }
+  .border-0 {
+    border-style: var(--tw-border-style);
+    border-width: 0px;
   }
   .border-t-0 {
     border-top-style: var(--tw-border-style);
@@ -463,8 +433,17 @@
   .bg-blue-400 {
     background-color: var(--color-blue-400);
   }
+  .bg-transparent {
+    background-color: transparent;
+  }
   .bg-white {
     background-color: var(--color-white);
+  }
+  .object-cover {
+    object-fit: cover;
+  }
+  .p-0 {
+    padding: calc(var(--spacing) * 0);
   }
   .p-1 {
     padding: calc(var(--spacing) * 1);
@@ -478,14 +457,14 @@
   .p-4 {
     padding: calc(var(--spacing) * 4);
   }
-  .p-5 {
-    padding: calc(var(--spacing) * 5);
-  }
   .p-8 {
     padding: calc(var(--spacing) * 8);
   }
-  .p-10 {
-    padding: calc(var(--spacing) * 10);
+  .px-6 {
+    padding-inline: calc(var(--spacing) * 6);
+  }
+  .py-2 {
+    padding-block: calc(var(--spacing) * 2);
   }
   .pt-0 {
     padding-top: calc(var(--spacing) * 0);
@@ -547,6 +526,13 @@
     font-size: var(--text-sm);
     line-height: var(--tw-leading, var(--text-sm--line-height));
   }
+  .text-xl {
+    font-size: var(--text-xl);
+    line-height: var(--tw-leading, var(--text-xl--line-height));
+  }
+  .text-\[11px\] {
+    font-size: 11px;
+  }
   .font-bold {
     --tw-font-weight: var(--font-weight-bold);
     font-weight: var(--font-weight-bold);
@@ -561,27 +547,56 @@
   .text-blue-400 {
     color: var(--color-blue-400);
   }
+  .text-gray-300 {
+    color: var(--color-gray-300);
+  }
   .text-gray-400 {
     color: var(--color-gray-400);
+  }
+  .text-red-300 {
+    color: var(--color-red-300);
   }
   .text-white {
     color: var(--color-white);
   }
-  .underline {
-    text-decoration-line: underline;
+  .text-yellow-300 {
+    color: var(--color-yellow-300);
   }
-  .outline {
-    outline-style: var(--tw-outline-style);
-    outline-width: 1px;
+  .transition {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, content-visibility, overlay, pointer-events;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
   }
   .outline-none {
     --tw-outline-style: none;
     outline-style: none;
   }
+  .placeholder\:text-gray-500 {
+    &::placeholder {
+      color: var(--color-gray-500);
+    }
+  }
+  .hover\:bg-blue-500 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: var(--color-blue-500);
+      }
+    }
+  }
   .hover\:bg-gray-900 {
     &:hover {
       @media (hover: hover) {
         background-color: var(--color-gray-900);
+      }
+    }
+  }
+  .hover\:bg-white\/10 {
+    &:hover {
+      @media (hover: hover) {
+        background-color: color-mix(in srgb, #fff 10%, transparent);
+        @supports (color: color-mix(in lab, red, red)) {
+          background-color: color-mix(in oklab, var(--color-white) 10%, transparent);
+        }
       }
     }
   }
@@ -604,6 +619,47 @@
       outline-style: none;
     }
   }
+  .disabled\:cursor-not-allowed {
+    &:disabled {
+      cursor: not-allowed;
+    }
+  }
+  .disabled\:bg-blue-400\/40 {
+    &:disabled {
+      background-color: color-mix(in srgb, oklch(70.7% 0.165 254.624) 40%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        background-color: color-mix(in oklab, var(--color-blue-400) 40%, transparent);
+      }
+    }
+  }
+  .disabled\:text-black\/50 {
+    &:disabled {
+      color: color-mix(in srgb, #000 50%, transparent);
+      @supports (color: color-mix(in lab, red, red)) {
+        color: color-mix(in oklab, var(--color-black) 50%, transparent);
+      }
+    }
+  }
+}
+@property --tw-rotate-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-y {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-z {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-y {
+  syntax: "*";
+  inherits: false;
 }
 @property --tw-border-style {
   syntax: "*";
@@ -613,11 +669,6 @@
 @property --tw-font-weight {
   syntax: "*";
   inherits: false;
-}
-@property --tw-outline-style {
-  syntax: "*";
-  inherits: false;
-  initial-value: solid;
 }
 @property --tw-shadow {
   syntax: "*";
@@ -687,9 +738,13 @@
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
+      --tw-rotate-x: initial;
+      --tw-rotate-y: initial;
+      --tw-rotate-z: initial;
+      --tw-skew-x: initial;
+      --tw-skew-y: initial;
       --tw-border-style: solid;
       --tw-font-weight: initial;
-      --tw-outline-style: solid;
       --tw-shadow: 0 0 #0000;
       --tw-shadow-color: initial;
       --tw-shadow-alpha: 100%;


### PR DESCRIPTION
## Related Issue\n\nCloses #8027\n\n## Summary\n- Replaced the static tweet composer input with a textarea and live character counter\n- Added a circular SVG progress ring that fills as text is entered\n- Swaps ring / counter colors to yellow near the limit and red when over 280\n- Disables Post when the composer is empty or over limit\n\n## Verification\n- git diff --check\n- npm run build (Twitter-clone)\n- Playwright smoke check on http://127.0.0.1:8002/\n  - 264 chars remaining shows blue state\n  - 15 chars remaining shows yellow state\n  - -1 chars remaining shows red state and disables Post\n