### PR TITLE
Add dark/light theme toggle with localStorage

### DIFF
--- a/public/Word_dictionary/index.html
+++ b/public/Word_dictionary/index.html
@@ -1,19 +1,23 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="dark-mode">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Dictionary Search Space</title>
+      <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css">
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@300;400;500;600;700&family=Playfair+Display:ital,wght@0,600;0,700;1,400&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="style.css" />
+  <link rel="speaker-icon" href="favicon_word_dictionary.png">
 </head>
 <body>
   <a href="/" class="project-back-button">
     <span class="back-arrow">←</span> 
     <span class="back-text">Back to Home</span>
   </a>
-
+<span id="theme">
+    <i class="fa-notdog fa-solid fa-sun"></i>
+</span>
   <div class="glow-container">
     <div class="mesh-glow glow-1"></div>
     <div class="mesh-glow glow-2"></div>

--- a/public/Word_dictionary/script.js
+++ b/public/Word_dictionary/script.js
@@ -374,3 +374,31 @@ clearHistoryBtn.addEventListener('click', clearHistory);
 document.addEventListener('DOMContentLoaded', () => {
   renderHistory();
 });
+
+/*theme toggle*/
+const themeBtn = document.getElementById("theme");
+const icon = themeBtn.querySelector("i");
+
+// Load saved theme
+const savedTheme = localStorage.getItem("theme");
+
+if (savedTheme === "light") {
+    document.documentElement.classList.add("light-theme");
+    icon.classList.replace("fa-sun", "fa-moon");
+} else {
+    document.documentElement.classList.remove("light-theme");
+    icon.classList.replace("fa-moon", "fa-sun");
+}
+
+// Toggle theme
+themeBtn.addEventListener("click", () => {
+    document.documentElement.classList.toggle("light-theme");
+
+    if (document.documentElement.classList.contains("light-theme")) {
+        icon.classList.replace("fa-sun", "fa-moon");
+        localStorage.setItem("theme", "light");
+    } else {
+        icon.classList.replace("fa-moon", "fa-sun");
+        localStorage.setItem("theme", "dark");
+    }
+});

--- a/public/Word_dictionary/style.css
+++ b/public/Word_dictionary/style.css
@@ -7,14 +7,15 @@
   padding: 0;
 }
 
-:root {
+:root {--opp : white;
   --canvas: #090a0f;
   --panel-bg: rgba(255, 255, 255, 0.75);
   --panel-dark: rgba(15, 18, 28, 0.7);
   --text-primary: #0f141e;
-  --text-muted: #5c6475;
+  --text-muted: #a1a8b8;
   --text-soft: #8e97a4;
   --border-glass: rgba(226, 232, 240, 0.8);
+  --pagi: rgb(44, 44, 44);
 
   /* Precision Vibrant Accents */
   --prime: #4f46e5;
@@ -34,7 +35,29 @@
   --font-sans: 'Plus Jakarta Sans', system-ui, sans-serif;
   --font-serif: 'Playfair Display', Georgia, serif;
 }
+:root.light-theme {--opp : black;
+  --canvas: #f8fafc;
+  --panel-bg: rgba(255, 255, 255, 0.95);
+  --panel-dark: rgba(250, 246, 246, 0.9);
 
+  --text-primary: #111827;
+  --text-muted: #4b5563;
+  --text-soft: #6b7280;
+--pagi: rgb(220, 220, 220);
+  --border-glass: rgba(203, 213, 225, 0.8);
+
+  /* Keep brand colors or slightly soften them */
+  --prime: #4f46e5;
+  --prime-glow: rgba(79, 70, 229, 0.12);
+  --prime-gradient: linear-gradient(135deg, #4f46e5 0%, #7c3aed 100%);
+
+  --mint: #0284c7;
+  --rose: #db2777;
+
+  /* Optional extras */
+  --shadow-soft: rgba(15, 23, 42, 0.08);
+  --glass-bg: rgba(255, 255, 255, 0.75);
+}
 body {
   font-family: var(--font-sans);
   background: var(--canvas);
@@ -111,7 +134,24 @@ body {
   color: #7c3aed;
   font-weight: 700;
 }
+#theme {
+    position: fixed;
+    top: 20px;
+    right: 20px;
+    cursor: pointer;
+    font-size: 24px;
+    z-index: 1000;
+    padding: 10px;
+    border-radius: 50%;
+    transition: 0.3s ease;
+}
 
+#theme:hover {
+    transform: scale(1.1);
+}
+#theme .fa-moon {
+    color: #312e81;
+}
 .app-container {
   position: relative;
   z-index: 10;
@@ -165,10 +205,11 @@ body {
   font-family: monospace;
   color: var(--text-soft);
 }
+.meta-right kbd{ border-color: var(--text-soft);} 
 .shortcut-pill {
   font-family: monospace;
   background: rgba(255, 255, 255, 0.06);
-  color: #ffffff;
+  color: var(--opp);
   padding: 2px 6px;
   border-radius: 4px;
   font-size: 11px;
@@ -190,7 +231,7 @@ body {
   font-weight: 800;
   letter-spacing: -0.02em;
   line-height: 1.15;
-  color: #ffffff;
+  color: rgb(104, 104, 135);
   margin-bottom: 12px;
 }
 .gradient-text {
@@ -228,7 +269,7 @@ body {
   left: 16px;
   width: 18px;
   height: 18px;
-  color: var(--text-soft);
+  color: var(--opp);
   pointer-events: none;
 }
 #input {
@@ -237,7 +278,7 @@ body {
   font-family: var(--font-sans);
   font-size: 15px;
   font-weight: 500;
-  color: #ffffff;
+  color: var(--opp);
   background: rgba(0, 0, 0, 0.2);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: var(--radius-input);
@@ -431,7 +472,7 @@ body {
 .luxury-result-card {
   display: flex;
   flex-direction: column;
-  background: #ffffff;
+   background: var(--panel-dark);;
   border: 1px solid var(--border-glass);
   border-radius: var(--radius-card);
   box-shadow: 0 30px 60px -15px rgba(0, 0, 0, 0.3);
@@ -473,7 +514,7 @@ body {
   font-size: 46px;
   font-weight: 600;
   letter-spacing: -0.01em;
-  color: var(--text-primary);
+  color: var(--text-soft);
   line-height: 1.1;
 }
 .lexical-phonetic-string {
@@ -539,7 +580,7 @@ body {
 .lexical-definition-text {
   font-size: 16px;
   line-height: 1.6;
-  color: #334155;
+  color: #718096;
   font-weight: 400;
 }
 .lexical-context-example {
@@ -611,7 +652,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  background: #f8fafc;
+  background: var(--pagi);
   padding: 16px 36px;
   border-top: 1px solid #f1f5f9;
 }
@@ -727,7 +768,7 @@ body {
   cursor: pointer;
   font-size: 12px;
   font-weight: 600;
-  color: #fff;
+  color:  #9ca3af;
   background: rgba(219, 39, 119, 0.12);
   border: 1px solid rgba(219, 39, 119, 0.25);
   transition: all 0.25s ease;
@@ -753,7 +794,7 @@ body {
   background: rgba(79, 70, 229, 0.12);
   border: 1px solid rgba(79, 70, 229, 0.25);
 
-  color: #c7d2fe;
+  color: #848fb4;
   font-size: 13px;
   font-weight: 600;
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8497

### Summary
Added a dark/light theme toggle feature with persistent theme preference using localStorage. Users can switch between themes using the theme icon, and their selected theme is preserved across page reloads.

### Type of Change
- [x] 🚀 New feature or UI/UX enhancement


---

## 🛠️ Changes Made
-Added a theme toggle button positioned at the top-right corner.
-Implemented dark and light theme support using CSS variables.
-Added dynamic icon switching (Sun ↔ Moon) based on the active theme.
-Stored user theme preference in localStorage.
-Restored the saved theme automatically on page load.
-Improved theme toggle visibility and user experience.

---

## 🧪 Testing and Verification

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [x] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [x] Verified responsive layout on Mobile viewports (using DevTools)
- [x] Verified responsive layout on Tablet viewports

---

## 📷 Screenshots
<img width="603" height="812" alt="Screenshot 2026-06-17 011139" src="https://github.com/user-attachments/assets/628cf224-c3f3-4fc2-a9c2-d60ca9d911fc" />
<img width="598" height="806" alt="Screenshot 2026-06-17 011125" src="https://github.com/user-attachments/assets/60d224d4-9bfb-4573-93df-5501c048d622" />

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.

