### PR TITLE
feat: add twitter infinite scroll with skeleton loading

### DIFF
--- a/public/Twitter-clone/index.html
+++ b/public/Twitter-clone/index.html
@@ -6,6 +6,56 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Home / X</title>
     <link rel="stylesheet" href="src/output.css">
+    <style>
+        .tweet-feed-shell {
+            position: relative;
+        }
+
+        .tweet-skeleton-card {
+            position: relative;
+            overflow: hidden;
+            background: #080808;
+        }
+
+        .tweet-skeleton-card::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            transform: translateX(-100%);
+            background: linear-gradient(90deg,
+                    rgba(31, 41, 55, 0) 0%,
+                    rgba(55, 65, 81, 0.55) 50%,
+                    rgba(31, 41, 55, 0) 100%);
+            animation: tweet-skeleton-shimmer 1.25s ease-in-out infinite;
+        }
+
+        @keyframes tweet-skeleton-shimmer {
+            100% {
+                transform: translateX(100%);
+            }
+        }
+
+        .tweet-skeleton-bar,
+        .tweet-skeleton-circle,
+        .tweet-skeleton-rect {
+            position: relative;
+            z-index: 1;
+            background: linear-gradient(90deg, #1f2937 25%, #374151 37%, #1f2937 63%);
+            background-size: 400% 100%;
+            animation: tweet-skeleton-pulse 1.2s ease-in-out infinite;
+        }
+
+        @keyframes tweet-skeleton-pulse {
+            0%,
+            100% {
+                background-position: 200% 0;
+            }
+
+            50% {
+                background-position: -200% 0;
+            }
+        }
+    </style>
 </head>
 
 <body class=" bg-black ">
@@ -84,149 +134,8 @@
                         </div>
                     </div>
                 </div>
-
-
-                <div class="border border-gray-400 p-3">
-                    <div class="flex items-center gap-2">
-                        <div> <img class="h-8 pr-2"
-                        src="https://www.bing.com/th/id/OIP.6cECdI45_I2-tWe4AggXMQAAAA?w=180&h=180&c=8&rs=1&qlt=90&o=6&dpr=1.3&pid=3.1&rm=2"
-                        alt=""></div>
-                        <span class="font-bold">THE KIINE</span>
-                        <div class="font-thin text-gray-400 text-sm flex gap-70">
-                            <span>@asherkiine • 16h</span>
-                            <span class="cursor-pointer hover:text-blue-400">•••</span>
-                        </div>
-                    </div>
-                    <div class="ml-12 flex flex-col gap-3">
-
-                        <div>What number do you see? <br>
-                            
-                            RT LEVEL- VERY HARD Nobody is yet to find the number <br>
-                            
-                            Correct answer wins $6,000 <br>
-                            
-                            Ends 87hrs</div>
-                            <div><img class="rounded-2xl" src="https://pbs.twimg.com/media/HJK8ldSXAAAXcsz?format=jpg&name=small" alt=""></div>
-                            <div class="flex justify-around">
-                                <span class="flex gap-1 items-center cursor-pointer">
-                                    <img src="assets/comment.svg" alt="">
-                                    <span class="font-thin text-gray-400 text-sm">
-                                        7.9K
-                                    </span>
-                                </span>
-                                <span class="flex gap-1 items-center cursor-pointer">
-                                    <img src="assets/repost.svg" alt="">
-                                    <span class="font-thin text-gray-400 text-sm">
-                                        7.9K
-                                    </span>
-                                </span>
-                                <span class="flex gap-1 items-center cursor-pointer">
-                                    <img src="assets/like.svg" alt="">
-                                    <span class="font-thin text-gray-400 text-sm">
-                                        7.9K
-                                    </span>
-                                </span>
-                                <span class="flex gap-1 items-center cursor-pointer">
-                                    <img src="assets/view.svg" alt="">
-                                    <span class="font-thin text-gray-400 text-sm">
-                                        7.9K
-                                    </span>
-                                </span>
-                            </div>
-                        </div>
-                </div>
-
-
-
-                <div class="border border-gray-400 p-3">
-                    <div class="flex items-center gap-2">
-                        <div> <img class="h-8 pr-2"
-                        src="https://www.bing.com/th/id/OIP.6cECdI45_I2-tWe4AggXMQAAAA?w=180&h=180&c=8&rs=1&qlt=90&o=6&dpr=1.3&pid=3.1&rm=2"
-                        alt=""></div>
-                        <span class="font-bold">Echo</span>
-                        <div class="font-thin text-gray-400 text-sm flex gap-63">
-                            <span>@BrokenDreamszz • 25 May</span>
-                            <span class="cursor-pointer hover:text-blue-400">•••</span>
-                        </div>
-                    </div>
-                    <div class="ml-12 flex flex-col gap-3">
-                            <div><img class="rounded-2xl" src="https://pbs.twimg.com/media/HJJQZ4faIAEHG6_?format=jpg&name=small" alt=""></div>
-                            <div class="flex justify-around">
-                                <span class="flex gap-1 items-center cursor-pointer">
-                                    <img src="assets/comment.svg" alt="">
-                                    <span class="font-thin text-gray-400 text-sm">
-                                        7.9K
-                                    </span>
-                                </span>
-                                <span class="flex gap-1 items-center cursor-pointer">
-                                    <img src="assets/repost.svg" alt="">
-                                    <span class="font-thin text-gray-400 text-sm">
-                                        7.9K
-                                    </span>
-                                </span>
-                                <span class="flex gap-1 items-center cursor-pointer">
-                                    <img src="assets/like.svg" alt="">
-                                    <span class="font-thin text-gray-400 text-sm">
-                                        7.9K
-                                    </span>
-                                </span>
-                                <span class="flex gap-1 items-center cursor-pointer">
-                                    <img src="assets/view.svg" alt="">
-                                    <span class="font-thin text-gray-400 text-sm">
-                                        7.9K
-                                    </span>
-                                </span>
-                            </div>
-                        </div>
-                </div>
-
-
-
-                <div class="border border-gray-400 p-3">
-                    <div class="flex items-center gap-2">
-                        <div> <img class="h-8 pr-2"
-                        src="https://www.bing.com/th/id/OIP.6cECdI45_I2-tWe4AggXMQAAAA?w=180&h=180&c=8&rs=1&qlt=90&o=6&dpr=1.3&pid=3.1&rm=2"
-                        alt=""></div>
-                        <span class="font-bold">LeoDaVinciWave</span>
-                        <div class="font-thin text-gray-400 text-sm flex gap-48">
-                            <span>@LeoDaVinciWave • 23h</span>
-                            <span class="cursor-pointer hover:text-blue-400">•••</span>
-                        </div>
-                        
-                    </div>
-                    <div class="ml-12 flex flex-col gap-3">
-
-                        <div>19 years of storage evolution</div>
-                            <div><img class="rounded-2xl" src="https://pbs.twimg.com/media/HJKrIEBasAAbqw9?format=jpg&name=small" alt=""></div>
-                            <div class="flex justify-around">
-                                <span class="flex gap-1 items-center cursor-pointer">
-                                    <img src="assets/comment.svg" alt="">
-                                    <span class="font-thin text-gray-400 text-sm">
-                                        7.9K
-                                    </span>
-                                </span>
-                                <span class="flex gap-1 items-center cursor-pointer">
-                                    <img src="assets/repost.svg" alt="">
-                                    <span class="font-thin text-gray-400 text-sm">
-                                        7.9K
-                                    </span>
-                                </span>
-                                <span class="flex gap-1 items-center cursor-pointer">
-                                    <img src="assets/like.svg" alt="">
-                                    <span class="font-thin text-gray-400 text-sm">
-                                        7.9K
-                                    </span>
-                                </span>
-                                <span class="flex gap-1 items-center cursor-pointer">
-                                    <img src="assets/view.svg" alt="">
-                                    <span class="font-thin text-gray-400 text-sm">
-                                        7.9K
-                                    </span>
-                                </span>
-                            </div>
-                            </div>
-                        </div>
-                    </div>
+                <div id="tweet-feed" class="flex flex-col">
+                    <div id="tweet-feed-sentinel" class="h-px w-full"></div>
                 </div>
                 
 
@@ -375,6 +284,238 @@
 
         </div>
     </div>
+    <script>
+        (() => {
+            const feed = document.getElementById('tweet-feed');
+            const sentinel = document.getElementById('tweet-feed-sentinel');
+            if (!feed || !sentinel) {
+                return;
+            }
+
+            const posts = [
+                {
+                    author: 'THE KIINE',
+                    handle: '@asherkiine',
+                    time: '16h',
+                    text: 'What number do you see? RT LEVEL- VERY HARD Nobody is yet to find the number. Correct answer wins $6,000. Ends 87hrs.',
+                    image: 'https://pbs.twimg.com/media/HJK8ldSXAAAXcsz?format=jpg&name=small',
+                    stats: ['7.9K', '7.9K', '7.9K', '7.9K']
+                },
+                {
+                    author: 'Echo',
+                    handle: '@BrokenDreamszz',
+                    time: '25 May',
+                    text: 'Some ideas need a slower rollout. Small batches, strong signals, and clean visuals make a feed feel alive.',
+                    image: 'https://pbs.twimg.com/media/HJJQZ4faIAEHG6_?format=jpg&name=small',
+                    stats: ['1.2K', '3.1K', '8.9K', '14K']
+                },
+                {
+                    author: 'LeoDaVinciWave',
+                    handle: '@LeoDaVinciWave',
+                    time: '23h',
+                    text: '19 years of storage evolution. Sometimes the best UX is just giving the user the next thing right when they ask for it.',
+                    image: 'https://pbs.twimg.com/media/HJKrIEBasAAbqw9?format=jpg&name=small',
+                    stats: ['943', '4.8K', '11K', '9.4K']
+                },
+                {
+                    author: 'PixelPulse',
+                    handle: '@pixelpulsehq',
+                    time: '11h',
+                    text: 'Infinite scroll only feels smooth when the next items arrive before the user thinks about waiting.'
+                },
+                {
+                    author: 'MayaBuilds',
+                    handle: '@mayabuilds',
+                    time: '8h',
+                    text: 'Skeleton loading keeps the interface honest. You can see the shape of the feed before the content lands.',
+                    image: 'https://images.unsplash.com/photo-1516321318423-f06f85e504b3?auto=format&fit=crop&w=1200&q=80'
+                },
+                {
+                    author: 'CloudDrift',
+                    handle: '@clouddrift',
+                    time: '6h',
+                    text: 'Batched rendering beats dumping the entire timeline onto the page at once. The browser gets to breathe.'
+                },
+                {
+                    author: 'AishaCodes',
+                    handle: '@aishacodes',
+                    time: '4h',
+                    text: 'A polished feed needs motion, but it also needs restraint. Loading states are part of the design system.',
+                    image: 'https://images.unsplash.com/photo-1498050108023-c5249f4df085?auto=format&fit=crop&w=1200&q=80'
+                },
+                {
+                    author: 'MarinaByte',
+                    handle: '@marinabyte',
+                    time: '3h',
+                    text: 'When the content is longer than the viewport, the observer should quietly keep the next chunk ready.'
+                },
+                {
+                    author: 'RohanBuilds',
+                    handle: '@rohanbuilds',
+                    time: '2h',
+                    text: 'This is the kind of feature users notice only when it is missing. That is usually a good sign.'
+                },
+                {
+                    author: 'SiennaNotes',
+                    handle: '@siennanotes',
+                    time: '1h',
+                    text: 'A skeleton card should feel like the feed is already there, just still arriving.',
+                    image: 'https://images.unsplash.com/photo-1522199794611-8a4c9b20d2a8?auto=format&fit=crop&w=1200&q=80'
+                },
+                {
+                    author: 'TuringLoop',
+                    handle: '@turingloop',
+                    time: '41m',
+                    text: 'IntersectionObserver is the nicest way to say “load the next thing when the user gets close.”'
+                },
+                {
+                    author: 'VibeMatrix',
+                    handle: '@vibematrix',
+                    time: '12m',
+                    text: 'The best infinite feeds do less work upfront and more work exactly when it becomes useful.'
+                }
+            ];
+
+            const batchSize = 4;
+            const prefetchMargin = 1200;
+            let nextIndex = 0;
+            let loading = false;
+            let observer;
+
+            const createActions = (stats) => `
+                <div class="flex justify-around">
+                    <span class="flex gap-1 items-center cursor-pointer">
+                        <img src="assets/comment.svg" alt="">
+                        <span class="font-thin text-gray-400 text-sm">${stats?.[0] ?? '1.2K'}</span>
+                    </span>
+                    <span class="flex gap-1 items-center cursor-pointer">
+                        <img src="assets/repost.svg" alt="">
+                        <span class="font-thin text-gray-400 text-sm">${stats?.[1] ?? '4.1K'}</span>
+                    </span>
+                    <span class="flex gap-1 items-center cursor-pointer">
+                        <img src="assets/like.svg" alt="">
+                        <span class="font-thin text-gray-400 text-sm">${stats?.[2] ?? '9.7K'}</span>
+                    </span>
+                    <span class="flex gap-1 items-center cursor-pointer">
+                        <img src="assets/view.svg" alt="">
+                        <span class="font-thin text-gray-400 text-sm">${stats?.[3] ?? '18K'}</span>
+                    </span>
+                </div>`;
+
+            const renderPost = (post) => `
+                <article class="border border-gray-400 p-3">
+                    <div class="flex items-center gap-2">
+                        <div>
+                            <img class="h-8 pr-2 rounded-full object-cover"
+                                src="https://www.bing.com/th/id/OIP.6cECdI45_I2-tWe4AggXMQAAAA?w=180&h=180&c=8&rs=1&qlt=90&o=6&dpr=1.3&pid=3.1&rm=2"
+                                alt="">
+                        </div>
+                        <span class="font-bold">${post.author}</span>
+                        <div class="font-thin text-gray-400 text-sm flex flex-1 justify-between gap-4">
+                            <span>${post.handle} • ${post.time}</span>
+                            <span class="cursor-pointer hover:text-blue-400">•••</span>
+                        </div>
+                    </div>
+                    <div class="ml-12 flex flex-col gap-3">
+                        <div>${post.text}</div>
+                        ${post.image ? `<div><img class="rounded-2xl w-full max-h-[28rem] object-cover" loading="lazy" src="${post.image}" alt=""></div>` : ''}
+                        ${createActions(post.stats)}
+                    </div>
+                </article>
+            `;
+
+            const renderSkeleton = () => `
+                <article class="tweet-skeleton-card border border-gray-400 p-3">
+                    <div class="flex items-center gap-2">
+                        <div class="tweet-skeleton-circle h-8 w-8 rounded-full"></div>
+                        <div class="flex flex-1 flex-col gap-2">
+                            <div class="tweet-skeleton-bar h-4 w-1/3 rounded-full"></div>
+                            <div class="tweet-skeleton-bar h-3 w-2/5 rounded-full"></div>
+                        </div>
+                    </div>
+                    <div class="ml-12 mt-4 flex flex-col gap-3">
+                        <div class="tweet-skeleton-bar h-4 w-full rounded-full"></div>
+                        <div class="tweet-skeleton-bar h-4 w-11/12 rounded-full"></div>
+                        <div class="tweet-skeleton-bar h-4 w-4/5 rounded-full"></div>
+                        <div class="tweet-skeleton-rect h-56 rounded-2xl"></div>
+                        <div class="flex justify-around">
+                            <div class="tweet-skeleton-bar h-4 w-14 rounded-full"></div>
+                            <div class="tweet-skeleton-bar h-4 w-14 rounded-full"></div>
+                            <div class="tweet-skeleton-bar h-4 w-14 rounded-full"></div>
+                            <div class="tweet-skeleton-bar h-4 w-14 rounded-full"></div>
+                        </div>
+                    </div>
+                </article>
+            `;
+
+            const setLoading = (state) => {
+                loading = state;
+                sentinel.setAttribute('aria-busy', state ? 'true' : 'false');
+            };
+
+            const shouldPrefetchMore = () => {
+                const sentinelTop = sentinel.getBoundingClientRect().top;
+                return sentinelTop <= window.innerHeight + prefetchMargin;
+            };
+
+            const appendSkeletons = () => {
+                const frag = document.createDocumentFragment();
+                const wrapper = document.createElement('div');
+                wrapper.innerHTML = Array.from({ length: batchSize }, renderSkeleton).join('');
+                while (wrapper.firstChild) {
+                    frag.appendChild(wrapper.firstChild);
+                }
+                feed.insertBefore(frag, sentinel);
+            };
+
+            const removeSkeletons = () => {
+                feed.querySelectorAll('.tweet-skeleton-card').forEach((node) => node.remove());
+            };
+
+            const appendNextBatch = () => {
+                if (loading || nextIndex >= posts.length) {
+                    return;
+                }
+
+                setLoading(true);
+                appendSkeletons();
+
+                window.setTimeout(() => {
+                    removeSkeletons();
+                    const slice = posts.slice(nextIndex, nextIndex + batchSize);
+                    const batch = document.createDocumentFragment();
+                    const wrapper = document.createElement('div');
+                    wrapper.innerHTML = slice.map(renderPost).join('');
+                    while (wrapper.firstChild) {
+                        batch.appendChild(wrapper.firstChild);
+                    }
+                    feed.insertBefore(batch, sentinel);
+                    nextIndex += slice.length;
+                    setLoading(false);
+                    if (nextIndex < posts.length && shouldPrefetchMore()) {
+                        window.setTimeout(appendNextBatch, 50);
+                        return;
+                    }
+                    if (observer && nextIndex >= posts.length) {
+                        observer.disconnect();
+                    }
+                }, 700);
+            };
+
+            observer = new IntersectionObserver((entries) => {
+                if (entries.some((entry) => entry.isIntersecting)) {
+                    appendNextBatch();
+                }
+            }, {
+                root: null,
+                rootMargin: '1200px 0px',
+                threshold: 0.1,
+            });
+
+            observer.observe(sentinel);
+            appendNextBatch();
+        })();
+    </script>
 </body>
 
 </html>

--- a/public/Twitter-clone/src/output.css
+++ b/public/Twitter-clone/src/output.css
@@ -7,10 +7,7 @@
       "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
     --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
       "Courier New", monospace;
-    --color-red-500: oklch(63.7% 0.237 25.331);
     --color-blue-400: oklch(70.7% 0.165 254.624);
-    --color-blue-500: oklch(62.3% 0.214 259.815);
-    --color-blue-800: oklch(42.4% 0.199 265.638);
     --color-gray-400: oklch(70.7% 0.022 261.325);
     --color-gray-500: oklch(55.1% 0.027 264.364);
     --color-gray-900: oklch(21% 0.034 264.665);
@@ -21,8 +18,6 @@
     --container-xl: 36rem;
     --text-sm: 0.875rem;
     --text-sm--line-height: calc(1.25 / 0.875);
-    --text-xl: 1.25rem;
-    --text-xl--line-height: calc(1.75 / 1.25);
     --text-2xl: 1.5rem;
     --text-2xl--line-height: calc(2 / 1.5);
     --text-3xl: 1.875rem;
@@ -32,6 +27,7 @@
     --radius-xl: 0.75rem;
     --radius-2xl: 1rem;
     --radius-4xl: 2rem;
+    --ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
     --default-font-family: var(--font-sans);
     --default-mono-font-family: var(--font-mono);
   }
@@ -185,14 +181,8 @@
   }
 }
 @layer utilities {
-  .absolute {
-    position: absolute;
-  }
   .fixed {
     position: fixed;
-  }
-  .relative {
-    position: relative;
   }
   .sticky {
     position: sticky;
@@ -224,8 +214,8 @@
       max-width: 96rem;
     }
   }
-  .mt-0 {
-    margin-top: calc(var(--spacing) * 0);
+  .mt-4 {
+    margin-top: calc(var(--spacing) * 4);
   }
   .mt-10 {
     margin-top: calc(var(--spacing) * 10);
@@ -233,14 +223,8 @@
   .mt-14 {
     margin-top: calc(var(--spacing) * 14);
   }
-  .mb-10 {
-    margin-bottom: calc(var(--spacing) * 10);
-  }
   .mb-20 {
     margin-bottom: calc(var(--spacing) * 20);
-  }
-  .ml-8 {
-    margin-left: calc(var(--spacing) * 8);
   }
   .ml-12 {
     margin-left: calc(var(--spacing) * 12);
@@ -254,17 +238,14 @@
   .flex {
     display: flex;
   }
-  .table {
-    display: table;
+  .h-3 {
+    height: calc(var(--spacing) * 3);
   }
-  .h-2 {
-    height: calc(var(--spacing) * 2);
+  .h-4 {
+    height: calc(var(--spacing) * 4);
   }
   .h-5 {
     height: calc(var(--spacing) * 5);
-  }
-  .h-6 {
-    height: calc(var(--spacing) * 6);
   }
   .h-8 {
     height: calc(var(--spacing) * 8);
@@ -278,8 +259,32 @@
   .h-14 {
     height: calc(var(--spacing) * 14);
   }
-  .w-6 {
-    width: calc(var(--spacing) * 6);
+  .h-56 {
+    height: calc(var(--spacing) * 56);
+  }
+  .h-px {
+    height: 1px;
+  }
+  .max-h-\[28rem\] {
+    max-height: 28rem;
+  }
+  .w-1\/3 {
+    width: calc(1 / 3 * 100%);
+  }
+  .w-2\/5 {
+    width: calc(2 / 5 * 100%);
+  }
+  .w-4\/5 {
+    width: calc(4 / 5 * 100%);
+  }
+  .w-8 {
+    width: calc(var(--spacing) * 8);
+  }
+  .w-11\/12 {
+    width: calc(11 / 12 * 100%);
+  }
+  .w-14 {
+    width: calc(var(--spacing) * 14);
   }
   .w-96 {
     width: calc(var(--spacing) * 96);
@@ -296,14 +301,11 @@
   .flex-1 {
     flex: 1;
   }
-  .border-collapse {
-    border-collapse: collapse;
+  .transform {
+    transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
   }
   .cursor-pointer {
     cursor: pointer;
-  }
-  .resize {
-    resize: both;
   }
   .flex-col {
     flex-direction: column;
@@ -316,21 +318,6 @@
   }
   .justify-between {
     justify-content: space-between;
-  }
-  .justify-center {
-    justify-content: center;
-  }
-  .justify-evenly {
-    justify-content: space-evenly;
-  }
-  .justify-start {
-    justify-content: flex-start;
-  }
-  .justify-items-stretch {
-    justify-items: stretch;
-  }
-  .gap-0 {
-    gap: calc(var(--spacing) * 0);
   }
   .gap-1 {
     gap: calc(var(--spacing) * 1);
@@ -350,9 +337,6 @@
   .gap-6 {
     gap: calc(var(--spacing) * 6);
   }
-  .gap-10 {
-    gap: calc(var(--spacing) * 10);
-  }
   .gap-14 {
     gap: calc(var(--spacing) * 14);
   }
@@ -365,77 +349,26 @@
   .gap-27 {
     gap: calc(var(--spacing) * 27);
   }
-  .gap-30 {
-    gap: calc(var(--spacing) * 30);
-  }
-  .gap-31 {
-    gap: calc(var(--spacing) * 31);
-  }
-  .gap-32 {
-    gap: calc(var(--spacing) * 32);
-  }
-  .gap-33 {
-    gap: calc(var(--spacing) * 33);
-  }
-  .gap-34 {
-    gap: calc(var(--spacing) * 34);
-  }
   .gap-36 {
     gap: calc(var(--spacing) * 36);
   }
   .gap-40 {
     gap: calc(var(--spacing) * 40);
   }
-  .gap-42 {
-    gap: calc(var(--spacing) * 42);
-  }
-  .gap-43 {
-    gap: calc(var(--spacing) * 43);
-  }
-  .gap-44 {
-    gap: calc(var(--spacing) * 44);
-  }
-  .gap-45 {
-    gap: calc(var(--spacing) * 45);
-  }
   .gap-46 {
     gap: calc(var(--spacing) * 46);
   }
-  .gap-48 {
-    gap: calc(var(--spacing) * 48);
-  }
-  .gap-50 {
-    gap: calc(var(--spacing) * 50);
-  }
-  .gap-55 {
-    gap: calc(var(--spacing) * 55);
-  }
   .gap-58 {
     gap: calc(var(--spacing) * 58);
-  }
-  .gap-60 {
-    gap: calc(var(--spacing) * 60);
-  }
-  .gap-63 {
-    gap: calc(var(--spacing) * 63);
-  }
-  .gap-65 {
-    gap: calc(var(--spacing) * 65);
-  }
-  .gap-70 {
-    gap: calc(var(--spacing) * 70);
-  }
-  .gap-80 {
-    gap: calc(var(--spacing) * 80);
-  }
-  .rounded {
-    border-radius: 0.25rem;
   }
   .rounded-2xl {
     border-radius: var(--radius-2xl);
   }
   .rounded-4xl {
     border-radius: var(--radius-4xl);
+  }
+  .rounded-full {
+    border-radius: calc(infinity * 1px);
   }
   .rounded-xl {
     border-radius: var(--radius-xl);
@@ -466,6 +399,9 @@
   .bg-white {
     background-color: var(--color-white);
   }
+  .object-cover {
+    object-fit: cover;
+  }
   .p-1 {
     padding: calc(var(--spacing) * 1);
   }
@@ -478,14 +414,8 @@
   .p-4 {
     padding: calc(var(--spacing) * 4);
   }
-  .p-5 {
-    padding: calc(var(--spacing) * 5);
-  }
   .p-8 {
     padding: calc(var(--spacing) * 8);
-  }
-  .p-10 {
-    padding: calc(var(--spacing) * 10);
   }
   .pt-0 {
     padding-top: calc(var(--spacing) * 0);
@@ -567,12 +497,9 @@
   .text-white {
     color: var(--color-white);
   }
-  .underline {
-    text-decoration-line: underline;
-  }
-  .outline {
-    outline-style: var(--tw-outline-style);
-    outline-width: 1px;
+  .ease-in-out {
+    --tw-ease: var(--ease-in-out);
+    transition-timing-function: var(--ease-in-out);
   }
   .outline-none {
     --tw-outline-style: none;
@@ -605,6 +532,26 @@
     }
   }
 }
+@property --tw-rotate-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-y {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-rotate-z {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-x {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-skew-y {
+  syntax: "*";
+  inherits: false;
+}
 @property --tw-border-style {
   syntax: "*";
   inherits: false;
@@ -614,10 +561,9 @@
   syntax: "*";
   inherits: false;
 }
-@property --tw-outline-style {
+@property --tw-ease {
   syntax: "*";
   inherits: false;
-  initial-value: solid;
 }
 @property --tw-shadow {
   syntax: "*";
@@ -687,9 +633,14 @@
 @layer properties {
   @supports ((-webkit-hyphens: none) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color:rgb(from red r g b)))) {
     *, ::before, ::after, ::backdrop {
+      --tw-rotate-x: initial;
+      --tw-rotate-y: initial;
+      --tw-rotate-z: initial;
+      --tw-skew-x: initial;
+      --tw-skew-y: initial;
       --tw-border-style: solid;
       --tw-font-weight: initial;
-      --tw-outline-style: solid;
+      --tw-ease: initial;
       --tw-shadow: 0 0 #0000;
       --tw-shadow-color: initial;
       --tw-shadow-alpha: 100%;


### PR DESCRIPTION
## Related Issue\n\nCloses #8025\n\n## Summary\n- Replaced the static Twitter feed with a rendered batch feed\n- Added an IntersectionObserver-driven infinite scroll trigger\n- Shows skeleton loading cards while the next batch is being prepared\n- Loads tweets in chunks instead of dumping the full feed at once\n\n## Verification\n- git diff --check\n- npm run build (Twitter-clone)\n- Playwright smoke checks on http://127.0.0.1:8003/\n  - initial render shows the first batch plus skeletons\n  - scrolling to the bottom loads the remaining tweets in stages\n  - no console/page errors\n