### PR TITLE
fix: remove duplicate Font Awesome stylesheet import in stats dashboard

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="Real-time stats dashboard for 100 Days 100 Web Projects – category breakdown, project status, and contributor metrics.">
 <title>Project Stats — 100 Days 100 Web Projects</title>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <style>


### PR DESCRIPTION
## Description

This PR removes a duplicate Font Awesome stylesheet import from `stats.html`.

### Issue

The same Font Awesome 6.4.2 stylesheet was being loaded twice:

* One import without Subresource Integrity (SRI)
* One import with SRI, `crossorigin`, and `referrerpolicy`

Loading the same render-blocking stylesheet twice causes an unnecessary network request and may slightly delay page rendering.

### Changes Made

* Removed the duplicate Font Awesome stylesheet import.
* Retained the version that includes:

  * `integrity`
  * `crossorigin`
  * `referrerpolicy`

### Benefits

* Eliminates redundant resource loading.
* Improves page performance.
* Keeps secure resource loading through SRI.
* Reduces unnecessary render-blocking requests.

### Testing

* Verified that Font Awesome icons continue to render correctly.
* Confirmed only a single request for `all.min.css` appears in the browser Network tab.

###Screenshots 
<img width="1460" height="840" alt="Screenshot 2026-06-17 at 9 03 21 PM" src="https://github.com/user-attachments/assets/f0ec3554-d9b6-449d-afd3-41c5691b1a0c" />



Closes #8816 