### PR TITLE
fix: move dotenv from dependencies to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,11 +31,10 @@
     "frontend"
   ],
   "license": "MIT",
-  "dependencies": {
-    "dotenv": "^17.4.2"
-  },
+
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "dotenv": "^17.4.2",
     "ajv": "^8.17.1",
     "eslint": "^10.4.1",
     "eslint-config-prettier": "^10.1.8",


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #8248 

### Summary

Moved dotenv from dependencies to devDependencies in package.json. It is not required at runtime for the main showcase website.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [x] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made

- Removed dotenv from dependencies
- Added dotenv to devDependencies
- Ran npm install to update package-lock.json

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [ ] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

Note: Not applicable because no project files modified.

---

## 📷 Screenshots / Video Recording

Not applicable, no UI changes were made. Only dependency classification fixed.

---

## 🤝 Contributor Checklist
- [ ] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
