### PR TITLE
fix(ZenSpace): remove forced theme change from audio sliders

### DIFF
--- a/public/ZenSpace/app.js
+++ b/public/ZenSpace/app.js
@@ -22,9 +22,9 @@ document.addEventListener("DOMContentLoaded", () => {
     track.slider.addEventListener("input", (e) => {
       const vol = parseFloat(e.target.value);
       track.audio.volume = vol;
+      
       if (vol > 0 && track.audio.paused) {
         track.audio.play().catch(() => {});
-        document.documentElement.setAttribute("data-theme", track.theme);
       } else if (vol === 0) {
         track.audio.pause();
       }


### PR DESCRIPTION
📝 Pull Request Description
Related Issue
Closes #8392 

Summary
Removed the unintended UI theme-switching behavior triggered by the Ambient Mixer volume sliders. Users can now adjust background audio tracks freely without it overriding their global theme preference.

Type of Change
[x] 🐛 Bug fix (non-breaking change which fixes an issue)

[ ] ✨ New project addition

[ ] 🚀 New feature or UI/UX enhancement

[ ] ♻️ Code refactoring / clean-up

🛠️ Changes Made
Modified app.js within the Audio Mixer initialization block.

Removed the document.documentElement.setAttribute("data-theme", track.theme); execution from the slider's input event listener, which was previously forcing the global theme to change to "cozy" or "cafe" regardless of the user's actual toggle selection.

🧪 Testing and Verification
Local Validation
[x] I have run node scripts/validateProjects.js locally and it passed with zero errors.

Browser Compatibility Check
[x] Tested and verified in Google Chrome

[x] Tested and verified in Mozilla Firefox

Responsive & Accessibility Checks
[x] Verified slider operates independently of the global theme toggle.

📷 Screenshots / Video Recording
Note: This is a strict logic fix. No screenshots required as there are no visual changes.

🤝 Contributor Checklist
[x] My code follows the code style guidelines of this project.

[x] I have performed a self-review of my own code.

[x] My changes generate no new warnings or console errors.

[x] There are no unrelated changes or formatter noise in this PR.