### PR TITLE
feat: Add GitHub source icon button to project cards (#7951)

### DIFF
--- a/index.js
+++ b/index.js
@@ -334,10 +334,10 @@ function buildProjectCardHTML({
                         Demo <i class="fas fa-arrow-right" aria-hidden="true"></i>
                     </a>`;
 
-  const codeLink = sourceOnly
+  const githubBtn = sourceOnly
     ? ""
-    : `<a href="${safeSourceUrl}" target="_blank" class="card-link view-code-link" rel="noopener noreferrer" onclick="event.stopPropagation()" aria-label="View source code of ${safeName} on GitHub (opens in a new tab)">
-                        <i class="fab fa-github" aria-hidden="true"></i> Code
+    : `<a href="${safeSourceUrl}" target="_blank" class="github-btn" rel="noopener noreferrer" onclick="event.stopPropagation()" aria-label="View source code of ${safeName} on GitHub (opens in a new tab)">
+                        <i class="fab fa-github" aria-hidden="true"></i>
                     </a>`;
 
   return {
@@ -374,9 +374,9 @@ function buildProjectCardHTML({
             <div class="card-footer">
                 <div class="card-actions-left">
                     ${primaryLink}
-                    ${codeLink}
                 </div>
                 <div class="card-actions-right" style="display: flex; gap: 8px; align-items: center;">
+                    ${githubBtn}
                     <button class="bookmark-btn ${isBookmarked ? "active" : ""}" data-id="${safeDay}" aria-label="${isBookmarked ? `Remove ${safeName} from bookmarks` : `Bookmark ${safeName}`}">
                         <i class="${isBookmarked ? "fa-solid" : "fa-regular"} fa-bookmark" aria-hidden="true"></i>
                     </button>

--- a/style.css
+++ b/style.css
@@ -1976,13 +1976,26 @@ input:focus {
   gap: 1rem;
 }
 
-.view-code-link {
+.github-btn {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: transparent;
   color: var(--text-secondary);
+  cursor: pointer;
+  transition: var(--t);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
 }
 
-.view-code-link:hover {
-  color: var(--text-primary);
-  transform: translateY(-1px);
+.github-btn:hover {
+  background: var(--accent-dim);
+  border-color: var(--border-accent);
+  color: var(--accent);
+  transform: translateY(-2px);
 }
 
 .bookmark-btn {


### PR DESCRIPTION
# Description
This PR addresses issue #7951 by replacing the text-based "Code" link on the project cards with a sleek, compact GitHub icon button. The button is placed next to the bookmark button in the card actions container, improving layout consistency and visual quality.

### Changes
- **`index.js`**:
  - Replaced `codeLink` in the `buildProjectCardHTML` function with `githubBtn`.
  - Relocated the button inside `.card-actions-right` (alongside the bookmark button) to keep the left side clean for the main action ("Demo" or "Source").
- **`style.css`**:
  - Removed styling rules for `.view-code-link`.
  - Added styling for `.github-btn` to match the exact size, border-radius, background, borders, and hover micro-animations (`transform: translateY(-2px)`) of the bookmark button.

## Related Issue
Resolves #7951

## Verification Details
- Local development server was spun up using `serve`.
- Validated layout rendering and responsiveness in the browser.
- Verified that hovering triggers smooth translateY animations and clicking correctly opens the corresponding project folder on GitHub (e.g., `https://github.com/dhairyagothi/100_days_100_web_project/tree/Main/public/T0_D0_LIST`).

### Preview / Screenshot
| Before | After |
|--------|-------|
| `Demo ->` and `(GitHub Icon) Code` in bottom-left | `Demo ->` in bottom-left; `[GitHub Icon] [Bookmark Icon]` in bottom-right |
