### PR TITLE
fix: restrict spacebar palette generation to non-interactive page focus

### DIFF
--- a/public/Color-Pelette/index.html
+++ b/public/Color-Pelette/index.html
@@ -1,58 +1,157 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Color Palette Generator</title>
     <style>
-        body { margin: 0; display: flex; flex-direction: column; height: 100vh; font-family: sans-serif; }
-        .palette { display: flex; flex: 1; }
-        .color-box { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; cursor: pointer; transition: 0.3s; }
-        .color-box:hover { flex: 1.2; }
-        .hex-code { background: rgba(0,0,0,0.5); color: white; padding: 10px; border-radius: 5px; font-weight: bold; }
-        .controls { height: 80px; display: flex; align-items: center; justify-content: center; background: #333; color: white; }
-        button { padding: 15px 30px; font-size: 16px; cursor: pointer; border: none; border-radius: 5px; background: #007bff; color: white; }
+      body {
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        height: 100vh;
+        font-family: sans-serif;
+      }
+      .palette {
+        display: flex;
+        flex: 1;
+      }
+      .color-box {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        cursor: pointer;
+        transition: 0.3s;
+      }
+      .color-box:hover {
+        flex: 1.2;
+      }
+      .hex-code {
+        background: rgba(0, 0, 0, 0.5);
+        color: white;
+        padding: 10px;
+        border-radius: 5px;
+        font-weight: bold;
+      }
+      .controls {
+        height: 80px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: #333;
+        color: white;
+      }
+      button {
+        padding: 15px 30px;
+        font-size: 16px;
+        cursor: pointer;
+        border: none;
+        border-radius: 5px;
+        background: #007bff;
+        color: white;
+      }
     </style>
-</head>
-<body>
+  </head>
+  <body>
+    <div class="palette" id="palette">
+      <div
+        class="color-box"
+        role="button"
+        tabindex="0"
+        onclick="copyToClipboard(0)"
+      >
+        <div class="hex-code" id="hex0">#FFFFFF</div>
+      </div>
+      <div
+        class="color-box"
+        role="button"
+        tabindex="0"
+        onclick="copyToClipboard(1)"
+      >
+        <div class="hex-code" id="hex1">#FFFFFF</div>
+      </div>
+      <div
+        class="color-box"
+        role="button"
+        tabindex="0"
+        onclick="copyToClipboard(2)"
+      >
+        <div class="hex-code" id="hex2">#FFFFFF</div>
+      </div>
+      <div
+        class="color-box"
+        role="button"
+        tabindex="0"
+        onclick="copyToClipboard(3)"
+      >
+        <div class="hex-code" id="hex3">#FFFFFF</div>
+      </div>
+      <div
+        class="color-box"
+        role="button"
+        tabindex="0"
+        onclick="copyToClipboard(4)"
+      >
+        <div class="hex-code" id="hex4">#FFFFFF</div>
+      </div>
+    </div>
 
-<div class="palette" id="palette">
-    <div class="color-box" role="button" tabindex="0" onclick="copyToClipboard(0)"> <div class="hex-code" id="hex0">#FFFFFF</div> </div>
-    <div class="color-box" role="button" tabindex="0" onclick="copyToClipboard(1)"> <div class="hex-code" id="hex1">#FFFFFF</div> </div>
-    <div class="color-box" role="button" tabindex="0" onclick="copyToClipboard(2)"> <div class="hex-code" id="hex2">#FFFFFF</div> </div>
-    <div class="color-box" role="button" tabindex="0" onclick="copyToClipboard(3)"> <div class="hex-code" id="hex3">#FFFFFF</div> </div>
-    <div class="color-box" role="button" tabindex="0" onclick="copyToClipboard(4)"> <div class="hex-code" id="hex4">#FFFFFF</div> </div>
-</div>
+    <div class="controls">
+      <button onclick="generatePalette()">
+        Generate New Palette (or press Space)
+      </button>
+    </div>
 
-<div class="controls">
-    <button onclick="generatePalette()">Generate New Palette (or press Space)</button>
-</div>
+    <script>
+      const hexCodes = [];
 
-<script>
-    const hexCodes = [];
-
-    function generatePalette() {
+      function generatePalette() {
         for (let i = 0; i < 5; i++) {
-            const randomColor = '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
-            hexCodes[i] = randomColor;
-            document.getElementById(`hex${i}`).innerText = randomColor;
-            document.querySelectorAll('.color-box')[i].style.backgroundColor = randomColor;
+          const randomColor =
+            '#' +
+            Math.floor(Math.random() * 16777215)
+              .toString(16)
+              .padStart(6, '0');
+          hexCodes[i] = randomColor;
+          document.getElementById(`hex${i}`).innerText = randomColor;
+          document.querySelectorAll('.color-box')[i].style.backgroundColor =
+            randomColor;
         }
-    }
+      }
 
-    function copyToClipboard(index) {
+      function copyToClipboard(index) {
         navigator.clipboard.writeText(hexCodes[index]);
-        alert("Copied: " + hexCodes[index]);
-    }
+        alert('Copied: ' + hexCodes[index]);
+      }
 
-    // Add Spacebar listener
-    document.body.onkeyup = function(e) {
-        if (e.keyCode == 32) generatePalette();
-    }
+      // Add Spacebar listener
+      document.body.onkeyup = function (e) {
+        // Prevent palette generation when user is interacting
+        // with buttons, inputs, textareas, selects, or editable elements
+        const activeElement = document.activeElement;
 
-    // Initial generate
-    generatePalette();
-</script>
+        const isInteractiveElement =
+          activeElement &&
+          (activeElement.tagName === 'BUTTON' ||
+            activeElement.tagName === 'INPUT' ||
+            activeElement.tagName === 'TEXTAREA' ||
+            activeElement.tagName === 'SELECT' ||
+            activeElement.isContentEditable);
 
-</body>
+        if (isInteractiveElement) {
+          return;
+        }
+
+        if (e.code === 'Space') {
+          e.preventDefault();
+          generatePalette();
+        }
+      };
+
+      // Initial generate
+      generatePalette();
+    </script>
+  </body>
 </html>


### PR DESCRIPTION

### Related Issue
Fixes #8514

### Description
This PR fixes an issue where pressing the Spacebar anywhere on the page would generate a new color palette, regardless of the user's current focus.

Previously, the Spacebar shortcut was attached globally and triggered palette regeneration even when users were interacting with page controls. This could cause accidental loss of previously generated palettes.

### Changes Made
- Updated the Spacebar keyboard shortcut logic to check the currently focused element.
- Prevented palette generation when focus is on interactive elements such as:
  - Buttons
  - Input fields
  - Textareas
  - Select elements
  - Content-editable elements
- Replaced deprecated `keyCode` usage with modern `e.code === "Space"` handling.
- Added `preventDefault()` to avoid unintended browser behavior.

### Before
- Pressing Spacebar anywhere generated a new palette.
- Users could accidentally regenerate palettes while interacting with controls.
- Deprecated `keyCode` API was used.

### After
- Spacebar generates a new palette only when no interactive element is focused.
- Button interactions no longer trigger unintended palette changes.
- Keyboard shortcut behavior is more predictable and accessible.

### Testing
- ✅ Generate New Palette button still works correctly.
- ✅ Pressing Spacebar on the page generates a new palette.
- ✅ Pressing Spacebar while a button is focused does not generate a palette.
- ✅ Verified no accidental palette regeneration occurs during interaction with controls.
- ✅ Tested in Chrome on Windows 11.

### Result
The Spacebar shortcut now behaves as intended, preventing accidental palette regeneration while preserving quick keyboard access for generating new color palettes.