### PR TITLE
fix: make navigation icons keyboard accessible

### DIFF
--- a/public/WORDLE/assets/css/style.css
+++ b/public/WORDLE/assets/css/style.css
@@ -463,3 +463,22 @@ body.dark-mode .modal-content .cross {
 body.dark-mode .modal-content .cross:hover {
     color: #ffffff;
 }
+.nav-icon-btn {
+    background: transparent;
+    border: none;
+    padding: 4px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.nav-icon-btn:focus-visible {
+    outline: 3px solid #3b82f6;
+    outline-offset: 3px;
+    border-radius: 6px;
+}
+
+.nav-icon-btn:hover {
+    opacity: 0.85;
+}

--- a/public/WORDLE/index.html
+++ b/public/WORDLE/index.html
@@ -15,22 +15,32 @@
     <!-- Clean, centered navbar -->
     <ul class='navbar' style="justify-content: center; position: relative;">
         <li style="position: absolute; right: 20px;">
-            <img class='info navele nav__icon' src="img/information.png" alt="Info">
-        </li>
+    <button
+        class="nav-icon-btn info"
+        aria-label="Open information"
+        title="Information">
+        <img class="navele nav__icon" src="img/information.png" alt="">
+    </button>
+</li>
         <li>
             <h1 class="heading navele" style="margin: 0;">Wordle</h1>
         </li>
         <li style="position: absolute; right: 75px; display: flex; gap: 15px; align-items: center;">
-            <img class='stats navele nav__icon' src="img/statistics.png" alt="Stats">
+            <button
+    class="nav-icon-btn stats"
+    aria-label="Open statistics"
+    title="Statistics">
+    <img class="navele nav__icon" src="img/statistics.png" alt="">
+</button>
             <span id="themeToggle" style="cursor: pointer; font-size: 24px;">🌙</span>
         </li>
     </ul>
     <hr style="border-color: rgba(200,200,200,0.2); margin-bottom: 20px;" />
 
-    <div class='message hidden' id='message'></div>
+    <div class='hidden message' id='message'></div>
     
     <!-- Popups -->
-    <div class='infoCard hidden popup' id="rules">
+    <div class='hidden infoCard popup' id="rules">
         <p class='crossOuter'><button class='cross' id='closeInfo'>&#9587</button></p>
         <p>Guess the <strong>WORDLE</strong> in six tries.</p>
         <p>Each guess must be a valid five-letter word. Hit the enter button to submit.</p>
@@ -39,7 +49,7 @@
         <p><strong>A new WORDLE will be available each day!</strong></p>
     </div>
 
-    <div class="infoCard hidden popup" id="stats">
+    <div class="hidden infoCard popup" id="stats">
         <p class='crossOuter'><button class='cross' id='closeStats'>&#9587</button></p>
         <p><strong>STATISTICS</strong></p>
         <p>0 &emsp;&emsp;0 &emsp;&emsp;0 &emsp;&emsp;0</p>
@@ -75,7 +85,7 @@
     </div>
 
     <!-- Game Over Modal Overlay -->
-    <div id="game-over-modal" class="modal-overlay hidden">
+    <div id="game-over-modal" class="hidden modal-overlay">
         <div class="modal-content">
             <button class="cross" id="closeGameOver">&#9587;</button>
             <div class="modal-body">


### PR DESCRIPTION
## Summary

This PR fixes an accessibility issue where the Information and Statistics controls in the navigation bar were implemented as non-interactive `<img>` elements.

Because images are not keyboard-focusable by default, keyboard users could not navigate to or activate these controls using Tab, Enter, or Space.

## Changes Made

- Replaced Information icon `<img>` with an accessible `<button>`.
- Replaced Statistics icon `<img>` with an accessible `<button>`.
- Added appropriate `aria-label` attributes.
- Added visible keyboard focus indicators using `:focus-visible`.
- Preserved existing styling and functionality.

## Accessibility Improvements

Users can now:

- Navigate to Information and Statistics controls using Tab.
- Activate controls using Enter.
- Activate controls using Space.
- Clearly identify focused controls through visible focus outlines.

## Testing

- ✅ Tab navigation reaches both controls.
- ✅ Enter opens the corresponding modal.
- ✅ Space opens the corresponding modal.
- ✅ Focus indicator is visible.
- ✅ Existing mouse interaction remains unchanged.

## Issue Fixed

Closes #8642