### PR TITLE
fix(mern-job-board): escape and cap job search input to prevent ReDoS

### DIFF
--- a/public/MERN_Job_Board/server/routes/jobs.js
+++ b/public/MERN_Job_Board/server/routes/jobs.js
@@ -3,14 +3,20 @@ const router  = express.Router();
 const Job     = require("../models/Job");
 const { protect, requireRole } = require("../middleware/auth");
 
+// Escape regex metacharacters so user search input is matched literally (prevents ReDoS and regex injection)
+const escapeRegex = (s) => String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 // GET /api/jobs  — All open jobs (public)
 router.get("/", async (req, res) => {
   try {
     const { search, type, location } = req.query;
     const filter = { isOpen: true };
-    if (search)   filter.$or = [{ title: new RegExp(search, "i") }, { description: new RegExp(search, "i") }, { techStack: new RegExp(search, "i") }];
+    if (search) {
+      const safe = escapeRegex(String(search).slice(0, 100));
+      filter.$or = [{ title: new RegExp(safe, "i") }, { description: new RegExp(safe, "i") }, { techStack: new RegExp(safe, "i") }];
+    }
     if (type)     filter.type = type;
-    if (location) filter.location = new RegExp(location, "i");
+    if (location) filter.location = new RegExp(escapeRegex(String(location).slice(0, 100)), "i");
     const jobs = await Job.find(filter)
       .populate("employer", "name company")
       .sort({ createdAt: -1 });


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8442

### Summary
`GET /api/jobs` compiled the public `search` and `location` query params directly into regular expressions, allowing a ReDoS (catastrophic backtracking stalls the single-threaded server) and regex injection. This PR escapes the input so it is matched as a literal substring and caps its length.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `server/routes/jobs.js`: added an `escapeRegex` helper and applied it (with a 100-char cap) to `search` and `location` before building the case-insensitive `RegExp`s. The substring-search behaviour is preserved; attacker-supplied regex constructs are neutralized.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change and does not touch this project.

What I did verify:
- `node --check server/routes/jobs.js` passes.
- Behaviour test: the ReDoS pattern `(a+)+$` is escaped to `\(a\+\)\+\$` and runs in 0ms (no backtracking); a literal search like `node.js` still matches `Node.js dev`; and `a.c` no longer wildcard-matches `axc` (confirming literal matching).
- This PR touches the GET search handler (top of the file); it does not overlap the PUT update handler, so it is independent of the related job-update PR.

### Browser Compatibility Check
- N/A: server-side change.

### Responsive & Accessibility Checks
- N/A: no UI changes.

---

## 📷 Screenshots / Video Recording
N/A.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
