### PR TITLE
fix: resolve game over styling by matching element id

### DIFF
--- a/public/Whack a mole/script.js
+++ b/public/Whack a mole/script.js
@@ -64,7 +64,7 @@ function StartGame() {
 
     startButton.disabled = true;   // prevent double-start
 
-    const gameOver = document.getElementById('GameOver');
+    const gameOver = document.getElementById('gameOver');
     if (gameOver) gameOver.style.display = 'none';
 
     MolePopUp();

--- a/public/Whack a mole/whack_a_mole.html
+++ b/public/Whack a mole/whack_a_mole.html
@@ -25,7 +25,7 @@
             <div class="hole" id="hole8"><div class="mole"></div></div>
             <div class="hole" id="hole9"><div class="mole"></div></div>
         </div>
-        <p id="GameOver" style="display: none;">Game Over!!</p>
+        <p id="gameOver" style="display: none;">Game Over!!</p>
         <button id="startButton">Start Game</button>
         <audio id="whackSound" src="whack.mp3"></audio>
     </div>


### PR DESCRIPTION
## Summary

This PR fixes an issue where the "Game Over!!" message was not receiving its intended styling due to an ID mismatch between the HTML and CSS.

## Root Cause

The HTML defined the element as:

```html
<p id="GameOver">Game Over!!</p>
```

while the CSS targeted:

```css
#gameOver
```

Because CSS ID selectors are case-sensitive, the styles were never applied.

## Changes Made

- Renamed the HTML element ID from `GameOver` to `gameOver`.
- Updated the corresponding JavaScript selector to use the new ID.
- Kept the existing CSS unchanged.

## Testing

- ✅ Game Over message appears when the timer reaches zero.
- ✅ Yellow text color is applied.
- ✅ Font size and bold styling are applied.
- ✅ Margin spacing is applied correctly.
- ✅ Existing game functionality remains unchanged.

## Issue Fixed

Closes #8643