### PR TITLE
fix: restore to-do list script behavior

### DIFF
--- a/public/TO_DO_LIST/todolist.js
+++ b/public/TO_DO_LIST/todolist.js
@@ -346,6 +346,10 @@ function Add() {
   taskInput.focus();
 }
 
+function addTask() {
+  Add();
+}
+
 // Allow pressing Enter in the input to add a task
 taskInput.addEventListener('keydown', (e) => {
   if (e.key === 'Enter') Add();
@@ -473,6 +477,7 @@ function deletePDF(button) {
 }
 
 function showPDFMessage() {
+  if (!pdfMessage) return;
   pdfMessage.style.display = 'flex';
   setTimeout(() => {
     pdfMessage.style.display = 'none';
@@ -527,10 +532,9 @@ function updateNotesTheme() {
     }
   });
 }
-/* =========================
-   KANBAN DRAG DROP FEATURE
-   (Append below existing code)
-
+// =========================
+// KANBAN DRAG DROP FEATURE
+// =========================
 // Make all newly created notes draggable
 function enableDragForNotes() {
   const notes = document.querySelectorAll(".notes");


### PR DESCRIPTION
Restores the TO_DO_LIST script so the current UI can load and basic actions work again.

- Adds the addTask alias expected by the HTML wiring
- Guards the PDF status message so save/export does not crash when the node is absent
- Fixes the broken comment block that was making the script invalid

Validation:
- node --check public/TO_DO_LIST/todolist.js
- git diff --check -- public/TO_DO_LIST/todolist.js

Closes #1830