### PR TITLE
fix: correct 2048 left and right controls

### DIFF
--- a/public/2048_game/script.js
+++ b/public/2048_game/script.js
@@ -193,7 +193,7 @@ function doMove (dir) {
   prevBoard = copyBoard(board);
   prevScore = score;
 
-  const rotTurns = { right: 0, down: 1, left: 2, up: 3 };
+  const rotTurns = { left: 0, down: 1, right: 2, up: 3 };
   let tmp = rotateBoard(board, rotTurns[dir]);
   let pts = 0;
   let moved = false;


### PR DESCRIPTION
## Summary\n- swap the 2048 move rotation mapping for left and right\n- keep keyboard, swipe, and any shared move dispatch consistent\n\n## Validation\n- git diff --check\n- Playwright check on a local server confirming left moves left and right moves right\n\nFixes #1483