### PR TITLE
fix: use local calendar date instead of UTC for daily reset

### DIFF
--- a/public/waterTracker/script.js
+++ b/public/waterTracker/script.js
@@ -1,26 +1,32 @@
 (() => {
-  const STORAGE_KEY = "waterTracker";
+  const STORAGE_KEY = 'waterTracker';
 
   const elements = {
-    dailyGoal: document.getElementById("dailyGoal"),
-    saveGoalBtn: document.getElementById("saveGoalBtn"),
-    waterLevel: document.getElementById("waterLevel"),
-    consumedAmount: document.getElementById("consumedAmount"),
-    goalAmount: document.getElementById("goalAmount"),
-    progressPercent: document.getElementById("progressPercent"),
-    progressText: document.getElementById("progressText"),
-    statusMessage: document.getElementById("statusMessage"),
-    customAmount: document.getElementById("customAmount"),
-    customAddBtn: document.getElementById("customAddBtn"),
-    undoBtn: document.getElementById("undoBtn"),
-    resetBtn: document.getElementById("resetBtn"),
-    quickAddButtons: document.querySelectorAll(".btn-add"),
+    dailyGoal: document.getElementById('dailyGoal'),
+    saveGoalBtn: document.getElementById('saveGoalBtn'),
+    waterLevel: document.getElementById('waterLevel'),
+    consumedAmount: document.getElementById('consumedAmount'),
+    goalAmount: document.getElementById('goalAmount'),
+    progressPercent: document.getElementById('progressPercent'),
+    progressText: document.getElementById('progressText'),
+    statusMessage: document.getElementById('statusMessage'),
+    customAmount: document.getElementById('customAmount'),
+    customAddBtn: document.getElementById('customAddBtn'),
+    undoBtn: document.getElementById('undoBtn'),
+    resetBtn: document.getElementById('resetBtn'),
+    quickAddButtons: document.querySelectorAll('.btn-add'),
   };
 
   let state = loadState();
 
   function todayKey() {
-    return new Date().toISOString().slice(0, 10);
+    const now = new Date();
+
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+
+    return `${year}-${month}-${day}`;
   }
 
   function defaultState() {
@@ -77,14 +83,14 @@
     return Math.min(100, Math.round((state.consumed / state.goal) * 100));
   }
 
-  function showStatus(message, type = "success") {
+  function showStatus(message, type = 'success') {
     elements.statusMessage.textContent = message;
-    elements.statusMessage.classList.toggle("is-warning", type === "info");
+    elements.statusMessage.classList.toggle('is-warning', type === 'info');
     if (message) {
       clearTimeout(showStatus._timer);
       showStatus._timer = setTimeout(() => {
         if (elements.statusMessage.textContent === message) {
-          elements.statusMessage.textContent = "";
+          elements.statusMessage.textContent = '';
         }
       }, 2200);
     }
@@ -98,19 +104,22 @@
     elements.consumedAmount.textContent = state.consumed;
     elements.goalAmount.textContent = state.goal;
     elements.progressPercent.textContent = `${percent}%`;
-    elements.waterLevel.style.setProperty("--fill", `${fill}%`);
-    elements.waterLevel.classList.toggle("goal-reached", state.consumed >= state.goal);
+    elements.waterLevel.style.setProperty('--fill', `${fill}%`);
+    elements.waterLevel.classList.toggle(
+      'goal-reached',
+      state.consumed >= state.goal
+    );
     elements.undoBtn.disabled = state.history.length === 0;
 
     const remaining = Math.max(0, state.goal - state.consumed);
     if (state.consumed >= state.goal) {
       elements.progressText.setAttribute(
-        "aria-label",
+        'aria-label',
         `Goal reached. You drank ${state.consumed} milliliters of your ${state.goal} milliliter goal.`
       );
     } else {
       elements.progressText.setAttribute(
-        "aria-label",
+        'aria-label',
         `${state.consumed} of ${state.goal} milliliters consumed. ${remaining} milliliters remaining.`
       );
     }
@@ -119,7 +128,7 @@
   function addWater(amount) {
     const ml = clampAmount(amount);
     if (!ml) {
-      showStatus("Enter a valid amount.", "info");
+      showStatus('Enter a valid amount.', 'info');
       return;
     }
 
@@ -129,7 +138,7 @@
     render();
 
     if (state.consumed >= state.goal) {
-      showStatus("Goal reached — great job staying hydrated!");
+      showStatus('Goal reached — great job staying hydrated!');
     } else {
       showStatus(`Added ${ml} ml`);
     }
@@ -150,12 +159,12 @@
     state.consumed = Math.max(0, state.consumed - last);
     saveState();
     render();
-    showStatus(`Removed ${last} ml`, "info");
+    showStatus(`Removed ${last} ml`, 'info');
   }
 
   function resetToday() {
     if (!state.consumed && !state.history.length) {
-      showStatus("Nothing to reset.", "info");
+      showStatus('Nothing to reset.', 'info');
       return;
     }
     if (!confirm("Reset today's water intake to zero?")) return;
@@ -165,38 +174,38 @@
     state.date = todayKey();
     saveState();
     render();
-    showStatus("Today's progress reset.", "info");
+    showStatus("Today's progress reset.", 'info');
   }
 
   elements.quickAddButtons.forEach((btn) => {
-    btn.addEventListener("click", () => {
+    btn.addEventListener('click', () => {
       addWater(Number(btn.dataset.amount));
     });
   });
 
-  elements.customAddBtn.addEventListener("click", () => {
+  elements.customAddBtn.addEventListener('click', () => {
     addWater(elements.customAmount.value);
-    elements.customAmount.value = "";
+    elements.customAmount.value = '';
   });
 
-  elements.customAmount.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") {
+  elements.customAmount.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
       e.preventDefault();
       elements.customAddBtn.click();
     }
   });
 
-  elements.saveGoalBtn.addEventListener("click", setGoal);
+  elements.saveGoalBtn.addEventListener('click', setGoal);
 
-  elements.dailyGoal.addEventListener("keydown", (e) => {
-    if (e.key === "Enter") {
+  elements.dailyGoal.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
       e.preventDefault();
       setGoal();
     }
   });
 
-  elements.undoBtn.addEventListener("click", undoLast);
-  elements.resetBtn.addEventListener("click", resetToday);
+  elements.undoBtn.addEventListener('click', undoLast);
+  elements.resetBtn.addEventListener('click', resetToday);
 
   render();
 })();


### PR DESCRIPTION
## Summary

Fixes an issue where daily water tracking progress could reset at the wrong time for users in non-UTC time zones.

## Root Cause

The application used:

```js
new Date().toISOString().slice(0, 10)
```

to determine the current day.

Since `toISOString()` returns a UTC date, users in time zones ahead of or behind UTC could experience daily progress resets before or after their local midnight.

## Changes Made

- Replaced UTC-based date generation with local date generation.
- Updated `todayKey()` to use:
  - `getFullYear()`
  - `getMonth()`
  - `getDate()`
- Preserved the existing storage format (`YYYY-MM-DD`).

## Before Fix

- Daily progress was tied to UTC midnight.
- Users in certain time zones could lose progress unexpectedly.
- Date comparisons did not reflect the user's local calendar day.

## After Fix

- Daily progress resets based on the user's local date.
- Progress remains available until local midnight.
- Date comparisons are consistent across time zones.

## Testing

- [x] Verified progress persists throughout the local day.
- [x] Verified reset occurs after local midnight.
- [x] Verified existing saved data remains compatible.
- [x] Tested date generation in multiple timezone offsets.

## Issue Fixed

Closes #8651