### PR TITLE
fix(contact-book): repair corrupted app.py and scope contact edit/delete to owner

### DIFF
--- a/public/Contact Book/app.py
+++ b/public/Contact Book/app.py
@@ -1,8 +1,4 @@
- from flask import Flask, render_template, redirect, url_for, request, flash, session
-from flask_sqlalchemy import SQLAlchemy
-from werkzeug.security import generate_password_hash, check_password_hash
-from datetime import datetime
-  flask import Flask, render_template, redirect, url_for, request, flash, session
+from flask import Flask, render_template, redirect, url_for, request, flash, session
 from flask_sqlalchemy import SQLAlchemy
 from werkzeug.security import generate_password_hash, check_password_hash
 from datetime import datetime
@@ -17,7 +13,7 @@ db = SQLAlchemy(app)
 
 
 class User(db.Model):
-    id = db.Colufrommn(db.Integer, primary_key=True)
+    id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(150), unique=True, nullable=False)
     password = db.Column(db.String(150), nullable=False)
 
@@ -204,29 +200,16 @@ def dashboard():
         contacts = Contact.query.filter_by(user_id=user_id).order_by(
             Contact.name.asc()
         ).all()
-if sort_order == "desc":
-    contacts = Contact.query.filter_by(user_id=user_id).order_by(Contact.name.desc()).all()
-else:
-    contacts = Contact.query.filter_by(user_id=user_id).order_by(Contact.name.asc()).all()
 
     contact_count = len(contacts)
-
-    return render_template(
-        "dashboard.html",
-        contacts=contacts,
-        contact_count=contact_count
-    contacts = Contact.query.filter_by(user_id=user_id).order_by(Contact.name).all()
-
-    contact_count = len(contacts)
-
-    return render_template(
-        "dashboard.html",
-        contacts=contacts,
-        contact_count=contact_count
     duplicates = scan_all_duplicates(user_id)
     duplicate_count = len(duplicates)
+
     return render_template(
-        "dashboard.html", contacts=contacts, duplicate_count=duplicate_count
+        "dashboard.html",
+        contacts=contacts,
+        contact_count=contact_count,
+        duplicate_count=duplicate_count,
     )
 
 
@@ -263,7 +246,7 @@ def add_contact():
 def edit_contact(id):
     if "user_id" not in session:
         return redirect(url_for("login"))
-    contact = Contact.query.get_or_404(id)
+    contact = Contact.query.filter_by(id=id, user_id=session["user_id"]).first_or_404()
     if request.method == "POST":
         name = request.form.get("name")
         email = request.form.get("email")
@@ -334,7 +317,7 @@ def save_pending_contact():
 
     edit_id = pending.get("edit_id")
     if edit_id:
-        contact = Contact.query.get_or_404(edit_id)
+        contact = Contact.query.filter_by(id=edit_id, user_id=session["user_id"]).first_or_404()
         contact.name = pending["name"]
         contact.email = pending["email"]
         contact.phone = pending["phone"]
@@ -453,11 +436,11 @@ def merge_contacts():
     )
 
 
-@app.route("/delete_contact/<int:id>")
+@app.route("/delete_contact/<int:id>", methods=["POST"])
 def delete_contact(id):
     if "user_id" not in session:
         return redirect(url_for("login"))
-    contact = Contact.query.get_or_404(id)
+    contact = Contact.query.filter_by(id=id, user_id=session["user_id"]).first_or_404()
     db.session.delete(contact)
     db.session.commit()
     return redirect(url_for("dashboard"))

--- a/public/Contact Book/templates/dashboard.html
+++ b/public/Contact Book/templates/dashboard.html
@@ -61,11 +61,10 @@
             </div>
             <div class="space-x-2">
                 <a href="{{ url_for('edit_contact', id=contact.id) }}" class="bg-yellow-400 text-white px-4 py-2 rounded">Edit</a>
-                <a href="{{ url_for('delete_contact', id=contact.id) }}"
-   onclick="return confirm('Are you sure you want to delete this contact?');"
-   class="bg-red-600 text-white px-4 py-2 rounded">
-   Delete
-</a>
+                <form method="POST" action="{{ url_for('delete_contact', id=contact.id) }}" class="inline"
+   onsubmit="return confirm('Are you sure you want to delete this contact?');">
+   <button type="submit" class="bg-red-600 text-white px-4 py-2 rounded">Delete</button>
+</form>
             </div>
         </li>
         {% endfor %}


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8431

### Summary
`public/Contact Book/app.py` did not run (merge corruption: `IndentationError` at line 1) and, once repaired, allowed any logged-in user to edit or delete any other user's contacts by id (IDOR), with delete reachable via GET (CSRF). This PR repairs the file and scopes contact access to the owner.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `app.py`: repaired the merge corruption that prevented startup, the leading-space first import, the duplicated import block, the `db.Colufrommn` typo (-> `db.Column`), and the duplicated/mis-indented `dashboard()` body (now a single clean implementation that keeps the sort, contact count, and duplicate-detection features).
- `app.py`: scoped contact lookups to the session user in `edit_contact`, `delete_contact`, and the `save_pending_contact` edit path: `Contact.query.filter_by(id=id, user_id=session["user_id"]).first_or_404()`, so other users' contacts return 404.
- `app.py` + `templates/dashboard.html`: `delete_contact` is now POST-only and the dashboard delete control is a POST form (was a GET link), which removes the trivial `<img src>` CSRF vector.

### Notes
- A full CSRF token (e.g. Flask-WTF) would further harden the POST forms and is a reasonable follow-up; it is out of scope here.
- `app.run(debug=True)` at the bottom of the file is a separate pre-existing concern and is intentionally not changed in this PR.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change and does not touch this project.

What I did verify:
- `python -m py_compile "public/Contact Book/app.py"` now passes (previously `IndentationError`).
- No unscoped `get_or_404` remains; every contact lookup is filtered by `user_id`.
- `delete_contact` is `methods=["POST"]` and the template submits via a POST form.
- A full runtime test needs Flask + the SQLite DB; the logic was reviewed against the model and template.

### Browser Compatibility Check
- N/A for the server logic; the only template change is swapping a delete link for an equivalent POST form/button.

### Responsive & Accessibility Checks
- N/A: no layout changes (the delete control keeps the same styling).

---

## 📷 Screenshots / Video Recording
N/A.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
