### PR TITLE
fix: scroll to top of project section on pagination click

### DIFF
--- a/index.js
+++ b/index.js
@@ -1010,8 +1010,6 @@ function scrollToProjectSection() {
   const header = document.querySelector(".projects-header");
   if (!header) return;
 
-  if (header.getBoundingClientRect().top < window.innerHeight) return;
-
   const navbar = document.querySelector(".navbar");
   const offset = navbar ? navbar.offsetHeight - 50 : 30;
   const targetY =


### PR DESCRIPTION
## 📝 Pull Request Description
### Related Issue
Closes #7895

### Summary
When clicking pagination controls, the page was not scrolling back 
to the top of the project section. This was caused by an early 
return condition in scrollToProjectSection() that skipped scrolling 
when the header was already partially visible in the viewport. 
Removed the condition so scrolling always triggers on page change.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)


---
## 🛠️ Changes Made
- Removed early return condition in scrollToProjectSection() that 
  prevented scrolling when header was already in viewport
- Now correctly scrolls to project section on every page change

---
## 🧪 Testing and Verification
### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [x] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [x] Verified responsive layout on Mobile viewports (using DevTools)
- [x] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---
## 📷 Screenshots / Video Recording
Before

<img width="1920" height="1080" alt="Untitled" src="https://github.com/user-attachments/assets/0063ebd8-364e-4744-907b-744286883f52" />

After

https://github.com/user-attachments/assets/fff273f5-1bf6-4358-bb3c-7261ecdf2492





---
## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.

### GSSoC 2026
This PR is submitted as part of GSSoC 2026 contribution 🚀