### PR TITLE
fix: use auto-fill grid to prevent empty slots in YouTube Clone - Fixes #8021

### DIFF
--- a/public/youtube clone/styles/video.css
+++ b/public/youtube clone/styles/video.css
@@ -37,7 +37,7 @@
 
 .video-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   column-gap: 16px;
   row-gap: 40px;
   margin-left: 82px;
@@ -89,7 +89,7 @@
 
 @media (min-width: 1000px) {
   .video-grid {
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    grid-template-columns: repeat(4, 1fr);
   }
 }
 

--- a/public/youtube clone/styles/video.css
+++ b/public/youtube clone/styles/video.css
@@ -37,7 +37,7 @@
 
 .video-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   column-gap: 16px;
   row-gap: 40px;
   margin-left: 82px;
@@ -89,7 +89,7 @@
 
 @media (min-width: 1000px) {
   .video-grid {
-    grid-template-columns: 1fr 1fr 1fr 1fr;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
   }
 }
 


### PR DESCRIPTION
## Related Issue
Closes #8021

## Summary
The video grid on the YouTube Clone homepage was showing an incomplete last row , only 2 video cards were visible while 2 grid slots remained empty. This happened because a fixed `grid-template-columns: 1fr 1fr 1fr 1fr` (4 columns) was used but only 6 videos exist in the HTML, leaving the last row with 2 empty slots.

**Before Fix:** Fixed 4-column grid → last row had 2 empty slots  
**After Fix:** `repeat(auto-fill, minmax(300px, 1fr))` → grid 
fills responsively with no empty slots.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Changed `grid-template-columns: 1fr 1fr 1fr` to  `repeat(auto-fill, minmax(300px, 1fr))` in `.video-grid`
- Updated `@media (min-width: 1000px)` query with same fix

## Testing and Verification
- [x] Tested and verified in Google Chrome
- [x] Verified responsive layout on Mobile viewports
- [x] No console errors

## Screenshots
**Before:** Bottom row showed only 2 videos, 2 slots were empty  
**After:** All 6 videos display properly in a complete grid ✅  


## Contributor Checklist
- [x] My code follows the code style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings or console errors
- [x] There are no unrelated changes or formatter noise in this PR