### PR TITLE
fix: prevent counter animation glitches during rapid clicks

### DIFF
--- a/public/counter-app/script.js
+++ b/public/counter-app/script.js
@@ -1,4 +1,5 @@
 let count = 0;
+let animationTimeout = null;
 
 const counterValue = document.getElementById('counter-value');
 const incrementBtn = document.getElementById('increment-btn');
@@ -9,31 +10,50 @@ const historyLog = document.getElementById('history-log');
 
 // Update UI
 function updateDisplay() {
-    counterValue.textContent = count;
-    // Simple visual pop on change
-    counterValue.style.transform = 'scale(1.1)';
-    setTimeout(() => counterValue.style.transform = 'scale(1)', 100);
+  counterValue.textContent = count;
+
+  // Prevent overlapping animation timers
+  if (animationTimeout) {
+    clearTimeout(animationTimeout);
+  }
+
+  // Restart animation cleanly
+  counterValue.style.transform = 'scale(1)';
+
+  // Force reflow so rapid clicks restart the animation
+  void counterValue.offsetWidth;
+
+  counterValue.style.transform = 'scale(1.1)';
+
+  animationTimeout = setTimeout(() => {
+    counterValue.style.transform = 'scale(1)';
+    animationTimeout = null;
+  }, 100);
 }
 
 // Event Listeners
 incrementBtn.addEventListener('click', () => {
-    count++;
-    updateDisplay();
+  count++;
+  updateDisplay();
 });
 
 decrementBtn.addEventListener('click', () => {
-    count--;
-    updateDisplay();
+  count--;
+  updateDisplay();
 });
 
 resetBtn.addEventListener('click', () => {
-    count = 0;
-    updateDisplay();
+  count = 0;
+  updateDisplay();
 });
 
 saveBtn.addEventListener('click', () => {
-    const li = document.createElement('li');
-    const timestamp = new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-    li.textContent = `Saved Count: ${count} at ${timestamp}`;
-    historyLog.prepend(li); // Adds newest log to the top
+  const li = document.createElement('li');
+  const timestamp = new Date().toLocaleTimeString([], {
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+  li.textContent = `Saved Count: ${count} at ${timestamp}`;
+  historyLog.prepend(li); // Adds newest log to the top
 });


### PR DESCRIPTION
### Related Issue
Fixes #8516

### Description
This PR fixes an issue where rapid clicks on the increment and decrement buttons caused multiple animation timers to overlap, resulting in flickering and inconsistent counter animations.

Previously, every counter update created a new `setTimeout()` without clearing any existing timer. During rapid interactions, multiple pending timers competed to reset the counter scale, producing visual glitches.

### Changes Made
- Added a dedicated timeout reference to track the active animation timer.
- Cleared any existing animation timeout before creating a new one.
- Restarted the animation cleanly on each update.
- Forced a reflow to ensure the scale animation can be replayed consistently during rapid clicks.
- Reset the timeout reference after animation completion.

### Before
- Each click created a new animation timeout.
- Rapid clicks stacked multiple timers.
- Counter animation flickered and became inconsistent.
- Scale resets could occur at unexpected times.

### After
- Only one animation timeout is active at any time.
- Rapid clicks smoothly restart the animation.
- No overlapping timers occur.
- Counter animation remains stable and predictable.

### Testing
- ✅ Rapidly clicked the increment button multiple times.
- ✅ Rapidly clicked the decrement button multiple times.
- ✅ Verified the animation remains smooth and consistent.
- ✅ Confirmed no flickering occurs.
- ✅ Verified reset functionality still works correctly.
- ✅ Tested in Chrome on Windows 11.

### Result
The counter animation now behaves consistently under rapid user interaction, eliminating flickering and ensuring a smooth visual experience.