### PR TITLE
fix(zomato-clone): require admin key for food writes, whitelist fields, run validators

### DIFF
--- a/public/zomato-clone/server/.env.example
+++ b/public/zomato-clone/server/.env.example
@@ -1,0 +1,4 @@
+# Admin key required for restaurant write operations (POST/PUT/DELETE /api/food).
+# Set it in the environment and send it as the "x-admin-key" request header.
+# If it is unset, all write requests are rejected (reads stay public).
+ADMIN_API_KEY=

--- a/public/zomato-clone/server/controllers/foodController.js
+++ b/public/zomato-clone/server/controllers/foodController.js
@@ -1,7 +1,20 @@
 const Food = require("../models/foodmodel");
 
+const ALLOWED_FIELDS = [
+  "name", "cuisines", "location", "address",
+  "priceForTwo", "diningRating", "deliveryRating", "distance", "images",
+];
+
+function pickAllowed(body) {
+  const data = {};
+  for (const field of ALLOWED_FIELDS) {
+    if (body[field] !== undefined) data[field] = body[field];
+  }
+  return data;
+}
+
 exports.createFood = async (req, res) => {
-  const data = await Food.create(req.body);
+  const data = await Food.create(pickAllowed(req.body));
   res.json(data);
 };
 
@@ -11,7 +24,10 @@ exports.getFoods = async (req, res) => {
 };
 
 exports.updateFood = async (req, res) => {
-  const data = await Food.findByIdAndUpdate(req.params.id, req.body);
+  const data = await Food.findByIdAndUpdate(req.params.id, pickAllowed(req.body), {
+    new: true,
+    runValidators: true,
+  });
   res.json(data);
 };
 

--- a/public/zomato-clone/server/routes/foodRoutes.js
+++ b/public/zomato-clone/server/routes/foodRoutes.js
@@ -2,15 +2,24 @@ const express = require("express");
 const router = express.Router();
 const ctrl = require("../controllers/foodController");
 
+// Require a server-side admin key for write operations
+function requireAdminKey(req, res, next) {
+  const adminKey = process.env.ADMIN_API_KEY;
+  if (!adminKey || req.get("x-admin-key") !== adminKey) {
+    return res.status(401).json({ message: "Unauthorized: admin key required" });
+  }
+  next();
+}
+
 //ejs
 router.get("/view", ctrl.renderFoods);
 
 router.get("/view/:id", ctrl.getFoodById);
 
-router.post("/", ctrl.createFood);
+router.post("/", requireAdminKey, ctrl.createFood);
 router.get("/", ctrl.getFoods);
-router.put("/:id", ctrl.updateFood);
-router.delete("/:id", ctrl.deleteFood);
+router.put("/:id", requireAdminKey, ctrl.updateFood);
+router.delete("/:id", requireAdminKey, ctrl.deleteFood);
 
 
 module.exports = router;


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8440

### Summary
The zomato-clone food/restaurant write API (`POST`/`PUT`/`DELETE /api/food`) was unauthenticated, and `updateFood` ran `findByIdAndUpdate` without validators. This PR gates the write routes behind a server-side admin key, whitelists the fields written to the model, and enables validators on update. Reads stay public, so the read-only frontend is unaffected.

Scope note: the project has no user/auth system, so this uses a minimal admin-key check rather than introducing a full authentication/role system (which would be a larger feature). The admin key is read from `process.env.ADMIN_API_KEY`; a full JWT/user-auth system would be a reasonable future enhancement.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `server/routes/foodRoutes.js`: added a `requireAdminKey` middleware (checks the `x-admin-key` header against `process.env.ADMIN_API_KEY`) and applied it to `POST`/`PUT`/`DELETE`. If the key is unset, writes are rejected (fail-secure). `GET`/`/view` routes are unchanged and public.
- `server/controllers/foodController.js`: create/update now write only whitelisted schema fields (`name`, `cuisines`, `location`, `address`, `priceForTwo`, `diningRating`, `deliveryRating`, `distance`, `images`); `updateFood` passes `{ new: true, runValidators: true }` so the schema's `required` and rating `min/max` (0-5) are enforced on update.
- Added `server/.env.example` documenting `ADMIN_API_KEY`.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change and does not touch this project.

What I did verify:
- `node --check` passes for both `foodRoutes.js` and `foodController.js`.
- Write routes now run `requireAdminKey`; reads (`GET /api/food`, `/view`) are untouched, so the read-only frontend (`restaurant.html` does a plain `GET`) keeps working.
- Update no longer mass-assigns `req.body` and now runs validators (an out-of-range `diningRating` is rejected).
- A full runtime test needs the Express server + MongoDB; the logic was reviewed against the schema and routes.

### Browser Compatibility Check
- N/A: server-side change; the public read endpoints are unchanged.

### Responsive & Accessibility Checks
- N/A: no UI changes.

---

## 📷 Screenshots / Video Recording
N/A.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
