### PR TITLE
feat: add contributor search filter

### DIFF
--- a/contributors/contributor.css
+++ b/contributors/contributor.css
@@ -200,6 +200,47 @@ body {
     margin-bottom: 6rem;
 }
 
+.contributors-toolbar {
+    max-width: 720px;
+    margin: 0 auto 4rem;
+}
+
+.contributors-search {
+    display: flex;
+    align-items: center;
+    gap: 0.9rem;
+    background: var(--glass-bg);
+    border: 1px solid var(--glass-border);
+    border-radius: 22px;
+    padding: 0.95rem 1.1rem;
+    backdrop-filter: blur(20px);
+}
+
+.contributors-search i {
+    color: var(--accent-color);
+    font-size: 1rem;
+}
+
+.contributors-search input {
+    width: 100%;
+    background: transparent;
+    border: 0;
+    color: var(--text-primary);
+    font: inherit;
+    outline: none;
+}
+
+.contributors-search input::placeholder {
+    color: var(--text-secondary);
+}
+
+.contributors-search-hint {
+    margin-top: 0.75rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    text-align: center;
+}
+
 .stat-item {
     background: var(--glass-bg);
     backdrop-filter: blur(20px);

--- a/contributors/contributor.html
+++ b/contributors/contributor.html
@@ -84,6 +84,21 @@ rel="stylesheet">
         </div>
       </div>
 
+      <div class="contributors-toolbar">
+        <div class="contributors-search">
+          <i class="fa-solid fa-magnifying-glass" aria-hidden="true"></i>
+          <input
+            type="search"
+            id="contributorSearch"
+            placeholder="Search contributors by username"
+            aria-label="Search contributors"
+          />
+        </div>
+        <p class="contributors-search-hint" id="contributorsSearchHint">
+          Start typing to filter the contributor list.
+        </p>
+      </div>
+
       <div id="contributors" class="contributors-grid"></div>
 
       <div class="contributor-header" style="margin-top: 5rem;">

--- a/contributors/contributor.js
+++ b/contributors/contributor.js
@@ -21,6 +21,12 @@ const closeCertificate =
 document.getElementById(
 "closeCertificate"
 );
+const contributorSearch =
+document.getElementById("contributorSearch");
+const contributorsSearchHint =
+document.getElementById("contributorsSearchHint");
+
+let contributorCards = [];
 
 
 closeModal?.addEventListener(
@@ -429,11 +435,13 @@ async function fetchContributors() {
         const totalCommitsEl = document.getElementById('totalCommits');
         if (totalCommitsEl) totalCommitsEl.textContent = totalCommits.toLocaleString();
 
-        contributorsContainer.innerHTML = ""; 
+        contributorsContainer.innerHTML = "";
+        contributorCards = [];
 
         contributors.forEach((contributor) => {
             const card = document.createElement("div");
             card.className = "contributor-card";
+            card.dataset.username = contributor.login.toLowerCase();
 
             card.innerHTML = `
                 <img src="${contributor.avatar_url}" alt="${contributor.login}">
@@ -470,6 +478,7 @@ async function fetchContributors() {
 </div>
             `;
             contributorsContainer.appendChild(card);
+            contributorCards.push(card);
             const detailsButton =
 card.querySelector(
 ".details-btn"
@@ -493,8 +502,10 @@ contributor.contributions
 
 });
 
-}
+	}
         });
+
+        applyContributorSearch();
     } catch (error) {
         console.error("Error fetching contributors:", error);
         if (contributorsContainer) contributorsContainer.innerHTML = "<p style='color: #ff4444;'>Failed to load contributors.</p>";
@@ -533,3 +544,25 @@ document.addEventListener("DOMContentLoaded", () => {
     fetchContributors();
     fetchStargazers();
 });
+
+function applyContributorSearch() {
+    const query = contributorSearch?.value.trim().toLowerCase() || "";
+    let visibleCount = 0;
+
+    contributorCards.forEach((card) => {
+        const username = card.dataset.username || "";
+        const matches = !query || username.includes(query);
+        card.style.display = matches ? "" : "none";
+        if (matches) visibleCount += 1;
+    });
+
+    if (contributorsSearchHint) {
+        contributorsSearchHint.textContent = query
+            ? visibleCount > 0
+                ? `Showing ${visibleCount} contributor${visibleCount === 1 ? "" : "s"} matching "${query}".`
+                : `No contributors match "${query}".`
+            : "Start typing to filter the contributor list.";
+    }
+}
+
+contributorSearch?.addEventListener("input", applyContributorSearch);

--- a/style.css
+++ b/style.css
@@ -270,17 +270,31 @@ body.light-mode .navbar {
 .btn {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.4rem;
   padding: 0.5rem 1rem;
   font-family: 'Inter Tight', sans-serif;
   font-size: 0.8125rem;
   font-weight: 500;
+  min-height: 2.5rem;
   border-radius: var(--radius-md);
   text-decoration: none;
   cursor: pointer;
   transition: var(--t);
   border: 1px solid transparent;
   white-space: nowrap;
+}
+
+.btn:focus-visible,
+.view-all-btn:focus-visible,
+.chip:focus-visible,
+.bookmark-btn:focus-visible,
+#themeToggle:focus-visible,
+#scrollBtn:focus-visible,
+.pagination-controls button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  box-shadow: 0 0 0 4px var(--accent-dim);
 }
 
 .btn-primary {
@@ -534,7 +548,7 @@ body.light-mode .navbar {
 
 .hero-actions {
   display: flex;
-  gap: 0.75rem;
+  gap: 0.9rem;
   justify-content: center;
   flex-wrap: wrap;
   margin-bottom: 3rem;
@@ -545,6 +559,7 @@ body.light-mode .navbar {
 .hero-actions .btn {
   padding: 0.65rem 1.5rem;
   font-size: 0.875rem;
+  min-width: 11.5rem;
 }
 
 /* Stats strip — inline, elegant, one row */
@@ -626,33 +641,31 @@ body.light-mode .navbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
-
-  gap: 1rem;
+  gap: 0.75rem 1rem;
+  flex-wrap: wrap;
 }
 
 .view-all-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.3rem;
+  min-height: 2.375rem;
+  padding: 0.45rem 1rem;
   border: 1px solid var(--border);
-
-  background: transparent;
-
+  background: rgba(255, 255, 255, 0.02);
   color: var(--text-secondary);
-
-  padding: 0.45rem 0.9rem;
-
-  border-radius: 10px;
-
+  border-radius: 999px;
   font-size: 0.8rem;
-
+  font-weight: 600;
   cursor: pointer;
-
   transition: var(--t);
+  white-space: nowrap;
 }
 
 .view-all-btn:hover {
   background: var(--accent-dim);
-
   color: var(--accent);
-
   border-color: var(--border-accent);
 }
 
@@ -712,6 +725,7 @@ body.light-mode .navbar {
 .chip {
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 0.25rem;
   padding: 0.22rem 0.6rem;
   font-family:
@@ -727,6 +741,7 @@ body.light-mode .navbar {
   color: var(--text-muted);
   cursor: pointer;
   transition: var(--t);
+  min-height: 2rem;
 }
 
 .chip:hover {
@@ -927,19 +942,12 @@ body.light-mode .navbar {
 .bookmark-btn {
   width: 38px;
   height: 38px;
-
   border-radius: 10px;
-
   border: 1px solid var(--border);
-
   background: transparent;
-
   color: var(--text-secondary);
-
   cursor: pointer;
-
   transition: var(--t);
-
   display: flex;
   align-items: center;
   justify-content: center;
@@ -947,21 +955,15 @@ body.light-mode .navbar {
 
 .bookmark-btn:hover {
   background: var(--accent-dim);
-
   border-color: var(--border-accent);
-
   color: var(--accent);
-
   transform: translateY(-2px);
 }
 
 .bookmark-btn.active {
   background: var(--accent-dim);
-
   border-color: var(--border-accent);
-
   color: var(--accent);
-
   box-shadow: 0 0 12px rgba(59, 130, 246, 0.25);
 }
 
@@ -1329,6 +1331,7 @@ html {
   }
   .hero-actions .btn {
     width: 100%;
+    min-width: 0;
     justify-content: center;
   }
   .stats-strip {
@@ -1587,4 +1590,3 @@ body.light-mode .brand-mark {
     background: linear-gradient(180deg, rgba(59, 130, 246, 0.15), rgba(255, 255, 255, 0.9));
     border: 1px solid rgba(0, 0, 0, 0.08);
 }
-


### PR DESCRIPTION
Adds a search input to the contributors page so visitors can quickly filter contributors by username. This branch also standardizes homepage button spacing and visibility so the main archive controls read more consistently.

- Adds a search bar above the contributor grid
- Filters contributor cards live as the user types
- Shows a helpful result count / empty-state hint
- Leaves the existing contributor stats, leaderboard, and stargazers intact
- Standardizes homepage button spacing, visibility, and focus states

Validation:
- node --check contributors/contributor.js
- git diff --check -- contributors/contributor.html contributors/contributor.css contributors/contributor.js
- git diff --check -- style.css

Closes #4971
Closes #1824
