### PR TITLE
fix(mern-job-board): whitelist editable fields on job update to prevent mass assignment

### DIFF
--- a/public/MERN_Job_Board/server/routes/jobs.js
+++ b/public/MERN_Job_Board/server/routes/jobs.js
@@ -65,7 +65,10 @@ router.put("/:id", protect, requireRole("employer"), async (req, res) => {
     if (!job) return res.status(404).json({ message: "Job not found" });
     if (job.employer.toString() !== req.user._id.toString())
       return res.status(403).json({ message: "Not your job listing" });
-    Object.assign(job, req.body);
+    const allowedFields = ["title", "location", "type", "salary", "description", "techStack", "isOpen"];
+    for (const field of allowedFields) {
+      if (req.body[field] !== undefined) job[field] = req.body[field];
+    }
     const updated = await job.save();
     res.json(updated);
   } catch (e) { res.status(500).json({ message: e.message }); }


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8438

### Summary
`PUT /api/jobs/:id` used `Object.assign(job, req.body)`, so an employer editing their own job could overwrite server-controlled fields (`employer`, `applicants`, `company`, `isOpen`, timestamps). This PR updates only a whitelist of employer-editable fields.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `server/routes/jobs.js` (PUT `/:id`): replaced `Object.assign(job, req.body)` with a loop over an allowed-field list (`title`, `location`, `type`, `salary`, `description`, `techStack`, `isOpen`). `employer`, `applicants`, `company`, and timestamps can no longer be set from the request body. `job.save()` still runs schema validators.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change and does not touch this project.

What I did verify:
- `node --check server/routes/jobs.js` passes.
- `Object.assign(job, req.body)` is gone; only the whitelisted fields are applied.
- The whitelist matches the fields the create route accepts (plus `isOpen` for open/close). The client has no job-edit form, so no client flow is affected.

### Browser Compatibility Check
- N/A: server-side change.

### Responsive & Accessibility Checks
- N/A: no UI changes.

---

## 📷 Screenshots / Video Recording
N/A.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
