### PR TITLE
fix: prevent dropdown overlap in navigation menu

### DIFF
--- a/cursor.js
+++ b/cursor.js
@@ -325,7 +325,7 @@
     panel.id = "cursorStyleDropdown";
     panel.setAttribute("role", "menu");
     panel.style.cssText = `
-      display:none;position:absolute;top:calc(100% + 8px);right:0;
+      display:none;position:absolute;top:calc(100% + 8px);right:0; transform:translateX(-55px);
       min-width:190px;background:var(--bg-elevated,#111315);
       border:1px solid var(--border,#1b1f24);border-radius:12px;
       padding:6px;box-shadow:0 16px 40px rgba(0,0,0,0.4);


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8303 

### Summary
Adjusted the Cursor Style dropdown position to prevent overlap with the Theme dropdown when both navigation menus are opened.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Updated the Cursor Style dropdown positioning in `cursor.js`.
- Added a horizontal offset using `transform: translateX(-55px)`.
- Prevented visual overlap between the Cursor Style and Theme dropdown menus.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
Before:
<img width="959" height="508" alt="Z" src="https://github.com/user-attachments/assets/c9fa8130-572a-4bfb-a682-3e0448faaae9" />

After:
<img width="959" height="500" alt="Z1" src="https://github.com/user-attachments/assets/93adb1c2-ec00-4331-9aae-c830a2e9cb7e" />


---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
