### PR TITLE
fix(bill-splitter): reject negative Total Bill and Tip % values (#8373)

### DIFF
--- a/public/Bill-Splitter/app.js
+++ b/public/Bill-Splitter/app.js
@@ -642,3 +642,22 @@ $('it-qr').addEventListener('click', () => {
     .map(([n, d]) => `${n}: ${fmt(d.total)}`).join('\n');
   showQR(`SplitWise Pro - Items Split\n\nPer Person:\n${perPerson}`);
 });
+
+/* ============================================================
+   INPUT VALIDATION (Bug #8373)
+   The Total Bill / Tip % fields accepted typed negative values despite their
+   `min` attributes, feeding invalid numbers into the split calculations.
+   Clamp every number input: negatives become 0, and values above a field's
+   `max` (e.g. Tip % > 100) are capped.
+============================================================ */
+document.querySelectorAll('input[type="number"]').forEach(input => {
+  input.addEventListener('input', () => {
+    const val = parseFloat(input.value);
+    if (isNaN(val)) return;
+    if (val < 0) {
+      input.value = 0;
+    } else if (input.max !== '' && val > parseFloat(input.max)) {
+      input.value = input.max;
+    }
+  });
+});


### PR DESCRIPTION
## Description
The **SplitWise Pro Bill Splitter** (`public/Bill-Splitter/`) accepted **negative** values in the Total Bill and Tip % fields. The inputs already carry `min` attributes, but `min` doesn't stop a user from *typing* a negative number — and the calculate functions read values with `parseFloat(...) || 0` and no guard, so negative bill/tip flowed into the split math and produced invalid results (across all tabs).

**Fix:** added a single `input` handler over every `input[type="number"]` that clamps values as they're typed — negatives become `0`, and values above a field's `max` (e.g. Tip % > 100) are capped. Minimal, central, and works for the Equal/Unequal/Items tabs.

## Related Issue
Fixes #8373

## Type of change
- [x] Bug fix (non-breaking)

## How was this tested?
- `node --check app.js` passes (no syntax errors).
- Logic verified for: negative bill -> 0, negative tip -> 0, tip 150 -> 100, valid values unchanged, 0 allowed, empty unchanged.


