### PR TITLE
fix(diabetes-health-risk): import os so the backend starts (NameError)

### DIFF
--- a/public/Diabetes-Health-Risk/backend/app.py
+++ b/public/Diabetes-Health-Risk/backend/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, jsonify
 import pickle
+import os
 import numpy as np
 from flask_cors import CORS
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8464

### Summary
`app.py` called `os.getenv(...)` at startup without importing `os`, so running the backend raised `NameError: name 'os' is not defined`. This adds the missing import.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `backend/app.py`: added `import os` so `os.getenv("FLASK_DEBUG", ...)` in the `__main__` block resolves and the server starts.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change.

What I did verify:
- `python -m py_compile backend/app.py` passes.
- `import os` is present (line 3) above the `os.getenv` call, so the prior runtime `NameError` no longer occurs.

### Browser Compatibility Check
- N/A: server-side change.

### Responsive & Accessibility Checks
- N/A: no UI changes.

---

## 📷 Screenshots / Video Recording
N/A.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
