### PR TITLE
fix: prevent memory leak from unreleased Blob URLs

### DIFF
--- a/public/code-playground/script.js
+++ b/public/code-playground/script.js
@@ -3,6 +3,7 @@ const cssCode = document.getElementById('cssCode');
 const jsCode = document.getElementById('jsCode');
 const runBtn = document.getElementById('runBtn');
 const previewFrame = document.getElementById('previewFrame');
+let currentBlobUrl = null;
 
 function run() {
   const code = `
@@ -17,12 +18,25 @@ function run() {
     </body>
     </html>
   `;
-  
+
+  // Release previously created Blob URL
+  if (currentBlobUrl) {
+    URL.revokeObjectURL(currentBlobUrl);
+  }
+
   const blob = new Blob([code], { type: 'text/html' });
-  previewFrame.src = URL.createObjectURL(blob);
-}
+
+  currentBlobUrl = URL.createObjectURL(blob);
+  previewFrame.src = currentBlobUrl;
+} 
 
 runBtn.addEventListener('click', run);
+
+window.addEventListener('beforeunload', () => {
+  if (currentBlobUrl) {
+    URL.revokeObjectURL(currentBlobUrl);
+  }
+});
 
 // Initial live run on page load
 window.addEventListener('DOMContentLoaded', run);


### PR DESCRIPTION
### Related Issue
Fixes #8511

### Description
This PR fixes a memory leak in the Interactive Code Playground caused by unreleased Blob URLs.

Previously, every click on the Run Code button created a new Blob URL using `URL.createObjectURL()`, but old URLs were never revoked. Over time, this caused unnecessary memory consumption during extended editing sessions.

### Changes Made
- Added a variable to track the currently active Blob URL.
- Revoked the previous Blob URL before creating a new preview.
- Added cleanup logic using `beforeunload` to release the final Blob URL when the page is closed.

### Before
- A new Blob URL was created on every code execution.
- Previously generated Blob URLs remained in memory.
- Memory usage gradually increased over time.

### After
- Old Blob URLs are revoked before generating new previews.
- Memory remains stable during repeated code executions.
- Resources are properly cleaned up when leaving the page.

### Testing
- ✅ Ran code repeatedly and verified preview updates correctly.
- ✅ Confirmed previous Blob URLs are revoked before new ones are created.
- ✅ Verified no impact on existing functionality.
- ✅ Tested in Chrome on Windows 11.

### Result
This fix eliminates the Blob URL memory leak and ensures efficient resource management during long editing sessions.