### PR TITLE
fix(url-shortener): validate http(s) scheme on store and redirect to prevent open redirect

### DIFF
--- a/public/url_shortener/backend/controllers/Response_API.js
+++ b/public/url_shortener/backend/controllers/Response_API.js
@@ -14,6 +14,17 @@ exports.Response_POST_API = async (req, res) => {
         throw new AppError("Enter URL first", 400);
     }
 
+    // Only allow http(s) URLs so javascript:, data:, file: and similar cannot be stored
+    let parsedURL;
+    try {
+        parsedURL = new URL(originalURL);
+    } catch (e) {
+        throw new AppError("Enter a valid URL starting with http:// or https://", 400);
+    }
+    if (parsedURL.protocol !== "http:" && parsedURL.protocol !== "https:") {
+        throw new AppError("Only http and https URLs can be shortened", 400);
+    }
+
     let Shortcode;
 
     if (customName) {

--- a/public/url_shortener/backend/controllers/redirect_window.js
+++ b/public/url_shortener/backend/controllers/redirect_window.js
@@ -31,5 +31,16 @@ exports.Redirect_window = async (req, res) => {
         deviceInfo: req.headers['user-agent']
     });
 
-    res.redirect(link.originalLink);
+    // Defense in depth: never redirect to a non http(s) destination, even if one was already stored
+    let destination;
+    try {
+        destination = new URL(link.originalLink);
+    } catch (e) {
+        return res.redirect(`${BASE_URL}/error?type=invalid`);
+    }
+    if (destination.protocol !== "http:" && destination.protocol !== "https:") {
+        return res.redirect(`${BASE_URL}/error?type=invalid`);
+    }
+
+    res.redirect(destination.href);
 };


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8434

### Summary
The URL shortener stored and redirected to user-supplied destination URLs with no scheme validation, allowing an open redirect and `javascript:`/`data:` payload delivery under the shortener's domain. This PR allows only `http`/`https` URLs: validated at creation, and re-checked at redirect time as defense in depth.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `backend/controllers/Response_API.js`: before storing, parse `originalURL` with `new URL(...)` and reject anything whose protocol is not `http:`/`https:` (returns 400 via the existing `AppError`). This blocks `javascript:`, `data:`, `file:`, etc. at creation.
- `backend/controllers/redirect_window.js`: before redirecting, re-validate the stored `originalLink`'s scheme; non http(s) (or unparseable) destinations are sent to the existing `/error?type=invalid` page instead of being followed. This protects against any malicious URLs already in the database.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change and does not touch this project.

What I did verify:
- `node --check` passes for both controllers.
- The raw `res.redirect(link.originalLink)` is gone; redirects now go through a validated `new URL(...)`.
- The store path uses the project's existing `AppError` pattern; the redirect path uses the existing `BASE_URL` error page.
- A full runtime test needs the Express server + MongoDB; the validation logic was reviewed directly.

### Browser Compatibility Check
- N/A: server-side change.

### Responsive & Accessibility Checks
- N/A: no UI changes.

---

## 📷 Screenshots / Video Recording
N/A.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
