### PR TITLE
fix(Day 50): resolve clipped first letters on recipe card titles

### DIFF
--- a/public/recipe/style.css
+++ b/public/recipe/style.css
@@ -471,6 +471,7 @@ select option {
     font-family: 'Playfair Display', serif;
     font-size: 1.2rem;
     margin-bottom: 8px;
+    padding-left: 5px;
 }
 
 .recipe-info p {
@@ -519,6 +520,9 @@ select option {
     color: #64748b;
     padding: 60px;
     grid-column: 1/-1;
+}
+.recipe-card-body h3 {
+    padding-left: 6px;
 }
 
 /* =========================


### PR DESCRIPTION
On the Day 50 (Recipe Genie) project, the first letters of all recipe card titles were being visually clipped on the left side (e.g., "Spaghetti" appeared as "paghetti", "Chicken" as "hicken").
Root Cause

The Playfair Display serif font has wide, sweeping curves on capital letters. Because the parent container (.recipe-card) has overflow: hidden; applied, these wide left-hand serifs were extending slightly outside the layout box and being chopped off by the browser.
Solution
- Added padding-left: 5px; to the .recipe-card-body h3 class in style.css.
- This gives the elegant serif characters just enough breathing room to render fully without breaking the strict grid layout or triggering the overflow crop.