### PR TITLE
fix: prevent multiple option selection before question transition completes

### DIFF
--- a/public/WebsitePersonalizer/index.html
+++ b/public/WebsitePersonalizer/index.html
@@ -1,190 +1,249 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Website Personalizer</title>
-  <link rel="stylesheet" href="style.css">
-  <link rel="icon" href="favicon_website_personalizer.png">
-</head>
-<body>
-<a href="/" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 16px;border-radius:8px;background:#1e293b;color:#3b82f6;border:1px solid #3b82f6;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;transition:all 0.2s ease;" onmouseover="this.style.background='#3b82f6';this.style.color='#fff'" onmouseout="this.style.background='#1e293b';this.style.color='#3b82f6'">← Back to Home</a>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Website Personalizer</title>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="icon" href="favicon_website_personalizer.png" />
+  </head>
+  <body>
+    <a
+      href="/"
+      class="project-back-button"
+      style="
+        position: fixed;
+        left: 18px;
+        top: 18px;
+        padding: 8px 16px;
+        border-radius: 8px;
+        background: #1e293b;
+        color: #3b82f6;
+        border: 1px solid #3b82f6;
+        text-decoration: none;
+        z-index: 9999;
+        font-weight: 700;
+        font-family: Inter, system-ui, sans-serif;
+        transition: all 0.2s ease;
+      "
+      onmouseover="
+        this.style.background = '#3b82f6';
+        this.style.color = '#fff';
+      "
+      onmouseout="
+        this.style.background = '#1e293b';
+        this.style.color = '#3b82f6';
+      "
+      >← Back to Home</a
+    >
 
-
-  <div id="quiz-phase" class="phase active">
-    <div class="quiz-wrap">
-      <div class="quiz-progress">
-        <div class="progress-bar"><div id="progress-fill"></div></div>
-        <span id="progress-label">1 / 5</span>
+    <div id="quiz-phase" class="phase active">
+      <div class="quiz-wrap">
+        <div class="quiz-progress">
+          <div class="progress-bar"><div id="progress-fill"></div></div>
+          <span id="progress-label">1 / 5</span>
+        </div>
+        <div id="card-stack"></div>
       </div>
-      <div id="card-stack"></div>
     </div>
-  </div>
 
-  <div id="brew-phase" class="phase">
-    <div class="brew-wrap">
-      <div class="brew-terminal">
-        <div class="term-bar">
-          <span class="dot red"></span><span class="dot yellow"></span><span class="dot green"></span>
-          <span class="term-title">personalizer.sh</span>
-        </div>
-        <div class="term-body">
-          <div id="brew-lines"></div>
-          <div class="term-cursor"></div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div id="site-phase" class="phase">
-
-    <div class="blob blob-1"></div>
-    <div class="blob blob-2"></div>
-    <div class="blob blob-3"></div>
-    <div class="grain-layer"></div>
-    <div class="grid-layer" id="grid-layer"></div>
-
-    <nav class="navbar">
-      <div class="logo" id="studio-name">FORMA</div>
-      <div class="nav-links">
-        <a href="#" id="nav-1">Work</a>
-        <a href="#" id="nav-2">About</a>
-        <a href="#" id="nav-3">Lab</a>
-        <a href="#" id="nav-4">Contact</a>
-      </div>
-      <button id="repersonalize-btn">Repersonalize</button>
-    </nav>
-
-    <header class="hero-section">
-      <div class="hero-copy">
-        <p class="hero-tag" id="hero-tag">Creative Studio</p>
-        <h1 class="hero-heading">
-          We craft <em id="hero-em">digital</em><br>experiences
-        </h1>
-        <p class="hero-sub" id="hero-sub">Branding · Motion · Web · Strategy</p>
-        <div class="hero-cta">
-          <button class="btn-primary">See Our Work</button>
-          <button class="btn-ghost">Get in Touch</button>
-        </div>
-      </div>
-
-      <div class="hero-media" id="hero-media">
-        <div class="hero-shape" id="hero-shape"></div>
-        <div class="hero-code" id="hero-code">
-          <div class="hc-bar">
-            <span class="hc-prompt">$</span> cat studio.config
+    <div id="brew-phase" class="phase">
+      <div class="brew-wrap">
+        <div class="brew-terminal">
+          <div class="term-bar">
+            <span class="dot red"></span><span class="dot yellow"></span
+            ><span class="dot green"></span>
+            <span class="term-title">personalizer.sh</span>
           </div>
-          <pre class="hc-body"><span class="ck">const</span> <span class="cv">studio</span> = {
+          <div class="term-body">
+            <div id="brew-lines"></div>
+            <div class="term-cursor"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div id="site-phase" class="phase">
+      <div class="blob blob-1"></div>
+      <div class="blob blob-2"></div>
+      <div class="blob blob-3"></div>
+      <div class="grain-layer"></div>
+      <div class="grid-layer" id="grid-layer"></div>
+
+      <nav class="navbar">
+        <div class="logo" id="studio-name">FORMA</div>
+        <div class="nav-links">
+          <a href="#" id="nav-1">Work</a>
+          <a href="#" id="nav-2">About</a>
+          <a href="#" id="nav-3">Lab</a>
+          <a href="#" id="nav-4">Contact</a>
+        </div>
+        <button id="repersonalize-btn">Repersonalize</button>
+      </nav>
+
+      <header class="hero-section">
+        <div class="hero-copy">
+          <p class="hero-tag" id="hero-tag">Creative Studio</p>
+          <h1 class="hero-heading">
+            We craft <em id="hero-em">digital</em><br />experiences
+          </h1>
+          <p class="hero-sub" id="hero-sub">
+            Branding · Motion · Web · Strategy
+          </p>
+          <div class="hero-cta">
+            <button class="btn-primary">See Our Work</button>
+            <button class="btn-ghost">Get in Touch</button>
+          </div>
+        </div>
+
+        <div class="hero-media" id="hero-media">
+          <div class="hero-shape" id="hero-shape"></div>
+          <div class="hero-code" id="hero-code">
+            <div class="hc-bar">
+              <span class="hc-prompt">$</span> cat studio.config
+            </div>
+            <pre
+              class="hc-body"
+            ><span class="ck">const</span> <span class="cv">studio</span> = {
   name:   <span class="cs">"FRG.SYS"</span>,
   stack:  <span class="cs">"next-gen"</span>,
   mode:   <span class="cs">"always_on"</span>,
   craft:  [<span class="cs">"web"</span>, <span class="cs">"code"</span>, <span class="cs">"motion"</span>],
   status: <span class="cs">"online"</span>  <span class="ck">// ██████ 100%</span>
 }<span class="c-blink">▮</span></pre>
+          </div>
+        </div>
+      </header>
+
+      <div class="marquee">
+        <div class="marquee-track">
+          <span>Branding</span><span class="msep">·</span> <span>Motion</span
+          ><span class="msep">·</span> <span>Development</span
+          ><span class="msep">·</span> <span>Art Direction</span
+          ><span class="msep">·</span> <span>Strategy</span
+          ><span class="msep">·</span> <span>Branding</span
+          ><span class="msep">·</span> <span>Motion</span
+          ><span class="msep">·</span> <span>Development</span
+          ><span class="msep">·</span> <span>Art Direction</span
+          ><span class="msep">·</span> <span>Strategy</span
+          ><span class="msep">·</span>
         </div>
       </div>
-    </header>
 
-    <div class="marquee">
-      <div class="marquee-track">
-        <span>Branding</span><span class="msep">·</span>
-        <span>Motion</span><span class="msep">·</span>
-        <span>Development</span><span class="msep">·</span>
-        <span>Art Direction</span><span class="msep">·</span>
-        <span>Strategy</span><span class="msep">·</span>
-        <span>Branding</span><span class="msep">·</span>
-        <span>Motion</span><span class="msep">·</span>
-        <span>Development</span><span class="msep">·</span>
-        <span>Art Direction</span><span class="msep">·</span>
-        <span>Strategy</span><span class="msep">·</span>
-      </div>
+      <section class="work-section">
+        <div class="work-top">
+          <h2>Selected Work</h2>
+          <a href="#" class="work-all">View all →</a>
+        </div>
+        <div class="work-grid">
+          <div class="work-card" data-index="0">
+            <div class="work-thumb"><span class="work-num">01</span></div>
+            <div class="work-info">
+              <span class="work-tag">Branding</span>
+              <h3>Aether Identity</h3>
+              <p class="proj-desc">
+                Full brand system for a tech startup — mark, type, and motion
+                guidelines.
+              </p>
+            </div>
+          </div>
+          <div class="work-card" data-index="1">
+            <div class="work-thumb"><span class="work-num">02</span></div>
+            <div class="work-info">
+              <span class="work-tag">Web</span>
+              <h3>Solstice Digital</h3>
+              <p class="proj-desc">
+                E-commerce platform with custom interaction design and 3D
+                product views.
+              </p>
+            </div>
+          </div>
+          <div class="work-card" data-index="2">
+            <div class="work-thumb"><span class="work-num">03</span></div>
+            <div class="work-info">
+              <span class="work-tag">Motion</span>
+              <h3>Drift Campaign</h3>
+              <p class="proj-desc">
+                Integrated motion campaign across OOH, social, and broadcast
+                channels.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section class="services-section">
+        <div class="services-intro">
+          <h2 id="services-h2">What We Do</h2>
+          <p id="services-sub">
+            End-to-end creative execution for brands that want to stand out.
+          </p>
+        </div>
+        <div class="serv-grid">
+          <div class="serv-item" data-num="01">
+            <h3>Brand Identity</h3>
+            <p>
+              Logo, system, voice. Built to outlast trends and built to scale.
+            </p>
+          </div>
+          <div class="serv-item" data-num="02">
+            <h3>Digital Design</h3>
+            <p>
+              Web, app, motion — pixels with purpose and interfaces that
+              convert.
+            </p>
+          </div>
+          <div class="serv-item" data-num="03">
+            <h3>Strategy</h3>
+            <p>
+              Research-backed positioning for ambitious brands at every stage.
+            </p>
+          </div>
+          <div class="serv-item" data-num="04">
+            <h3>Creative Direction</h3>
+            <p>Unifying creative voice across every touchpoint and platform.</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="about-section">
+        <div class="about-text">
+          <h2 id="about-h2">We are Forma</h2>
+          <p>
+            A small team of designers and developers who care deeply about the
+            craft. We work with ambitious brands to create work that sticks.
+          </p>
+          <a href="#" class="about-link">Our story →</a>
+        </div>
+        <div class="about-stats">
+          <div class="stat">
+            <span class="stat-num">7+</span
+            ><span class="stat-label">Years</span>
+          </div>
+          <div class="stat">
+            <span class="stat-num">120</span
+            ><span class="stat-label">Projects</span>
+          </div>
+          <div class="stat">
+            <span class="stat-num">40</span
+            ><span class="stat-label">Clients</span>
+          </div>
+        </div>
+      </section>
+
+      <footer class="page-footer">
+        <div class="footer-left">
+          <span class="footer-logo" id="footer-name">FORMA</span>
+          <span class="footer-copy">© 2025. All rights reserved.</span>
+        </div>
+        <div class="footer-right">
+          <a href="#">Twitter</a>
+          <a href="#">Dribbble</a>
+          <a href="#">LinkedIn</a>
+        </div>
+      </footer>
     </div>
 
-    <section class="work-section">
-      <div class="work-top">
-        <h2>Selected Work</h2>
-        <a href="#" class="work-all">View all →</a>
-      </div>
-      <div class="work-grid">
-        <div class="work-card" data-index="0">
-          <div class="work-thumb"><span class="work-num">01</span></div>
-          <div class="work-info">
-            <span class="work-tag">Branding</span>
-            <h3>Aether Identity</h3>
-            <p class="proj-desc">Full brand system for a tech startup — mark, type, and motion guidelines.</p>
-          </div>
-        </div>
-        <div class="work-card" data-index="1">
-          <div class="work-thumb"><span class="work-num">02</span></div>
-          <div class="work-info">
-            <span class="work-tag">Web</span>
-            <h3>Solstice Digital</h3>
-            <p class="proj-desc">E-commerce platform with custom interaction design and 3D product views.</p>
-          </div>
-        </div>
-        <div class="work-card" data-index="2">
-          <div class="work-thumb"><span class="work-num">03</span></div>
-          <div class="work-info">
-            <span class="work-tag">Motion</span>
-            <h3>Drift Campaign</h3>
-            <p class="proj-desc">Integrated motion campaign across OOH, social, and broadcast channels.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section class="services-section">
-      <div class="services-intro">
-        <h2 id="services-h2">What We Do</h2>
-        <p id="services-sub">End-to-end creative execution for brands that want to stand out.</p>
-      </div>
-      <div class="serv-grid">
-        <div class="serv-item" data-num="01">
-          <h3>Brand Identity</h3>
-          <p>Logo, system, voice. Built to outlast trends and built to scale.</p>
-        </div>
-        <div class="serv-item" data-num="02">
-          <h3>Digital Design</h3>
-          <p>Web, app, motion — pixels with purpose and interfaces that convert.</p>
-        </div>
-        <div class="serv-item" data-num="03">
-          <h3>Strategy</h3>
-          <p>Research-backed positioning for ambitious brands at every stage.</p>
-        </div>
-        <div class="serv-item" data-num="04">
-          <h3>Creative Direction</h3>
-          <p>Unifying creative voice across every touchpoint and platform.</p>
-        </div>
-      </div>
-    </section>
-
-    <section class="about-section">
-      <div class="about-text">
-        <h2 id="about-h2">We are Forma</h2>
-        <p>A small team of designers and developers who care deeply about the craft. We work with ambitious brands to create work that sticks.</p>
-        <a href="#" class="about-link">Our story →</a>
-      </div>
-      <div class="about-stats">
-        <div class="stat"><span class="stat-num">7+</span><span class="stat-label">Years</span></div>
-        <div class="stat"><span class="stat-num">120</span><span class="stat-label">Projects</span></div>
-        <div class="stat"><span class="stat-num">40</span><span class="stat-label">Clients</span></div>
-      </div>
-    </section>
-
-    <footer class="page-footer">
-      <div class="footer-left">
-        <span class="footer-logo" id="footer-name">FORMA</span>
-        <span class="footer-copy">© 2025. All rights reserved.</span>
-      </div>
-      <div class="footer-right">
-        <a href="#">Twitter</a>
-        <a href="#">Dribbble</a>
-        <a href="#">LinkedIn</a>
-      </div>
-    </footer>
-
-  </div>
-
-  <script src="script.js"></script>
-</body>
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/public/WebsitePersonalizer/script.js
+++ b/public/WebsitePersonalizer/script.js
@@ -3,91 +3,91 @@ const QUESTIONS = [
     id: 'vibe',
     text: "What's your aesthetic vibe?",
     opts: [
-      { label: '✦  Clean & Minimal',   val: 'minimal'   },
-      { label: '⬡  Dark & Cyberpunk',  val: 'cyberpunk'  },
-      { label: '✿  Soft & Aesthetic',  val: 'aesthetic'  },
-      { label: '◼  BOLD & LOUD',       val: 'bold'       },
+      { label: '✦  Clean & Minimal', val: 'minimal' },
+      { label: '⬡  Dark & Cyberpunk', val: 'cyberpunk' },
+      { label: '✿  Soft & Aesthetic', val: 'aesthetic' },
+      { label: '◼  BOLD & LOUD', val: 'bold' },
     ],
   },
   {
     id: 'mode',
     text: 'Light or dark interface?',
     opts: [
-      { label: '☀  Light — bright & clean',    val: 'light' },
-      { label: '◐  Dark — easy on the eyes',   val: 'dark'  },
+      { label: '☀  Light — bright & clean', val: 'light' },
+      { label: '◐  Dark — easy on the eyes', val: 'dark' },
     ],
   },
   {
     id: 'color',
     text: 'Pick your signature color.',
     opts: [
-      { label: '▲  Electric Violet',  val: 'violet'  },
-      { label: '●  Crimson Rose',     val: 'rose'    },
-      { label: '◆  Deep Emerald',     val: 'emerald' },
-      { label: '■  Warm Amber',       val: 'amber'   },
+      { label: '▲  Electric Violet', val: 'violet' },
+      { label: '●  Crimson Rose', val: 'rose' },
+      { label: '◆  Deep Emerald', val: 'emerald' },
+      { label: '■  Warm Amber', val: 'amber' },
     ],
   },
   {
     id: 'motion',
     text: 'How much motion feels right?',
     opts: [
-      { label: '〜  Fluid & expressive',   val: 'fluid'  },
-      { label: '·   Subtle — just hints',  val: 'subtle' },
-      { label: '⟳  Slow & cinematic',     val: 'slow'   },
-      { label: '—  None — keep it still', val: 'none'   },
+      { label: '〜  Fluid & expressive', val: 'fluid' },
+      { label: '·   Subtle — just hints', val: 'subtle' },
+      { label: '⟳  Slow & cinematic', val: 'slow' },
+      { label: '—  None — keep it still', val: 'none' },
     ],
   },
   {
     id: 'typo',
     text: "What's your reading style?",
     opts: [
-      { label: '≡  Compact & dense',   val: 'compact' },
-      { label: '=  Default balance',   val: 'default' },
-      { label: '≈  Relaxed & roomy',   val: 'relaxed' },
-      { label: '↔  Wide-spaced prose', val: 'wide'    },
+      { label: '≡  Compact & dense', val: 'compact' },
+      { label: '=  Default balance', val: 'default' },
+      { label: '≈  Relaxed & roomy', val: 'relaxed' },
+      { label: '↔  Wide-spaced prose', val: 'wide' },
     ],
   },
 ];
 
 const VIBES = {
   minimal: {
-    name:     'FORMA',
-    tag:      'Design Studio',
-    em:       'considered',
-    sub:      'Clarity · Craft · Restraint',
-    servH:    'What We Do',
-    servSub:  'Careful work for brands that know less is more.',
-    aboutH:   'We are Forma',
+    name: 'FORMA',
+    tag: 'Design Studio',
+    em: 'considered',
+    sub: 'Clarity · Craft · Restraint',
+    servH: 'What We Do',
+    servSub: 'Careful work for brands that know less is more.',
+    aboutH: 'We are Forma',
     navLinks: ['Work', 'Studio', 'Process', 'Contact'],
   },
   cyberpunk: {
-    name:     'FRG.SYS',
-    tag:      'DIGITAL_FORGE // v2.4',
-    em:       'next-gen',
-    sub:      'Code · Neon · Systems · Edge',
-    servH:    'SERVICES.LIST',
-    servSub:  'Stack-agnostic. Deadline-proof. Always online.',
-    aboutH:   'We are FRG.SYS',
+    name: 'FRG.SYS',
+    tag: 'DIGITAL_FORGE // v2.4',
+    em: 'next-gen',
+    sub: 'Code · Neon · Systems · Edge',
+    servH: 'SERVICES.LIST',
+    servSub: 'Stack-agnostic. Deadline-proof. Always online.',
+    aboutH: 'We are FRG.SYS',
     navLinks: ['./work', './about', './lab', './contact'],
   },
   aesthetic: {
-    name:     'AURA',
-    tag:      'Creative Atelier',
-    em:       'beautiful',
-    sub:      'Beauty · Flow · Form · Feeling',
-    servH:    'Our Offerings',
-    servSub:  'Gentle, intentional, deeply considered creative work.',
-    aboutH:   'We are Aura',
+    name: 'AURA',
+    tag: 'Creative Atelier',
+    em: 'beautiful',
+    sub: 'Beauty · Flow · Form · Feeling',
+    servH: 'Our Offerings',
+    servSub: 'Gentle, intentional, deeply considered creative work.',
+    aboutH: 'We are Aura',
     navLinks: ['Work', 'Story', 'Studio', 'Connect'],
   },
   bold: {
-    name:     'BLCK',
-    tag:      'IMPACT STUDIO — EST. 2018',
-    em:       'LOUD',
-    sub:      'Power · Identity · Edge · No Apologies',
-    servH:    'WHAT WE DO',
-    servSub:  'Big brands. Bigger ideas. No compromises.',
-    aboutH:   'WE ARE BLCK',
+    name: 'BLCK',
+    tag: 'IMPACT STUDIO — EST. 2018',
+    em: 'LOUD',
+    sub: 'Power · Identity · Edge · No Apologies',
+    servH: 'WHAT WE DO',
+    servSub: 'Big brands. Bigger ideas. No compromises.',
+    aboutH: 'WE ARE BLCK',
     navLinks: ['WORK', 'ABOUT', 'LAB', 'CONTACT'],
   },
 };
@@ -110,13 +110,14 @@ const BREW_LINES = [
 
 const answers = {};
 let current = 0;
+let isTransitioning = false;
 
-const quizPhase  = document.getElementById('quiz-phase');
-const brewPhase  = document.getElementById('brew-phase');
-const sitePhase  = document.getElementById('site-phase');
-const cardStack  = document.getElementById('card-stack');
-const fillEl     = document.getElementById('progress-fill');
-const labelEl    = document.getElementById('progress-label');
+const quizPhase = document.getElementById('quiz-phase');
+const brewPhase = document.getElementById('brew-phase');
+const sitePhase = document.getElementById('site-phase');
+const cardStack = document.getElementById('card-stack');
+const fillEl = document.getElementById('progress-fill');
+const labelEl = document.getElementById('progress-label');
 
 function buildCard(q, idx) {
   const card = document.createElement('div');
@@ -125,34 +126,53 @@ function buildCard(q, idx) {
     <span class="q-num">Question ${idx + 1} of ${QUESTIONS.length}</span>
     <p class="q-text">${q.text}</p>
     <div class="q-options">
-      ${q.opts.map(o => `<button class="q-opt" data-val="${o.val}">${o.label}</button>`).join('')}
+      ${q.opts.map((o) => `<button class="q-opt" data-val="${o.val}">${o.label}</button>`).join('')}
     </div>
   `;
-  card.querySelectorAll('.q-opt').forEach(btn => {
+  card.querySelectorAll('.q-opt').forEach((btn) => {
     btn.addEventListener('click', () => pick(q.id, btn.dataset.val, card));
   });
   return card;
 }
 
 function pick(qid, val, card) {
+  if (isTransitioning) return;
+
+  isTransitioning = true;
+
   answers[qid] = val;
-  card.querySelectorAll('.q-opt').forEach(b => b.classList.toggle('selected', b.dataset.val === val));
+
+  const options = card.querySelectorAll('.q-opt');
+
+  options.forEach((btn) => {
+    btn.disabled = true;
+
+    btn.classList.toggle('selected', btn.dataset.val === val);
+  });
+
   setTimeout(() => {
     card.classList.add('exit');
+
     setTimeout(() => {
       card.remove();
+
       current++;
+
+      isTransitioning = false;
+
       current < QUESTIONS.length ? showCard(current) : startBrew();
     }, 380);
   }, 180);
 }
 
 function showCard(idx) {
-  fillEl.style.width  = `${((idx + 1) / QUESTIONS.length) * 100}%`;
+  fillEl.style.width = `${((idx + 1) / QUESTIONS.length) * 100}%`;
   labelEl.textContent = `${idx + 1} / ${QUESTIONS.length}`;
   const card = buildCard(QUESTIONS[idx], idx);
   cardStack.appendChild(card);
-  requestAnimationFrame(() => requestAnimationFrame(() => card.classList.add('visible')));
+  requestAnimationFrame(() =>
+    requestAnimationFrame(() => card.classList.add('visible'))
+  );
 }
 
 function startBrew() {
@@ -161,7 +181,10 @@ function startBrew() {
   const linesEl = document.getElementById('brew-lines');
   let i = 0;
   function next() {
-    if (i >= BREW_LINES.length) { setTimeout(revealSite, 700); return; }
+    if (i >= BREW_LINES.length) {
+      setTimeout(revealSite, 700);
+      return;
+    }
     const { text, cls } = BREW_LINES[i];
     const span = document.createElement('span');
     span.className = 'term-line' + (cls ? ` ${cls}` : '');
@@ -175,29 +198,29 @@ function startBrew() {
 
 function applyTheme() {
   const body = document.body;
-  const vibe   = answers.vibe   || 'minimal';
-  const mode   = answers.mode   || 'light';
-  const color  = answers.color  || 'violet';
+  const vibe = answers.vibe || 'minimal';
+  const mode = answers.mode || 'light';
+  const color = answers.color || 'violet';
   const motion = answers.motion || 'fluid';
-  const typo   = answers.typo   || 'default';
+  const typo = answers.typo || 'default';
 
-  body.dataset.vibe   = vibe;
-  body.dataset.mode   = mode;
-  body.dataset.color  = color;
+  body.dataset.vibe = vibe;
+  body.dataset.mode = mode;
+  body.dataset.color = color;
   body.dataset.motion = motion;
-  body.dataset.typo   = typo;
+  body.dataset.typo = typo;
 
   const v = VIBES[vibe];
 
-  ['studio-name', 'footer-name'].forEach(id => {
+  ['studio-name', 'footer-name'].forEach((id) => {
     const el = document.getElementById(id);
     if (el) el.textContent = v.name;
   });
 
-  document.getElementById('hero-tag').textContent  = v.tag;
-  document.getElementById('hero-em').textContent   = v.em;
-  document.getElementById('hero-sub').textContent  = v.sub;
-  document.getElementById('services-h2').textContent  = v.servH;
+  document.getElementById('hero-tag').textContent = v.tag;
+  document.getElementById('hero-em').textContent = v.em;
+  document.getElementById('hero-sub').textContent = v.sub;
+  document.getElementById('services-h2').textContent = v.servH;
   document.getElementById('services-sub').textContent = v.servSub;
   document.getElementById('about-h2').textContent = v.aboutH;
 
@@ -208,13 +231,14 @@ function applyTheme() {
 
   const shape = document.getElementById('hero-shape');
   if (vibe === 'aesthetic') {
-    shape.style.width  = '260px';
+    shape.style.width = '260px';
     shape.style.height = '260px';
     shape.style.background = `radial-gradient(circle, color-mix(in srgb, var(--c-accent) 70%, white), color-mix(in srgb, var(--c-accent2) 70%, white))`;
-    shape.style.boxShadow = '0 0 80px color-mix(in srgb, var(--c-accent) 40%, transparent)';
+    shape.style.boxShadow =
+      '0 0 80px color-mix(in srgb, var(--c-accent) 40%, transparent)';
   } else if (vibe === 'bold') {
     shape.style.borderRadius = '0';
-    shape.style.width  = '200px';
+    shape.style.width = '200px';
     shape.style.height = '160px';
   }
 }
@@ -228,20 +252,22 @@ function revealSite() {
 }
 
 document.getElementById('repersonalize-btn').addEventListener('click', () => {
-  Object.keys(answers).forEach(k => delete answers[k]);
+  Object.keys(answers).forEach((k) => delete answers[k]);
   current = 0;
   cardStack.innerHTML = '';
   document.getElementById('brew-lines').innerHTML = '';
 
   const body = document.body;
-  ['vibe', 'mode', 'color', 'motion', 'typo'].forEach(a => delete body.dataset[a]);
+  ['vibe', 'mode', 'color', 'motion', 'typo'].forEach(
+    (a) => delete body.dataset[a]
+  );
 
   const shape = document.getElementById('hero-shape');
   shape.removeAttribute('style');
 
   sitePhase.classList.remove('active');
   quizPhase.classList.add('active');
-  fillEl.style.width  = '20%';
+  fillEl.style.width = '20%';
   labelEl.textContent = '1 / 5';
   showCard(0);
 });

--- a/public/WebsitePersonalizer/style.css
+++ b/public/WebsitePersonalizer/style.css
@@ -1,16 +1,22 @@
-*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
 
 :root {
-  --bg:      #ffffff;
+  --bg: #ffffff;
   --surface: #f4f4f4;
-  --text:    #111111;
-  --muted:   #888888;
-  --accent:  #6c47ff;
+  --text: #111111;
+  --muted: #888888;
+  --accent: #6c47ff;
   --accent2: #ff6b6b;
-  --border:  rgba(0,0,0,0.09);
+  --border: rgba(0, 0, 0, 0.09);
 
   --r-card: 14px;
-  --r-btn:  8px;
+  --r-btn: 8px;
 
   --font-head: 'Georgia', serif;
   --font-body: 'Inter', system-ui, -apple-system, sans-serif;
@@ -20,11 +26,21 @@
   --ease: cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-html { scroll-behavior: smooth; }
-body { background: var(--bg); color: var(--text); font-family: var(--font-body); }
+html {
+  scroll-behavior: smooth;
+}
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-body);
+}
 
-.phase { display: none; }
-.phase.active { display: flex; }
+.phase {
+  display: none;
+}
+.phase.active {
+  display: flex;
+}
 
 #quiz-phase {
   min-height: 100vh;
@@ -42,7 +58,11 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   gap: 1.75rem;
 }
 
-.quiz-progress { display: flex; align-items: center; gap: 1rem; }
+.quiz-progress {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
 .progress-bar {
   flex: 1;
   height: 3px;
@@ -65,7 +85,10 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   color: var(--muted);
 }
 
-#card-stack { position: relative; min-height: 400px; }
+#card-stack {
+  position: relative;
+  min-height: 400px;
+}
 
 .q-card {
   position: absolute;
@@ -79,11 +102,20 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   gap: 1.75rem;
   opacity: 0;
   transform: translateY(30px) scale(0.97);
-  transition: opacity 0.38s var(--ease), transform 0.38s var(--ease);
+  transition:
+    opacity 0.38s var(--ease),
+    transform 0.38s var(--ease);
   pointer-events: none;
 }
-.q-card.visible { opacity: 1; transform: none; pointer-events: auto; }
-.q-card.exit    { opacity: 0; transform: translateY(-30px) scale(0.97); }
+.q-card.visible {
+  opacity: 1;
+  transform: none;
+  pointer-events: auto;
+}
+.q-card.exit {
+  opacity: 0;
+  transform: translateY(-30px) scale(0.97);
+}
 
 .q-num {
   font-size: 0.7rem;
@@ -114,7 +146,10 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   color: var(--text);
   line-height: 1.35;
   text-align: left;
-  transition: border-color 0.15s, background 0.15s, transform 0.1s;
+  transition:
+    border-color 0.15s,
+    background 0.15s,
+    transform 0.1s;
 }
 .q-opt:hover {
   border-color: var(--accent);
@@ -128,6 +163,15 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   font-weight: 600;
 }
 
+.q-opt:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.q-opt:disabled:not(.selected) {
+  pointer-events: none;
+}
+
 #brew-phase {
   min-height: 100vh;
   align-items: center;
@@ -135,32 +179,45 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   background: #0a0a0a;
   padding: 2rem;
 }
-.brew-wrap { width: 100%; max-width: 560px; }
+.brew-wrap {
+  width: 100%;
+  max-width: 560px;
+}
 .brew-terminal {
   background: #111;
   border-radius: 14px;
-  border: 1px solid rgba(255,255,255,0.06);
+  border: 1px solid rgba(255, 255, 255, 0.06);
   overflow: hidden;
-  box-shadow: 0 40px 100px rgba(0,0,0,0.7);
+  box-shadow: 0 40px 100px rgba(0, 0, 0, 0.7);
 }
 .term-bar {
   display: flex;
   align-items: center;
   gap: 0.45rem;
   padding: 0.75rem 1rem;
-  background: rgba(255,255,255,0.03);
-  border-bottom: 1px solid rgba(255,255,255,0.06);
+  background: rgba(255, 255, 255, 0.03);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
 }
-.dot { width: 12px; height: 12px; border-radius: 50%; }
-.dot.red    { background: #ff5f57; }
-.dot.yellow { background: #ffbd2e; }
-.dot.green  { background: #28c840; }
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+.dot.red {
+  background: #ff5f57;
+}
+.dot.yellow {
+  background: #ffbd2e;
+}
+.dot.green {
+  background: #28c840;
+}
 .term-title {
   flex: 1;
   text-align: center;
   margin-left: -4.5rem;
   font-size: 0.7rem;
-  color: rgba(255,255,255,0.3);
+  color: rgba(255, 255, 255, 0.3);
   font-family: var(--font-mono);
 }
 .term-body {
@@ -171,19 +228,39 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   line-height: 1.95;
   color: #ddd;
 }
-.term-line { display: block; opacity: 0; animation: fadeline 0.18s forwards; }
-.term-line .prompt { color: #6c47ff; margin-right: 0.5rem; }
-.term-line .ok  { color: #28c840; }
-.term-line .dim { color: rgba(255,255,255,0.28); }
-@keyframes fadeline { to { opacity: 1; } }
+.term-line {
+  display: block;
+  opacity: 0;
+  animation: fadeline 0.18s forwards;
+}
+.term-line .prompt {
+  color: #6c47ff;
+  margin-right: 0.5rem;
+}
+.term-line .ok {
+  color: #28c840;
+}
+.term-line .dim {
+  color: rgba(255, 255, 255, 0.28);
+}
+@keyframes fadeline {
+  to {
+    opacity: 1;
+  }
+}
 .term-cursor {
-  width: 8px; height: 1em;
+  width: 8px;
+  height: 1em;
   display: inline-block;
   vertical-align: text-bottom;
   background: #6c47ff;
   animation: blink 1s step-end infinite;
 }
-@keyframes blink { 50% { opacity: 0; } }
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
 
 #site-phase {
   display: none;
@@ -194,9 +271,13 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   font-family: var(--font-body);
   overflow-x: hidden;
   position: relative;
-  transition: background 0.4s, color 0.4s;
+  transition:
+    background 0.4s,
+    color 0.4s;
 }
-#site-phase.active { display: flex; }
+#site-phase.active {
+  display: flex;
+}
 
 .navbar {
   display: flex;
@@ -208,7 +289,9 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   z-index: 100;
   background: var(--bg);
   border-bottom: 1px solid var(--border);
-  transition: background 0.4s, border-color 0.4s;
+  transition:
+    background 0.4s,
+    border-color 0.4s;
 }
 .logo {
   margin-right: auto;
@@ -217,7 +300,10 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   letter-spacing: 0.18em;
   color: var(--accent);
 }
-.nav-links { display: flex; gap: 2rem; }
+.nav-links {
+  display: flex;
+  gap: 2rem;
+}
 .nav-links a {
   font-size: 0.86rem;
   font-weight: 500;
@@ -225,7 +311,9 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   text-decoration: none;
   transition: color 0.15s;
 }
-.nav-links a:hover { color: var(--text); }
+.nav-links a:hover {
+  color: var(--text);
+}
 #repersonalize-btn {
   padding: 0.5rem 1.1rem;
   border: 1.5px solid var(--accent);
@@ -238,7 +326,10 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   cursor: pointer;
   transition: all 0.15s;
 }
-#repersonalize-btn:hover { background: var(--accent); color: #fff; }
+#repersonalize-btn:hover {
+  background: var(--accent);
+  color: #fff;
+}
 
 .hero-section {
   display: grid;
@@ -251,7 +342,10 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   padding: 7rem 3rem 6rem;
   min-height: 88vh;
 }
-.hero-copy { display: flex; flex-direction: column; }
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+}
 .hero-tag {
   font-size: 0.72rem;
   font-weight: 700;
@@ -267,14 +361,21 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   letter-spacing: -0.025em;
   margin-bottom: 1.5rem;
 }
-.hero-heading em { font-style: italic; color: var(--accent); }
+.hero-heading em {
+  font-style: italic;
+  color: var(--accent);
+}
 .hero-sub {
   font-size: 1rem;
   color: var(--muted);
   letter-spacing: 0.015em;
   margin-bottom: 3rem;
 }
-.hero-cta { display: flex; gap: 1rem; flex-wrap: wrap; }
+.hero-cta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
 
 .btn-primary {
   padding: 0.9rem 2.2rem;
@@ -285,9 +386,14 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   font-size: 0.9rem;
   font-weight: 700;
   cursor: pointer;
-  transition: opacity 0.15s, transform 0.12s;
+  transition:
+    opacity 0.15s,
+    transform 0.12s;
 }
-.btn-primary:hover { opacity: 0.85; transform: translateY(-1px); }
+.btn-primary:hover {
+  opacity: 0.85;
+  transform: translateY(-1px);
+}
 
 .btn-ghost {
   padding: 0.9rem 2.2rem;
@@ -298,7 +404,9 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   font-size: 0.9rem;
   font-weight: 600;
   cursor: pointer;
-  transition: border-color 0.15s, background 0.15s;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
 }
 .btn-ghost:hover {
   border-color: var(--accent);
@@ -317,15 +425,21 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   border-radius: var(--r-card);
 }
 .hero-shape {
-  width: 200px; height: 200px;
+  width: 200px;
+  height: 200px;
   border-radius: 50%;
   background: linear-gradient(135deg, var(--accent), var(--accent2));
   animation: floatY 4.5s ease-in-out infinite;
   transition: all 0.4s;
 }
 @keyframes floatY {
-  0%,100% { transform: translateY(0) rotate(0deg); }
-  50%      { transform: translateY(-22px) rotate(6deg); }
+  0%,
+  100% {
+    transform: translateY(0) rotate(0deg);
+  }
+  50% {
+    transform: translateY(-22px) rotate(6deg);
+  }
 }
 
 .hero-code {
@@ -340,18 +454,32 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
 }
 .hc-bar {
   font-size: 0.68rem;
-  color: rgba(108,71,255,0.6);
+  color: rgba(108, 71, 255, 0.6);
   letter-spacing: 0.06em;
   padding-bottom: 0.6rem;
   margin-bottom: 0.75rem;
-  border-bottom: 1px solid rgba(108,71,255,0.18);
+  border-bottom: 1px solid rgba(108, 71, 255, 0.18);
 }
-.hc-bar .hc-prompt { color: var(--accent); margin-right: 0.4rem; }
-.hc-body { color: #c8c8ff; }
-.ck { color: #7ca0ff; }
-.cv { color: #e5e5ff; }
-.cs { color: #7ec987; }
-.c-blink { color: var(--accent); animation: blink 1s step-end infinite; }
+.hc-bar .hc-prompt {
+  color: var(--accent);
+  margin-right: 0.4rem;
+}
+.hc-body {
+  color: #c8c8ff;
+}
+.ck {
+  color: #7ca0ff;
+}
+.cv {
+  color: #e5e5ff;
+}
+.cs {
+  color: #7ec987;
+}
+.c-blink {
+  color: var(--accent);
+  animation: blink 1s step-end infinite;
+}
 
 .marquee {
   padding: 1.1rem 0;
@@ -371,8 +499,17 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   color: var(--muted);
   animation: scrollLeft 20s linear infinite;
 }
-.marquee-track .msep { color: var(--accent); }
-@keyframes scrollLeft { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+.marquee-track .msep {
+  color: var(--accent);
+}
+@keyframes scrollLeft {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(-50%);
+  }
+}
 
 .work-section {
   padding: 6rem 3rem;
@@ -390,17 +527,31 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   font-family: var(--font-head);
   font-size: clamp(1.7rem, 3vw, 2.4rem);
 }
-.work-all { color: var(--accent); text-decoration: none; font-size: 0.88rem; font-weight: 700; }
-.work-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1.75rem; }
+.work-all {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.88rem;
+  font-weight: 700;
+}
+.work-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.75rem;
+}
 .work-card {
   overflow: hidden;
   cursor: pointer;
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: var(--r-card);
-  transition: transform var(--dur) var(--ease), box-shadow var(--dur);
+  transition:
+    transform var(--dur) var(--ease),
+    box-shadow var(--dur);
 }
-.work-card:hover { transform: translateY(-5px); box-shadow: 0 24px 56px rgba(0,0,0,0.1); }
+.work-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 24px 56px rgba(0, 0, 0, 0.1);
+}
 .work-thumb {
   height: 240px;
   display: flex;
@@ -409,17 +560,37 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   position: relative;
   overflow: hidden;
 }
-.work-card[data-index="0"] .work-thumb { background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 25%, var(--surface)), color-mix(in srgb, var(--accent2) 35%, var(--surface))); }
-.work-card[data-index="1"] .work-thumb { background: linear-gradient(135deg, color-mix(in srgb, var(--accent2) 25%, var(--surface)), color-mix(in srgb, var(--accent) 35%, var(--surface))); }
-.work-card[data-index="2"] .work-thumb { background: linear-gradient(135deg, color-mix(in srgb, var(--accent) 18%, var(--surface)), color-mix(in srgb, var(--accent) 38%, var(--surface))); }
+.work-card[data-index='0'] .work-thumb {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--accent) 25%, var(--surface)),
+    color-mix(in srgb, var(--accent2) 35%, var(--surface))
+  );
+}
+.work-card[data-index='1'] .work-thumb {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--accent2) 25%, var(--surface)),
+    color-mix(in srgb, var(--accent) 35%, var(--surface))
+  );
+}
+.work-card[data-index='2'] .work-thumb {
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--accent) 18%, var(--surface)),
+    color-mix(in srgb, var(--accent) 38%, var(--surface))
+  );
+}
 .work-num {
   font-family: var(--font-head);
   font-size: 4rem;
   font-weight: 700;
-  color: rgba(255,255,255,0.2);
+  color: rgba(255, 255, 255, 0.2);
   user-select: none;
 }
-.work-info { padding: 1.25rem 1.5rem 1.5rem; }
+.work-info {
+  padding: 1.25rem 1.5rem 1.5rem;
+}
 .work-tag {
   font-size: 0.67rem;
   font-weight: 700;
@@ -427,8 +598,17 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   text-transform: uppercase;
   color: var(--accent);
 }
-.work-info h3 { font-family: var(--font-head); font-size: 1.1rem; margin-top: 0.25rem; margin-bottom: 0.4rem; }
-.proj-desc { font-size: 0.83rem; color: var(--muted); line-height: 1.55; }
+.work-info h3 {
+  font-family: var(--font-head);
+  font-size: 1.1rem;
+  margin-top: 0.25rem;
+  margin-bottom: 0.4rem;
+}
+.proj-desc {
+  font-size: 0.83rem;
+  color: var(--muted);
+  line-height: 1.55;
+}
 
 .about-section {
   display: grid;
@@ -446,10 +626,26 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   font-size: clamp(1.7rem, 3vw, 2.4rem);
   margin-bottom: 1.25rem;
 }
-.about-text p { color: var(--muted); line-height: 1.75; margin-bottom: 2rem; }
-.about-link { color: var(--accent); font-weight: 700; font-size: 0.9rem; text-decoration: none; }
-.about-stats { display: flex; gap: 3rem; }
-.stat { display: flex; flex-direction: column; gap: 0.3rem; }
+.about-text p {
+  color: var(--muted);
+  line-height: 1.75;
+  margin-bottom: 2rem;
+}
+.about-link {
+  color: var(--accent);
+  font-weight: 700;
+  font-size: 0.9rem;
+  text-decoration: none;
+}
+.about-stats {
+  display: flex;
+  gap: 3rem;
+}
+.stat {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
 .stat-num {
   font-family: var(--font-head);
   font-size: 3.2rem;
@@ -473,12 +669,34 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   padding: 2rem 3rem;
   border-top: 1px solid var(--border);
 }
-.footer-left { display: flex; align-items: center; gap: 1.75rem; }
-.footer-logo { font-size: 0.82rem; font-weight: 800; letter-spacing: 0.18em; color: var(--accent); }
-.footer-copy { font-size: 0.75rem; color: var(--muted); }
-.footer-right { display: flex; gap: 1.75rem; }
-.footer-right a { font-size: 0.78rem; color: var(--muted); text-decoration: none; transition: color 0.15s; }
-.footer-right a:hover { color: var(--text); }
+.footer-left {
+  display: flex;
+  align-items: center;
+  gap: 1.75rem;
+}
+.footer-logo {
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.18em;
+  color: var(--accent);
+}
+.footer-copy {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+.footer-right {
+  display: flex;
+  gap: 1.75rem;
+}
+.footer-right a {
+  font-size: 0.78rem;
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.15s;
+}
+.footer-right a:hover {
+  color: var(--text);
+}
 
 .services-section {
   padding: 6rem 3rem;
@@ -487,26 +705,47 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
   margin: 0 auto;
   border-top: 1px solid var(--border);
 }
-.services-intro { max-width: 560px; margin-bottom: 4rem; }
+.services-intro {
+  max-width: 560px;
+  margin-bottom: 4rem;
+}
 .services-intro h2 {
   font-family: var(--font-head);
   font-size: clamp(1.7rem, 3vw, 2.4rem);
   margin-bottom: 0.75rem;
 }
-.services-intro p { color: var(--muted); line-height: 1.7; }
-.serv-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 2.5rem; }
+.services-intro p {
+  color: var(--muted);
+  line-height: 1.7;
+}
+.serv-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 2.5rem;
+}
 .serv-item {
   padding: 2rem 0;
   border-top: 2px solid var(--border);
   transition: border-color 0.18s;
 }
-.serv-item:hover { border-top-color: var(--accent); }
-.serv-item h3 { font-family: var(--font-head); font-size: 1.05rem; margin-bottom: 0.75rem; }
-.serv-item p { font-size: 0.86rem; color: var(--muted); line-height: 1.65; }
+.serv-item:hover {
+  border-top-color: var(--accent);
+}
+.serv-item h3 {
+  font-family: var(--font-head);
+  font-size: 1.05rem;
+  margin-bottom: 0.75rem;
+}
+.serv-item p {
+  font-size: 0.86rem;
+  color: var(--muted);
+  line-height: 1.65;
+}
 
 .grain-layer {
   display: none;
-  position: fixed; inset: 0;
+  position: fixed;
+  inset: 0;
   z-index: 500;
   pointer-events: none;
   opacity: 0.05;
@@ -515,13 +754,14 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
 }
 .grid-layer {
   display: none;
-  position: fixed; inset: 0;
+  position: fixed;
+  inset: 0;
   z-index: 500;
   pointer-events: none;
   background-size: 42px 42px;
   background-image:
-    linear-gradient(rgba(108,71,255,0.09) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(108,71,255,0.09) 1px, transparent 1px);
+    linear-gradient(rgba(108, 71, 255, 0.09) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(108, 71, 255, 0.09) 1px, transparent 1px);
 }
 
 .reveal .navbar,
@@ -530,36 +770,62 @@ body { background: var(--bg); color: var(--text); font-family: var(--font-body);
 .reveal .work-section,
 .reveal .services-section,
 .reveal .about-section,
-.reveal .page-footer { animation: slideUp 0.65s var(--ease) both; }
-.reveal .navbar          { animation-delay: 0.00s; }
-.reveal .hero-section    { animation-delay: 0.07s; }
-.reveal .marquee         { animation-delay: 0.14s; }
-.reveal .work-section    { animation-delay: 0.21s; }
-.reveal .services-section{ animation-delay: 0.28s; }
-.reveal .about-section   { animation-delay: 0.35s; }
-.reveal .page-footer     { animation-delay: 0.42s; }
+.reveal .page-footer {
+  animation: slideUp 0.65s var(--ease) both;
+}
+.reveal .navbar {
+  animation-delay: 0s;
+}
+.reveal .hero-section {
+  animation-delay: 0.07s;
+}
+.reveal .marquee {
+  animation-delay: 0.14s;
+}
+.reveal .work-section {
+  animation-delay: 0.21s;
+}
+.reveal .services-section {
+  animation-delay: 0.28s;
+}
+.reveal .about-section {
+  animation-delay: 0.35s;
+}
+.reveal .page-footer {
+  animation-delay: 0.42s;
+}
 @keyframes slideUp {
-  from { opacity: 0; transform: translateY(28px); }
-  to   { opacity: 1; transform: none; }
+  from {
+    opacity: 0;
+    transform: translateY(28px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
 }
 
-body[data-vibe="minimal"] .hero-shape {
-  width: 220px; height: 220px;
+body[data-vibe='minimal'] .hero-shape {
+  width: 220px;
+  height: 220px;
   background: none;
   border: 2px solid var(--accent);
-  box-shadow: inset 0 0 0 40px color-mix(in srgb, var(--accent) 8%, transparent),
-              0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent);
+  box-shadow:
+    inset 0 0 0 40px color-mix(in srgb, var(--accent) 8%, transparent),
+    0 0 0 1px color-mix(in srgb, var(--accent) 20%, transparent);
 }
-body[data-vibe="minimal"] .serv-item { padding-top: 2.5rem; }
+body[data-vibe='minimal'] .serv-item {
+  padding-top: 2.5rem;
+}
 
-body[data-vibe="bold"] {
+body[data-vibe='bold'] {
   --font-head: 'Impact', 'Arial Black', sans-serif;
   --font-body: 'Arial', Helvetica, sans-serif;
   --r-card: 0px;
-  --r-btn:  0px;
-  --border: rgba(0,0,0,0.15);
+  --r-btn: 0px;
+  --border: rgba(0, 0, 0, 0.15);
 }
-body[data-vibe="bold"] .hero-section {
+body[data-vibe='bold'] .hero-section {
   grid-template-columns: 1fr;
   max-width: 100%;
   min-height: 90vh;
@@ -568,92 +834,204 @@ body[data-vibe="bold"] .hero-section {
   border-bottom: 5px solid var(--accent);
   align-content: end;
 }
-body[data-vibe="bold"] .hero-media { display: none; }
-body[data-vibe="bold"] .hero-copy { max-width: 900px; }
-body[data-vibe="bold"] .hero-tag { color: var(--accent); letter-spacing: 0.25em; }
-body[data-vibe="bold"] .hero-heading {
+body[data-vibe='bold'] .hero-media {
+  display: none;
+}
+body[data-vibe='bold'] .hero-copy {
+  max-width: 900px;
+}
+body[data-vibe='bold'] .hero-tag {
+  color: var(--accent);
+  letter-spacing: 0.25em;
+}
+body[data-vibe='bold'] .hero-heading {
   font-size: clamp(4rem, 8.5vw, 8rem);
   color: #ffffff;
   line-height: 0.92;
   letter-spacing: -0.04em;
 }
-body[data-vibe="bold"] .hero-heading em { color: var(--accent); font-style: normal; }
-body[data-vibe="bold"] .hero-sub { color: rgba(255,255,255,0.4); font-size: 0.95rem; }
-body[data-vibe="bold"] .btn-ghost { color: rgba(255,255,255,0.7); border-color: rgba(255,255,255,0.2); }
-body[data-vibe="bold"] .btn-ghost:hover { border-color: #fff; background: transparent; color: #fff; }
-body[data-vibe="bold"] .btn-primary { box-shadow: 4px 4px 0 #000; }
-body[data-vibe="bold"] .navbar { border-bottom: 3px solid var(--text); }
-body[data-vibe="bold"] .work-grid { grid-template-columns: 1fr 1fr; gap: 2rem; }
-body[data-vibe="bold"] .work-thumb { height: 280px; }
-body[data-vibe="bold"] .work-card { border: 2px solid var(--text); transition: transform 0.15s, box-shadow 0.15s; }
-body[data-vibe="bold"] .work-card:hover { transform: translate(-4px,-4px); box-shadow: 8px 8px 0 var(--text); }
-body[data-vibe="bold"] .work-num { font-size: 6rem; opacity: 0.12; }
-body[data-vibe="bold"] .work-info h3 { font-size: 1.2rem; }
-body[data-vibe="bold"] .serv-grid { grid-template-columns: 1fr 1fr; gap: 0; }
-body[data-vibe="bold"] .serv-item {
+body[data-vibe='bold'] .hero-heading em {
+  color: var(--accent);
+  font-style: normal;
+}
+body[data-vibe='bold'] .hero-sub {
+  color: rgba(255, 255, 255, 0.4);
+  font-size: 0.95rem;
+}
+body[data-vibe='bold'] .btn-ghost {
+  color: rgba(255, 255, 255, 0.7);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+body[data-vibe='bold'] .btn-ghost:hover {
+  border-color: #fff;
+  background: transparent;
+  color: #fff;
+}
+body[data-vibe='bold'] .btn-primary {
+  box-shadow: 4px 4px 0 #000;
+}
+body[data-vibe='bold'] .navbar {
+  border-bottom: 3px solid var(--text);
+}
+body[data-vibe='bold'] .work-grid {
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+}
+body[data-vibe='bold'] .work-thumb {
+  height: 280px;
+}
+body[data-vibe='bold'] .work-card {
+  border: 2px solid var(--text);
+  transition:
+    transform 0.15s,
+    box-shadow 0.15s;
+}
+body[data-vibe='bold'] .work-card:hover {
+  transform: translate(-4px, -4px);
+  box-shadow: 8px 8px 0 var(--text);
+}
+body[data-vibe='bold'] .work-num {
+  font-size: 6rem;
+  opacity: 0.12;
+}
+body[data-vibe='bold'] .work-info h3 {
+  font-size: 1.2rem;
+}
+body[data-vibe='bold'] .serv-grid {
+  grid-template-columns: 1fr 1fr;
+  gap: 0;
+}
+body[data-vibe='bold'] .serv-item {
   padding: 2.5rem 2rem;
   border: 2px solid var(--text);
   border-top-width: 5px;
   margin: -1px -1px 0 0;
 }
-body[data-vibe="bold"] .serv-item:hover { border-top-color: var(--accent); }
-body[data-vibe="bold"] .serv-item h3 { font-size: 1.2rem; }
-body[data-vibe="bold"] .about-section { border-top: 3px solid var(--text); }
-body[data-vibe="bold"] .stat-num { font-size: 4.5rem; line-height: 0.9; }
-body[data-vibe="bold"] .page-footer { border-top: 3px solid var(--text); }
+body[data-vibe='bold'] .serv-item:hover {
+  border-top-color: var(--accent);
+}
+body[data-vibe='bold'] .serv-item h3 {
+  font-size: 1.2rem;
+}
+body[data-vibe='bold'] .about-section {
+  border-top: 3px solid var(--text);
+}
+body[data-vibe='bold'] .stat-num {
+  font-size: 4.5rem;
+  line-height: 0.9;
+}
+body[data-vibe='bold'] .page-footer {
+  border-top: 3px solid var(--text);
+}
 
-body[data-vibe="cyberpunk"] {
+body[data-vibe='cyberpunk'] {
   --font-head: var(--font-mono);
   --font-body: var(--font-mono);
   --r-card: 2px;
-  --r-btn:  2px;
-  --border: rgba(108,71,255,0.25);
+  --r-btn: 2px;
+  --border: rgba(108, 71, 255, 0.25);
 }
-body[data-vibe="cyberpunk"] .hero-section {
+body[data-vibe='cyberpunk'] .hero-section {
   max-width: 100%;
   padding: 7rem 6rem 6rem;
   gap: 3rem;
   background: #06060e;
-  border-bottom: 1px solid rgba(108,71,255,0.5);
+  border-bottom: 1px solid rgba(108, 71, 255, 0.5);
 }
-body[data-vibe="cyberpunk"] .hero-copy * { color: #e0e0ff; }
-body[data-vibe="cyberpunk"] .hero-tag { color: var(--accent); letter-spacing: 0.28em; font-size: 0.68rem; }
-body[data-vibe="cyberpunk"] .hero-heading {
+body[data-vibe='cyberpunk'] .hero-copy * {
+  color: #e0e0ff;
+}
+body[data-vibe='cyberpunk'] .hero-tag {
+  color: var(--accent);
+  letter-spacing: 0.28em;
+  font-size: 0.68rem;
+}
+body[data-vibe='cyberpunk'] .hero-heading {
   font-size: clamp(2rem, 4vw, 3.2rem);
   letter-spacing: -0.01em;
   text-shadow: 0 0 40px color-mix(in srgb, var(--accent) 45%, transparent);
 }
-body[data-vibe="cyberpunk"] .hero-heading em { color: var(--accent); font-style: normal; text-shadow: 0 0 30px var(--accent); }
-body[data-vibe="cyberpunk"] .hero-sub { color: rgba(200,200,255,0.5); }
-body[data-vibe="cyberpunk"] .hero-shape { display: none; }
-body[data-vibe="cyberpunk"] .hero-code { display: flex; }
-body[data-vibe="cyberpunk"] .hero-media { background: #0c0c18; border-color: rgba(108,71,255,0.25); height: 360px; }
-body[data-vibe="cyberpunk"] .navbar { background: #06060e; border-bottom-color: rgba(108,71,255,0.4); }
-body[data-vibe="cyberpunk"] .logo { text-shadow: 0 0 18px var(--accent); letter-spacing: 0.3em; }
-body[data-vibe="cyberpunk"] .nav-links a { color: rgba(200,200,255,0.45); }
-body[data-vibe="cyberpunk"] .nav-links a:hover { color: var(--accent); }
-body[data-vibe="cyberpunk"] .marquee { background: #06060e; border-color: rgba(108,71,255,0.3); }
-body[data-vibe="cyberpunk"] .work-grid { grid-template-columns: 1fr; gap: 0; }
-body[data-vibe="cyberpunk"] .work-card {
+body[data-vibe='cyberpunk'] .hero-heading em {
+  color: var(--accent);
+  font-style: normal;
+  text-shadow: 0 0 30px var(--accent);
+}
+body[data-vibe='cyberpunk'] .hero-sub {
+  color: rgba(200, 200, 255, 0.5);
+}
+body[data-vibe='cyberpunk'] .hero-shape {
+  display: none;
+}
+body[data-vibe='cyberpunk'] .hero-code {
+  display: flex;
+}
+body[data-vibe='cyberpunk'] .hero-media {
+  background: #0c0c18;
+  border-color: rgba(108, 71, 255, 0.25);
+  height: 360px;
+}
+body[data-vibe='cyberpunk'] .navbar {
+  background: #06060e;
+  border-bottom-color: rgba(108, 71, 255, 0.4);
+}
+body[data-vibe='cyberpunk'] .logo {
+  text-shadow: 0 0 18px var(--accent);
+  letter-spacing: 0.3em;
+}
+body[data-vibe='cyberpunk'] .nav-links a {
+  color: rgba(200, 200, 255, 0.45);
+}
+body[data-vibe='cyberpunk'] .nav-links a:hover {
+  color: var(--accent);
+}
+body[data-vibe='cyberpunk'] .marquee {
+  background: #06060e;
+  border-color: rgba(108, 71, 255, 0.3);
+}
+body[data-vibe='cyberpunk'] .work-grid {
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+body[data-vibe='cyberpunk'] .work-card {
   display: grid;
   grid-template-columns: 200px 1fr;
   border-radius: 0;
   border: none;
   border-left: 3px solid var(--accent);
-  border-bottom: 1px solid rgba(108,71,255,0.12);
+  border-bottom: 1px solid rgba(108, 71, 255, 0.12);
 }
-body[data-vibe="cyberpunk"] .work-card:first-child { border-top: 1px solid rgba(108,71,255,0.12); }
-body[data-vibe="cyberpunk"] .work-card:hover { transform: none; box-shadow: none; background: rgba(108,71,255,0.04); }
-body[data-vibe="cyberpunk"] .work-thumb { height: 150px; border-radius: 0; }
-body[data-vibe="cyberpunk"] .work-num { font-family: var(--font-mono); font-size: 0.75rem; color: rgba(108,71,255,0.5); }
-body[data-vibe="cyberpunk"] .work-info h3 { font-size: 0.95rem; letter-spacing: 0.04em; }
-body[data-vibe="cyberpunk"] .serv-grid { grid-template-columns: 1fr 1fr; gap: 1px; background: rgba(108,71,255,0.2); }
-body[data-vibe="cyberpunk"] .serv-item {
+body[data-vibe='cyberpunk'] .work-card:first-child {
+  border-top: 1px solid rgba(108, 71, 255, 0.12);
+}
+body[data-vibe='cyberpunk'] .work-card:hover {
+  transform: none;
+  box-shadow: none;
+  background: rgba(108, 71, 255, 0.04);
+}
+body[data-vibe='cyberpunk'] .work-thumb {
+  height: 150px;
+  border-radius: 0;
+}
+body[data-vibe='cyberpunk'] .work-num {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: rgba(108, 71, 255, 0.5);
+}
+body[data-vibe='cyberpunk'] .work-info h3 {
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+}
+body[data-vibe='cyberpunk'] .serv-grid {
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: rgba(108, 71, 255, 0.2);
+}
+body[data-vibe='cyberpunk'] .serv-item {
   background: #06060e;
   border-top: none;
   padding: 2rem 1.75rem;
 }
-body[data-vibe="cyberpunk"] .serv-item::before {
+body[data-vibe='cyberpunk'] .serv-item::before {
   content: '> ' attr(data-num);
   display: block;
   font-family: var(--font-mono);
@@ -662,9 +1040,15 @@ body[data-vibe="cyberpunk"] .serv-item::before {
   letter-spacing: 0.1em;
   margin-bottom: 0.65rem;
 }
-body[data-vibe="cyberpunk"] .serv-item:hover { background: rgba(108,71,255,0.06); }
-body[data-vibe="cyberpunk"] .grid-layer { display: block; }
-body[data-vibe="cyberpunk"] .stat-num { text-shadow: 0 0 22px var(--accent); }
+body[data-vibe='cyberpunk'] .serv-item:hover {
+  background: rgba(108, 71, 255, 0.06);
+}
+body[data-vibe='cyberpunk'] .grid-layer {
+  display: block;
+}
+body[data-vibe='cyberpunk'] .stat-num {
+  text-shadow: 0 0 22px var(--accent);
+}
 
 .blob {
   display: none;
@@ -675,40 +1059,55 @@ body[data-vibe="cyberpunk"] .stat-num { text-shadow: 0 0 22px var(--accent); }
   z-index: 0;
 }
 .blob-1 {
-  width: 600px; height: 600px;
-  top: -150px; left: -150px;
+  width: 600px;
+  height: 600px;
+  top: -150px;
+  left: -150px;
   opacity: 0.45;
   background: color-mix(in srgb, var(--accent) 35%, transparent);
   animation: blobDrift 14s ease-in-out infinite;
 }
 .blob-2 {
-  width: 500px; height: 500px;
-  bottom: -100px; right: -100px;
+  width: 500px;
+  height: 500px;
+  bottom: -100px;
+  right: -100px;
   opacity: 0.4;
   background: color-mix(in srgb, var(--accent2) 35%, transparent);
   animation: blobDrift 18s ease-in-out infinite reverse;
 }
 .blob-3 {
-  width: 350px; height: 350px;
-  top: 45%; left: 40%;
+  width: 350px;
+  height: 350px;
+  top: 45%;
+  left: 40%;
   opacity: 0.3;
   background: color-mix(in srgb, var(--accent) 25%, white);
   animation: blobDrift 11s ease-in-out infinite 3s;
 }
 @keyframes blobDrift {
-  0%,100% { transform: translate(0,0) scale(1); }
-  40%     { transform: translate(40px,-50px) scale(1.06); }
-  70%     { transform: translate(-25px,30px) scale(0.94); }
+  0%,
+  100% {
+    transform: translate(0, 0) scale(1);
+  }
+  40% {
+    transform: translate(40px, -50px) scale(1.06);
+  }
+  70% {
+    transform: translate(-25px, 30px) scale(0.94);
+  }
 }
 
-body[data-vibe="aesthetic"] {
+body[data-vibe='aesthetic'] {
   --font-head: 'Palatino Linotype', 'Book Antiqua', Palatino, serif;
   --r-card: 28px;
   --r-btn: 99px;
-  --border: rgba(255,255,255,0.25);
+  --border: rgba(255, 255, 255, 0.25);
 }
-body[data-vibe="aesthetic"] .blob { display: block; }
-body[data-vibe="aesthetic"] .hero-section {
+body[data-vibe='aesthetic'] .blob {
+  display: block;
+}
+body[data-vibe='aesthetic'] .hero-section {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -718,126 +1117,278 @@ body[data-vibe="aesthetic"] .hero-section {
   padding: 8rem 4rem 7rem;
   position: relative;
   z-index: 1;
-  background: radial-gradient(ellipse 90% 80% at 50% 30%,
-    color-mix(in srgb, var(--accent) 12%, var(--bg)), var(--bg));
+  background: radial-gradient(
+    ellipse 90% 80% at 50% 30%,
+    color-mix(in srgb, var(--accent) 12%, var(--bg)),
+    var(--bg)
+  );
 }
-body[data-vibe="aesthetic"] .hero-copy { align-items: center; max-width: 680px; }
-body[data-vibe="aesthetic"] .hero-media { display: none; }
-body[data-vibe="aesthetic"] .hero-cta { justify-content: center; }
-body[data-vibe="aesthetic"] .hero-heading {
+body[data-vibe='aesthetic'] .hero-copy {
+  align-items: center;
+  max-width: 680px;
+}
+body[data-vibe='aesthetic'] .hero-media {
+  display: none;
+}
+body[data-vibe='aesthetic'] .hero-cta {
+  justify-content: center;
+}
+body[data-vibe='aesthetic'] .hero-heading {
   font-size: clamp(2.8rem, 5vw, 4.8rem);
   font-weight: 400;
   letter-spacing: -0.01em;
   line-height: 1.08;
 }
-body[data-vibe="aesthetic"] .hero-heading em {
+body[data-vibe='aesthetic'] .hero-heading em {
   font-style: italic;
   background: linear-gradient(135deg, var(--accent), var(--accent2));
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
-body[data-vibe="aesthetic"] .hero-sub { font-size: 1.05rem; }
-body[data-vibe="aesthetic"] .navbar {
+body[data-vibe='aesthetic'] .hero-sub {
+  font-size: 1.05rem;
+}
+body[data-vibe='aesthetic'] .navbar {
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   background: color-mix(in srgb, var(--bg) 65%, transparent);
-  border-bottom-color: rgba(255,255,255,0.2);
+  border-bottom-color: rgba(255, 255, 255, 0.2);
 }
-body[data-vibe="aesthetic"] .work-grid { grid-template-columns: 1fr 1fr; gap: 1.5rem; }
-body[data-vibe="aesthetic"] .work-thumb { height: 300px; }
-body[data-vibe="aesthetic"] .work-card {
+body[data-vibe='aesthetic'] .work-grid {
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+body[data-vibe='aesthetic'] .work-thumb {
+  height: 300px;
+}
+body[data-vibe='aesthetic'] .work-card {
   backdrop-filter: blur(12px);
-  border: 1px solid rgba(255,255,255,0.3);
+  border: 1px solid rgba(255, 255, 255, 0.3);
   background: color-mix(in srgb, var(--surface) 55%, transparent);
-  box-shadow: 0 8px 32px rgba(0,0,0,0.07);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.07);
 }
-body[data-vibe="aesthetic"] .serv-grid { grid-template-columns: 1fr 1fr; gap: 1.5rem; }
-body[data-vibe="aesthetic"] .serv-item {
+body[data-vibe='aesthetic'] .serv-grid {
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+}
+body[data-vibe='aesthetic'] .serv-item {
   border-top: none;
   border-radius: 20px;
   padding: 2rem;
   backdrop-filter: blur(12px);
   background: color-mix(in srgb, var(--surface) 55%, transparent);
-  border: 1px solid rgba(255,255,255,0.3);
+  border: 1px solid rgba(255, 255, 255, 0.3);
 }
-body[data-vibe="aesthetic"] .serv-item:hover { border-color: color-mix(in srgb, var(--accent) 35%, transparent); }
+body[data-vibe='aesthetic'] .serv-item:hover {
+  border-color: color-mix(in srgb, var(--accent) 35%, transparent);
+}
 
-body[data-mode="dark"] {
-  --bg:      #111111;
+body[data-mode='dark'] {
+  --bg: #111111;
   --surface: #1c1c1c;
-  --text:    #eeeeee;
-  --muted:   #777777;
-  --border:  rgba(255,255,255,0.08);
+  --text: #eeeeee;
+  --muted: #777777;
+  --border: rgba(255, 255, 255, 0.08);
 }
-body[data-mode="dark"][data-vibe="bold"] .work-card { border-color: var(--text); }
-body[data-mode="dark"][data-vibe="bold"] .work-card:hover { box-shadow: 8px 8px 0 var(--text); }
-body[data-mode="dark"][data-vibe="bold"] .serv-item { border-color: var(--text); }
-body[data-mode="dark"][data-vibe="bold"] .about-section { border-top-color: var(--text); }
+body[data-mode='dark'][data-vibe='bold'] .work-card {
+  border-color: var(--text);
+}
+body[data-mode='dark'][data-vibe='bold'] .work-card:hover {
+  box-shadow: 8px 8px 0 var(--text);
+}
+body[data-mode='dark'][data-vibe='bold'] .serv-item {
+  border-color: var(--text);
+}
+body[data-mode='dark'][data-vibe='bold'] .about-section {
+  border-top-color: var(--text);
+}
 
-body[data-color="violet"]  { --accent: #6c47ff; --accent2: #ff6b9d; }
-body[data-color="rose"]    { --accent: #e11d48; --accent2: #fb923c; }
-body[data-color="emerald"] { --accent: #059669; --accent2: #0891b2; }
-body[data-color="amber"]   { --accent: #d97706; --accent2: #dc2626; }
+body[data-color='violet'] {
+  --accent: #6c47ff;
+  --accent2: #ff6b9d;
+}
+body[data-color='rose'] {
+  --accent: #e11d48;
+  --accent2: #fb923c;
+}
+body[data-color='emerald'] {
+  --accent: #059669;
+  --accent2: #0891b2;
+}
+body[data-color='amber'] {
+  --accent: #d97706;
+  --accent2: #dc2626;
+}
 
-body[data-motion="subtle"] { --dur: 0.15s; }
-body[data-motion="subtle"] .hero-shape    { animation-duration: 9s; }
-body[data-motion="subtle"] .marquee-track { animation-duration: 35s; }
-body[data-motion="subtle"] .blob          { animation-duration: 25s; }
-body[data-motion="slow"]   { --dur: 1.1s; }
-body[data-motion="slow"]   .hero-shape    { animation-duration: 10s; }
-body[data-motion="slow"]   .marquee-track { animation-duration: 50s; }
-body[data-motion="none"] *, body[data-motion="none"] *::before, body[data-motion="none"] *::after {
+body[data-motion='subtle'] {
+  --dur: 0.15s;
+}
+body[data-motion='subtle'] .hero-shape {
+  animation-duration: 9s;
+}
+body[data-motion='subtle'] .marquee-track {
+  animation-duration: 35s;
+}
+body[data-motion='subtle'] .blob {
+  animation-duration: 25s;
+}
+body[data-motion='slow'] {
+  --dur: 1.1s;
+}
+body[data-motion='slow'] .hero-shape {
+  animation-duration: 10s;
+}
+body[data-motion='slow'] .marquee-track {
+  animation-duration: 50s;
+}
+body[data-motion='none'] *,
+body[data-motion='none'] *::before,
+body[data-motion='none'] *::after {
   animation: none !important;
   transition-duration: 0.01ms !important;
 }
 
-body[data-typo="compact"] { font-size: 13px; line-height: 1.35; }
-body[data-typo="compact"] .hero-section  { padding: 4rem 3rem 3rem; min-height: 65vh; }
-body[data-typo="compact"] .hero-heading  { font-size: clamp(1.8rem, 3.5vw, 3rem); margin-bottom: 0.9rem; }
-body[data-typo="compact"] .hero-sub      { margin-bottom: 1.75rem; }
-body[data-typo="compact"] .work-section,
-body[data-typo="compact"] .services-section,
-body[data-typo="compact"] .about-section { padding: 3.5rem 3rem; }
-body[data-typo="compact"] .work-thumb    { height: 180px; }
-body[data-typo="compact"] .work-grid     { gap: 1rem; }
-body[data-typo="compact"] .serv-grid     { gap: 1.5rem; }
-body[data-typo="compact"] .serv-item     { padding: 1.25rem 0; }
+body[data-typo='compact'] {
+  font-size: 13px;
+  line-height: 1.35;
+}
+body[data-typo='compact'] .hero-section {
+  padding: 4rem 3rem 3rem;
+  min-height: 65vh;
+}
+body[data-typo='compact'] .hero-heading {
+  font-size: clamp(1.8rem, 3.5vw, 3rem);
+  margin-bottom: 0.9rem;
+}
+body[data-typo='compact'] .hero-sub {
+  margin-bottom: 1.75rem;
+}
+body[data-typo='compact'] .work-section,
+body[data-typo='compact'] .services-section,
+body[data-typo='compact'] .about-section {
+  padding: 3.5rem 3rem;
+}
+body[data-typo='compact'] .work-thumb {
+  height: 180px;
+}
+body[data-typo='compact'] .work-grid {
+  gap: 1rem;
+}
+body[data-typo='compact'] .serv-grid {
+  gap: 1.5rem;
+}
+body[data-typo='compact'] .serv-item {
+  padding: 1.25rem 0;
+}
 
-body[data-typo="relaxed"] { font-size: 18px; line-height: 1.95; }
-body[data-typo="relaxed"] .hero-section  { padding: 9rem 3rem 8rem; min-height: 92vh; }
-body[data-typo="relaxed"] .hero-heading  { font-size: clamp(3rem, 5.5vw, 5rem); margin-bottom: 2rem; line-height: 1.08; }
-body[data-typo="relaxed"] .hero-sub      { font-size: 1.15rem; margin-bottom: 3.5rem; }
-body[data-typo="relaxed"] .work-section,
-body[data-typo="relaxed"] .services-section,
-body[data-typo="relaxed"] .about-section { padding: 9rem 3rem; }
-body[data-typo="relaxed"] .work-thumb    { height: 300px; }
-body[data-typo="relaxed"] .serv-grid     { gap: 3.5rem; }
+body[data-typo='relaxed'] {
+  font-size: 18px;
+  line-height: 1.95;
+}
+body[data-typo='relaxed'] .hero-section {
+  padding: 9rem 3rem 8rem;
+  min-height: 92vh;
+}
+body[data-typo='relaxed'] .hero-heading {
+  font-size: clamp(3rem, 5.5vw, 5rem);
+  margin-bottom: 2rem;
+  line-height: 1.08;
+}
+body[data-typo='relaxed'] .hero-sub {
+  font-size: 1.15rem;
+  margin-bottom: 3.5rem;
+}
+body[data-typo='relaxed'] .work-section,
+body[data-typo='relaxed'] .services-section,
+body[data-typo='relaxed'] .about-section {
+  padding: 9rem 3rem;
+}
+body[data-typo='relaxed'] .work-thumb {
+  height: 300px;
+}
+body[data-typo='relaxed'] .serv-grid {
+  gap: 3.5rem;
+}
 
-body[data-typo="wide"] { font-size: 16px; letter-spacing: 0.04em; line-height: 1.9; }
-body[data-typo="wide"] .hero-sub     { letter-spacing: 0.08em; }
-body[data-typo="wide"] .about-text p { max-width: 480px; }
-body[data-typo="wide"] .proj-desc    { letter-spacing: 0.02em; }
-body[data-typo="wide"] .serv-item p  { max-width: 220px; }
+body[data-typo='wide'] {
+  font-size: 16px;
+  letter-spacing: 0.04em;
+  line-height: 1.9;
+}
+body[data-typo='wide'] .hero-sub {
+  letter-spacing: 0.08em;
+}
+body[data-typo='wide'] .about-text p {
+  max-width: 480px;
+}
+body[data-typo='wide'] .proj-desc {
+  letter-spacing: 0.02em;
+}
+body[data-typo='wide'] .serv-item p {
+  max-width: 220px;
+}
 
 @media (max-width: 900px) {
-  .serv-grid { grid-template-columns: 1fr 1fr; }
-  body[data-vibe="cyberpunk"] .work-card  { grid-template-columns: 1fr; }
-  body[data-vibe="cyberpunk"] .work-thumb { height: 200px; }
+  .serv-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  body[data-vibe='cyberpunk'] .work-card {
+    grid-template-columns: 1fr;
+  }
+  body[data-vibe='cyberpunk'] .work-thumb {
+    height: 200px;
+  }
 }
 @media (max-width: 768px) {
-  .hero-section  { grid-template-columns: 1fr; padding: 4rem 1.5rem 3rem; min-height: auto; gap: 2.5rem; }
-  .hero-media    { height: 260px; }
-  .work-section  { padding: 4rem 1.5rem; }
-  .work-grid     { grid-template-columns: 1fr; }
-  .services-section { padding: 4rem 1.5rem; }
-  .serv-grid     { grid-template-columns: 1fr 1fr; }
-  .about-section { grid-template-columns: 1fr; padding: 4rem 1.5rem; gap: 2.5rem; }
-  .navbar        { padding: 1rem 1.5rem; }
-  .nav-links     { display: none; }
-  .page-footer   { flex-direction: column; gap: 1rem; padding: 1.5rem; text-align: center; }
-  body[data-vibe="bold"] .hero-section      { padding: 4rem 1.5rem 3rem; }
-  body[data-vibe="bold"] .hero-heading      { font-size: clamp(3rem, 10vw, 5rem); }
-  body[data-vibe="cyberpunk"] .hero-section { padding: 4rem 1.5rem 3rem; }
-  body[data-vibe="aesthetic"] .hero-section { padding: 5rem 1.5rem 4rem; }
+  .hero-section {
+    grid-template-columns: 1fr;
+    padding: 4rem 1.5rem 3rem;
+    min-height: auto;
+    gap: 2.5rem;
+  }
+  .hero-media {
+    height: 260px;
+  }
+  .work-section {
+    padding: 4rem 1.5rem;
+  }
+  .work-grid {
+    grid-template-columns: 1fr;
+  }
+  .services-section {
+    padding: 4rem 1.5rem;
+  }
+  .serv-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+  .about-section {
+    grid-template-columns: 1fr;
+    padding: 4rem 1.5rem;
+    gap: 2.5rem;
+  }
+  .navbar {
+    padding: 1rem 1.5rem;
+  }
+  .nav-links {
+    display: none;
+  }
+  .page-footer {
+    flex-direction: column;
+    gap: 1rem;
+    padding: 1.5rem;
+    text-align: center;
+  }
+  body[data-vibe='bold'] .hero-section {
+    padding: 4rem 1.5rem 3rem;
+  }
+  body[data-vibe='bold'] .hero-heading {
+    font-size: clamp(3rem, 10vw, 5rem);
+  }
+  body[data-vibe='cyberpunk'] .hero-section {
+    padding: 4rem 1.5rem 3rem;
+  }
+  body[data-vibe='aesthetic'] .hero-section {
+    padding: 5rem 1.5rem 4rem;
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #8649 by preventing users from selecting multiple answer options before the question card transition completes.

## Problem

Currently, when a user clicks an option, the answer is stored immediately but the card is only removed after a delayed transition (`setTimeout`). During this delay, users can continue clicking other options, causing multiple selections and inconsistent behavior.

## Changes Made

- Added a transition lock (`isTransitioning`) to prevent repeated selections.
- Disabled all answer buttons immediately after the first selection.
- Ensured only one answer is recorded per question.
- Ignored additional clicks while the card is transitioning.
- Added disabled-state styling for better visual feedback.

## Before Fix

- Multiple options could be clicked rapidly.
- Multiple buttons could appear selected.
- Additional clicks were processed before the next question loaded.

## After Fix

- Only the first click is accepted.
- All options become disabled immediately after selection.
- Additional clicks are ignored until the next question appears.
- Question flow remains consistent and predictable.

## Testing Performed

- [x] Selected an option normally and verified progression.
- [x] Rapidly clicked multiple options and confirmed only the first selection was accepted.
- [x] Verified all other options became disabled after selection.
- [x] Confirmed next question loads correctly.
- [x] Completed the full quiz flow without issues.


Closes #8649