### PR TITLE
fix: add recovery flow for country API failures

### DIFF
--- a/public/country-explorer/index.html
+++ b/public/country-explorer/index.html
@@ -28,6 +28,14 @@
       <div id="loading-msg" class="status-text">
         Fetching global database...
       </div>
+
+      <button
+        id="retry-btn"
+        class="toggle-btn"
+        style="display: none; margin: 15px auto"
+      >
+        Retry Loading Data
+      </button>
       <main id="countries-grid" class="grid-layout"></main>
     </div>
     <script src="script.js"></script>

--- a/public/country-explorer/script.js
+++ b/public/country-explorer/script.js
@@ -1,27 +1,37 @@
-const countriesGrid = document.getElementById("countries-grid");
-const searchBar = document.getElementById("search-bar");
-const regionFilter = document.getElementById("region-filter");
-const themeToggle = document.getElementById("theme-toggle");
-const loadingMsg = document.getElementById("loading-msg");
+const countriesGrid = document.getElementById('countries-grid');
+const searchBar = document.getElementById('search-bar');
+const regionFilter = document.getElementById('region-filter');
+const themeToggle = document.getElementById('theme-toggle');
+const loadingMsg = document.getElementById('loading-msg');
+const retryBtn = document.getElementById('retry-btn');
 
 let allCountries = [];
 
-// Theme Sync Management
-const storedTheme = localStorage.getItem("explorer-theme") || "dark";
-document.documentElement.setAttribute("data-theme", storedTheme);
+function setControlsEnabled(enabled) {
+  searchBar.disabled = !enabled;
+  regionFilter.disabled = !enabled;
+}
 
-themeToggle.addEventListener("click", () => {
-  const currentTheme = document.documentElement.getAttribute("data-theme");
-  const newTheme = currentTheme === "dark" ? "light" : "dark";
-  document.documentElement.setAttribute("data-theme", newTheme);
-  localStorage.setItem("explorer-theme", newTheme);
+// Theme Sync Management
+const storedTheme = localStorage.getItem('explorer-theme') || 'dark';
+document.documentElement.setAttribute('data-theme', storedTheme);
+
+themeToggle.addEventListener('click', () => {
+  const currentTheme = document.documentElement.getAttribute('data-theme');
+  const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+  document.documentElement.setAttribute('data-theme', newTheme);
+  localStorage.setItem('explorer-theme', newTheme);
 });
 
 // Asynchronous Data Fetch Engine
 async function initExplorer() {
+  setControlsEnabled(false);
+  retryBtn.style.display = 'none';
+  loadingMsg.style.display = 'block';
+
   try {
     const response = await fetch(
-      "https://restcountries.com/3.1/all?fields=name,flags,population,continences,region,capital",
+      'https://restcountries.com/3.1/all?fields=name,flags,population,continences,region,capital'
     );
     if (!response.ok) throw new Error();
     allCountries = await response.json();
@@ -29,16 +39,25 @@ async function initExplorer() {
     // Sort alphabetical arrays safely
     allCountries.sort((a, b) => a.name.common.localeCompare(b.name.common));
 
-    loadingMsg.style.display = "none";
+    loadingMsg.style.display = 'none';
+
+    setControlsEnabled(true);
+
     renderExplorerGrid(allCountries);
   } catch (err) {
+    allCountries = [];
+
+    setControlsEnabled(false);
+
     loadingMsg.textContent =
-      "Data network offline. Unable to populate metrics.";
+      'Data network offline. Unable to populate metrics.';
+
+    retryBtn.style.display = 'block';
   }
 }
 
 function renderExplorerGrid(countriesList) {
-  countriesGrid.innerHTML = "";
+  countriesGrid.innerHTML = '';
 
   if (countriesList.length === 0) {
     countriesGrid.innerHTML =
@@ -47,16 +66,16 @@ function renderExplorerGrid(countriesList) {
   }
 
   countriesList.forEach((country) => {
-    const card = document.createElement("div");
-    card.className = "country-card";
+    const card = document.createElement('div');
+    card.className = 'country-card';
 
     const capitalStr =
       country.capital && country.capital.length > 0
         ? country.capital[0]
-        : "N/A";
+        : 'N/A';
     const populationNum = country.population
       ? country.population.toLocaleString()
-      : "0";
+      : '0';
 
     card.innerHTML = `
             <img src="${country.flags.svg || country.flags.png}" class="flag-img" alt="Flag of ${country.name.common}">
@@ -86,7 +105,12 @@ function runFilterPipeline() {
   renderExplorerGrid(filtered);
 }
 
-searchBar.addEventListener("input", runFilterPipeline);
-regionFilter.addEventListener("change", runFilterPipeline);
+searchBar.addEventListener('input', runFilterPipeline);
+regionFilter.addEventListener('change', runFilterPipeline);
+
+retryBtn.addEventListener('click', () => {
+  loadingMsg.textContent = 'Fetching global database...';
+  initExplorer();
+});
 
 initExplorer();


### PR DESCRIPTION

### Related Issue
Fixes #8517

### Description
This PR fixes an issue where the application became non-functional after a failed REST Countries API request.

Previously, when the API request failed due to network issues, server errors, or API downtime, the application displayed an error message but left the search bar and region filter enabled. Since no country data was loaded, these controls could not function correctly and there was no way to recover without refreshing the page.

### Changes Made
- Added a helper function to enable/disable search and filter controls.
- Disabled search and region filter controls while data is loading.
- Kept controls disabled when API requests fail.
- Added a Retry button that appears after a failed API request.
- Added retry logic to allow users to fetch country data again without reloading the page.
- Automatically re-enabled controls after successful data loading.

### Before
- API failures left `allCountries` empty.
- Search and region filter remained active but unusable.
- Users had no way to recover without refreshing the page.
- Application appeared interactive despite having no available data.

### After
- Controls remain disabled until valid data is loaded.
- Controls stay disabled when API requests fail.
- Retry button appears after failures.
- Users can reload country data directly from the UI.
- Controls are automatically restored after a successful retry.

### Testing
- ✅ Verified search and region filter are disabled during loading.
- ✅ Simulated API failure and confirmed controls remain disabled.
- ✅ Confirmed Retry button appears after failure.
- ✅ Verified Retry successfully fetches data when the API becomes available.
- ✅ Confirmed controls are re-enabled after successful loading.
- ✅ Tested in Chrome on Windows 11.

### Result
The application now handles API failures gracefully by preventing unusable interactions and providing a built-in recovery mechanism without requiring a page refresh.