### PR TITLE
fix(recipe): show full card titles (fix clipped first letter) (#8162)

### DIFF
--- a/public/recipe/script.js
+++ b/public/recipe/script.js
@@ -56,7 +56,7 @@ function renderRecipes(recipes) {
   recipeGrid.innerHTML = recipes.map((recipe, index) => `
     <div class="recipe-card" onclick="showRecipe(${index})">
       ${recipe.img ? `<img src="${recipe.img}" alt="${recipe.name}" onerror="this.style.display='none'">` : ''}
-      <div class="recipe-card-body">
+      <div class="recipe-info">
         <h3>${recipe.name || recipe.title || "Recipe"}</h3>
         <p>${(recipe.instructions || recipe.description || "").slice(0, 80)}...</p>
         ${recipe.tags ? `<div class="tags">${recipe.tags.map(t => `<span class="tag">${t}</span>`).join("")}</div>` : ""}


### PR DESCRIPTION
## Description
On the **Recipe Genie** listing (`public/recipe/`), every recipe card title had its **first letter clipped** ("Spaghetti Carbonara" rendered as "paghetti Carbonara").

**Root cause:** the card markup in `script.js` wrapped the title in `<div class="recipe-card-body">`, but the stylesheet has **no rule** for `.recipe-card-body` — the styled class is `.recipe-info` (which sets `padding: 20px`). With no padding, the `<h3>` title sat flush against the card's `border-radius: 24px; overflow: hidden` edge, so the rounded corner clipped the first letter of every title.

**Fix:** rename the wrapper to the intended `.recipe-info` class, restoring the card padding so titles display in full. One-line change.

## Related Issue
Fixes #8162

## Type of change
- [x] Bug fix (non-breaking)

## Screenshots
<!-- After-screenshot showing recipe card titles displaying their full first letter -->
