### PR TITLE
fix: remove duplicate validate:projects key and fix broken CI validatation chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "generate-previews": "node scripts/generate-previews.js",
     "dev": "npx -y serve . -p 3000",
-    "validate:projects": "node .github/scripts/validate-projects.js",
-    "validate:projects": "node scripts/validate-projects.js",
+    "validate:projects": "node .github/scripts/detect-duplicates.js",
     "validate:projects-fixture": "node scripts/validate-projects-fixture.js",
     "lint": "eslint --no-config-lookup -c eslint.config.js .",
     "lint:all": "npx -y htmlhint '**/*.html' --ignore 'node_modules/**,**/node_modules/**'",


### PR DESCRIPTION
## Description

Fixes the broken CI validation chain caused by a duplicate `"validate:projects"` key in `package.json` and missing script references.

### Root Cause

- `package.json` had two identical `"validate:projects"` keys on consecutive lines (9-10). JSON parsers that allow duplicates keep only the **last** value, so the first entry `node .github/scripts/validate-projects.js` was dead code.
- The referenced file `.github/scripts/validate-projects.js` does **not exist** in the repository.
- The second entry `node scripts/validate-projects.js` also does **not exist**.
- However, `.github/scripts/detect-duplicates.js` **does exist** and is a fully functional validator for `projects.json`.

### Changes Made

**`package.json`** (lines 9-10):
- Removed the dead duplicate entry `"validate:projects": "node .github/scripts/validate-projects.js"`
- Updated the surviving entry to point to the existing validation script: `"validate:projects": "node .github/scripts/detect-duplicates.js"`

### What `detect-duplicates.js` validates

- ✅ Duplicate day numbers (blocking error)
- ✅ Duplicate file paths (blocking error)
- ✅ Path format compliance (must be `./public/*.html`)
- ✅ String length constraints (name ≤ 120 chars, desc ≤ 500 chars)
- ✅ Valid JSON parsing

### Fix Verification

The `lint-staged` configuration already references `npm run validate:projects`, which now correctly resolves to the existing `detect-duplicates.js` script.

Fixes #8263