### PR TITLE
fix: detect cross-lane collisions at intersection

### DIFF
--- a/public/traffic_signal/index.html
+++ b/public/traffic_signal/index.html
@@ -1,11 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Traffic Signal Simulation Game</title>
     <link rel="stylesheet" href="style.css" />
-    <link rel="icon" href="favicon_traffic.png">
+    <link rel="icon" href="favicon_traffic.png" />
   </head>
   <body>
     <div id="game-container">
@@ -22,7 +22,9 @@
         </div>
         <div class="hud-panel">
           <p class="hud-label">Collisions</p>
-          <p class="hud-value" id="collision-display" style="color: #ff4444">0</p>
+          <p class="hud-value" id="collision-display" style="color: #ff4444">
+            0
+          </p>
         </div>
         <div class="hud-panel">
           <p class="hud-label">Level</p>
@@ -35,18 +37,43 @@
       <aside id="signal-panel" aria-label="Traffic Signal">
         <p class="signal-label">SIGNAL</p>
         <div class="signal-box" role="img" aria-label="Traffic light">
-          <div class="signal-light active-red" id="red-light" aria-label="Red light"></div>
-          <div class="signal-light" id="yellow-light" aria-label="Yellow light"></div>
-          <div class="signal-light" id="green-light" aria-label="Green light"></div>
+          <div
+            class="signal-light active-red"
+            id="red-light"
+            aria-label="Red light"
+          ></div>
+          <div
+            class="signal-light"
+            id="yellow-light"
+            aria-label="Yellow light"
+          ></div>
+          <div
+            class="signal-light"
+            id="green-light"
+            aria-label="Green light"
+          ></div>
         </div>
         <div class="timer-bar-wrap">
           <div id="timer-bar" style="width: 100%; background: var(--red)"></div>
         </div>
-        <p style="text-align: center; margin-top: 5px; font-family: 'Orbitron', monospace; font-size: 11px; color: #fff;" id="timer-count">5s</p>
+        <p
+          style="
+            text-align: center;
+            margin-top: 5px;
+            font-family: 'Orbitron', monospace;
+            font-size: 11px;
+            color: #fff;
+          "
+          id="timer-count"
+        >
+          5s
+        </p>
       </aside>
 
       <nav id="controls" aria-label="Game controls">
-        <button class="ctrl-btn" onclick="toggleDayNight()">🌙 Day/Night</button>
+        <button class="ctrl-btn" onclick="toggleDayNight()">
+          🌙 Day/Night
+        </button>
         <button class="ctrl-btn" onclick="togglePause()">⏸ Pause</button>
       </nav>
 

--- a/public/traffic_signal/script.js
+++ b/public/traffic_signal/script.js
@@ -1,21 +1,32 @@
-const canvas = document.getElementById("gameCanvas");
-const ctx = canvas.getContext("2d");
+const canvas = document.getElementById('gameCanvas');
+const ctx = canvas.getContext('2d');
 
 function resize() {
   canvas.width = window.innerWidth;
   canvas.height = window.innerHeight;
 }
 resize();
-window.addEventListener("resize", resize);
+window.addEventListener('resize', resize);
 
-let W, H, gameRunning = false, paused = false, isNight = false;
-let score = 0, carsPassed = 0, collisions = 0, level = 1;
-let signal = "red";
+let W,
+  H,
+  gameRunning = false,
+  paused = false,
+  isNight = false;
+let score = 0,
+  carsPassed = 0,
+  collisions = 0,
+  level = 1;
+let signal = 'red';
 let signalTimer = 0;
 const SIGNAL_DURATIONS = { red: 5, yellow: 1.5, green: 4 };
 let signalMax = SIGNAL_DURATIONS.red;
-let cars = [], clouds = [], stars = [], buildings = [];
-let spawnTimer = 0, levelTimer = 0;
+let cars = [],
+  clouds = [],
+  stars = [],
+  buildings = [];
+let spawnTimer = 0,
+  levelTimer = 0;
 let animFrame;
 let lastTime = 0;
 const LANE_COUNT = 5;
@@ -73,8 +84,17 @@ function genClouds() {
     });
 }
 
-const CAR_COLORS = ["#e74c3c", "#3498db", "#f39c12", "#2ecc71", "#9b59b6", "#1abc9c", "#e67e22", "#ecf0f1"];
-const CAR_TYPES = ["sedan", "truck", "bus", "sports"];
+const CAR_COLORS = [
+  '#e74c3c',
+  '#3498db',
+  '#f39c12',
+  '#2ecc71',
+  '#9b59b6',
+  '#1abc9c',
+  '#e67e22',
+  '#ecf0f1',
+];
+const CAR_TYPES = ['sedan', 'truck', 'bus', 'sports'];
 
 function makeCar(lane) {
   const goRight = lane < 3;
@@ -98,7 +118,7 @@ function makeCar(lane) {
     h: d.h,
     color: CAR_COLORS[Math.floor(Math.random() * CAR_COLORS.length)],
     speed: baseSpeed,
-    state: "moving",
+    state: 'moving',
     passed: false,
     collided: false,
     alpha: 1,
@@ -110,14 +130,14 @@ function getStopX(car) {
 }
 
 function nextSignal() {
-  if (signal === "red") {
-    signal = "green";
+  if (signal === 'red') {
+    signal = 'green';
     signalMax = SIGNAL_DURATIONS.green - Math.min(level * 0.12, 2);
-  } else if (signal === "green") {
-    signal = "yellow";
+  } else if (signal === 'green') {
+    signal = 'yellow';
     signalMax = SIGNAL_DURATIONS.yellow;
   } else {
-    signal = "red";
+    signal = 'red';
     signalMax = SIGNAL_DURATIONS.red - Math.min(level * 0.08, 2);
   }
   signalTimer = signalMax;
@@ -125,11 +145,19 @@ function nextSignal() {
 }
 
 function updateSignalUI() {
-  document.getElementById("red-light").className = "signal-light" + (signal === "red" ? " active-red" : "");
-  document.getElementById("yellow-light").className = "signal-light" + (signal === "yellow" ? " active-yellow" : "");
-  document.getElementById("green-light").className = "signal-light" + (signal === "green" ? " active-green" : "");
-  const bar = document.getElementById("timer-bar");
-  bar.style.background = signal === "red" ? "var(--red)" : signal === "yellow" ? "var(--yellow)" : "var(--green)";
+  document.getElementById('red-light').className =
+    'signal-light' + (signal === 'red' ? ' active-red' : '');
+  document.getElementById('yellow-light').className =
+    'signal-light' + (signal === 'yellow' ? ' active-yellow' : '');
+  document.getElementById('green-light').className =
+    'signal-light' + (signal === 'green' ? ' active-green' : '');
+  const bar = document.getElementById('timer-bar');
+  bar.style.background =
+    signal === 'red'
+      ? 'var(--red)'
+      : signal === 'yellow'
+        ? 'var(--yellow)'
+        : 'var(--green)';
 }
 
 function initGame() {
@@ -142,7 +170,7 @@ function initGame() {
   carsPassed = 0;
   collisions = 0;
   level = 1;
-  signal = "red";
+  signal = 'red';
   signalTimer = SIGNAL_DURATIONS.red;
   signalMax = SIGNAL_DURATIONS.red;
   spawnTimer = 0;
@@ -152,11 +180,12 @@ function initGame() {
 }
 
 function updateHUD() {
-  document.getElementById("score-display").textContent = score;
-  document.getElementById("passed-display").textContent = carsPassed;
-  document.getElementById("collision-display").textContent = collisions;
-  document.getElementById("level-display").textContent = level;
-  document.getElementById("diff-badge").textContent = `LEVEL ${level} — ${level < 3 ? "EASY" : level < 6 ? "MEDIUM" : level < 9 ? "HARD" : "EXTREME"}`;
+  document.getElementById('score-display').textContent = score;
+  document.getElementById('passed-display').textContent = carsPassed;
+  document.getElementById('collision-display').textContent = collisions;
+  document.getElementById('level-display').textContent = level;
+  document.getElementById('diff-badge').textContent =
+    `LEVEL ${level} — ${level < 3 ? 'EASY' : level < 6 ? 'MEDIUM' : level < 9 ? 'HARD' : 'EXTREME'}`;
   if (collisions >= 5) endGame();
 }
 
@@ -173,8 +202,9 @@ function update(dt) {
   signalTimer -= dt;
   if (signalTimer <= 0) nextSignal();
   const pct = Math.max(0, signalTimer / signalMax);
-  document.getElementById("timer-bar").style.width = pct * 100 + "%";
-  document.getElementById("timer-count").textContent = Math.ceil(signalTimer) + "s";
+  document.getElementById('timer-bar').style.width = pct * 100 + '%';
+  document.getElementById('timer-count').textContent =
+    Math.ceil(signalTimer) + 's';
   levelTimer += dt;
   if (levelTimer > 20) {
     level = Math.min(level + 1, 12);
@@ -185,7 +215,9 @@ function update(dt) {
   const spawnRate = Math.max(0.6, 2.2 - level * 0.12);
   if (spawnTimer <= 0) {
     const lane = Math.floor(Math.random() * LANE_COUNT);
-    const maxCarsInLane = cars.filter((c) => c.lane === lane && !c.passed && !c.collided).length;
+    const maxCarsInLane = cars.filter(
+      (c) => c.lane === lane && !c.passed && !c.collided
+    ).length;
     if (maxCarsInLane < 4) cars.push(makeCar(lane));
     spawnTimer = spawnRate + Math.random() * 0.5;
   }
@@ -199,20 +231,25 @@ function update(dt) {
       return;
     }
     const stopX = getStopX(car);
-    const atStop = car.goRight ? car.x + car.w >= stopX - 2 : car.x <= stopX + 2;
-    if (signal === "red" || signal === "yellow") {
+    const atStop = car.goRight
+      ? car.x + car.w >= stopX - 2
+      : car.x <= stopX + 2;
+    if (signal === 'red' || signal === 'yellow') {
       if (atStop) {
-        car.state = "stopped";
+        car.state = 'stopped';
         car.x = car.goRight ? stopX - car.w : stopX;
       } else {
         const dist = car.goRight ? stopX - car.w - car.x : car.x - stopX;
         const slowZone = 120;
-        const spd = dist < slowZone ? car.speed * (0.3 + 0.7 * (dist / slowZone)) : car.speed;
+        const spd =
+          dist < slowZone
+            ? car.speed * (0.3 + 0.7 * (dist / slowZone))
+            : car.speed;
         car.x += (car.goRight ? 1 : -1) * spd * 60 * dt;
-        car.state = dist < slowZone ? "stopping" : "moving";
+        car.state = dist < slowZone ? 'stopping' : 'moving';
       }
     } else {
-      car.state = "moving";
+      car.state = 'moving';
       car.x += (car.goRight ? 1 : -1) * car.speed * 60 * dt;
     }
     if (!car.passed) {
@@ -226,32 +263,48 @@ function update(dt) {
       }
     }
   });
+
   for (let i = 0; i < cars.length; i++) {
     if (cars[i].collided || cars[i].passed) continue;
+
     for (let j = i + 1; j < cars.length; j++) {
       if (cars[j].collided || cars[j].passed) continue;
-      if (cars[i].lane !== cars[j].lane) continue;
-      const a = cars[i], b = cars[j];
-      if (a.x < b.x + b.w - 4 && a.x + a.w > b.x + 4 && a.y < b.y + b.h - 4 && a.y + a.h > b.y + 4) {
-        a.collided = b.collided = true;
-        collisions++;
-        score = Math.max(0, score - 30);
-        updateHUD();
-        flashRed();
-      }
+
+      const a = cars[i];
+      const b = cars[j];
+
+      const isOverlapping =
+        a.x < b.x + b.w - 4 &&
+        a.x + a.w > b.x + 4 &&
+        a.y < b.y + b.h - 4 &&
+        a.y + a.h > b.y + 4;
+
+      if (!isOverlapping) continue;
+
+      a.collided = true;
+      b.collided = true;
+
+      collisions++;
+      score = Math.max(0, score - 30);
+
+      updateHUD();
+      flashRed();
     }
   }
+
   clouds.forEach((c) => {
     c.x += c.speed * dt;
     if (c.x > W + 200) c.x = -200;
   });
-  cars = cars.filter((c) => c.alpha > 0 && !(c.passed && (c.x > W + 200 || c.x < -200)));
+  cars = cars.filter(
+    (c) => c.alpha > 0 && !(c.passed && (c.x > W + 200 || c.x < -200))
+  );
 }
 
 function flashRed() {
-  const el = document.getElementById("collision-flash");
-  el.style.background = "rgba(255,0,0,0.35)";
-  setTimeout(() => (el.style.background = "rgba(255,0,0,0)"), 250);
+  const el = document.getElementById('collision-flash');
+  el.style.background = 'rgba(255,0,0,0.35)';
+  setTimeout(() => (el.style.background = 'rgba(255,0,0,0)'), 250);
 }
 
 function draw() {
@@ -270,11 +323,11 @@ function draw() {
 function drawSky() {
   const grad = ctx.createLinearGradient(0, 0, 0, SKY_H);
   if (isNight) {
-    grad.addColorStop(0, "#02020f");
-    grad.addColorStop(1, "#0d0d3a");
+    grad.addColorStop(0, '#02020f');
+    grad.addColorStop(1, '#0d0d3a');
   } else {
-    grad.addColorStop(0, "#3a9bd5");
-    grad.addColorStop(1, "#aee8f5");
+    grad.addColorStop(0, '#3a9bd5');
+    grad.addColorStop(1, '#aee8f5');
   }
   ctx.fillStyle = grad;
   ctx.fillRect(0, 0, W, SKY_H);
@@ -282,7 +335,7 @@ function drawSky() {
 
 function drawCloudsOrStars() {
   if (isNight) {
-    ctx.fillStyle = "#fff";
+    ctx.fillStyle = '#fff';
     stars.forEach((s) => {
       ctx.globalAlpha = 0.5 + 0.5 * Math.sin(Date.now() / 1000 + s.x);
       ctx.beginPath();
@@ -292,25 +345,25 @@ function drawCloudsOrStars() {
     ctx.globalAlpha = 1;
     ctx.beginPath();
     ctx.arc(W * 0.88, SKY_H * 0.18, 28, 0, Math.PI * 2);
-    ctx.fillStyle = "#fffde7";
-    ctx.shadowColor = "#fffde7";
+    ctx.fillStyle = '#fffde7';
+    ctx.shadowColor = '#fffde7';
     ctx.shadowBlur = 30;
     ctx.fill();
     ctx.shadowBlur = 0;
     ctx.beginPath();
     ctx.arc(W * 0.88 + 10, SKY_H * 0.18 - 4, 24, 0, Math.PI * 2);
-    ctx.fillStyle = "#02020f";
+    ctx.fillStyle = '#02020f';
     ctx.fill();
   } else {
     ctx.beginPath();
     ctx.arc(W * 0.85, SKY_H * 0.2, 36, 0, Math.PI * 2);
-    ctx.fillStyle = "#ffe87c";
-    ctx.shadowColor = "#ffcc00";
+    ctx.fillStyle = '#ffe87c';
+    ctx.shadowColor = '#ffcc00';
     ctx.shadowBlur = 40;
     ctx.fill();
     ctx.shadowBlur = 0;
     clouds.forEach((c) => {
-      ctx.fillStyle = "rgba(255,255,255,0.85)";
+      ctx.fillStyle = 'rgba(255,255,255,0.85)';
       drawCloud(c.x, c.y, c.w);
     });
   }
@@ -329,18 +382,18 @@ function drawCloud(x, y, w) {
 function drawBuildings() {
   buildings.forEach((b) => {
     const by = SKY_H - b.h;
-    ctx.fillStyle = isNight ? "#1a1a2e" : "#8b7355";
+    ctx.fillStyle = isNight ? '#1a1a2e' : '#8b7355';
     ctx.fillRect(b.x, by, b.w, b.h);
     b.windows.forEach((win) => {
       const wx = b.x + 5 + win.c * 14;
       const wy = by + 8 + win.r * 18;
       if (wx + 8 > b.x + b.w - 3) return;
       if (isNight && win.on) {
-        ctx.fillStyle = "rgba(255,240,150,0.7)";
+        ctx.fillStyle = 'rgba(255,240,150,0.7)';
       } else if (!isNight) {
-        ctx.fillStyle = "rgba(180,220,255,0.5)";
+        ctx.fillStyle = 'rgba(180,220,255,0.5)';
       } else {
-        ctx.fillStyle = "rgba(40,40,60,0.8)";
+        ctx.fillStyle = 'rgba(40,40,60,0.8)';
       }
       ctx.fillRect(wx, wy, 8, 10);
     });
@@ -350,25 +403,27 @@ function drawBuildings() {
 function drawRoad() {
   const grad = ctx.createLinearGradient(0, ROAD_TOP, 0, ROAD_BOTTOM);
   if (isNight) {
-    grad.addColorStop(0, "#2a2a2a");
-    grad.addColorStop(1, "#1a1a1a");
+    grad.addColorStop(0, '#2a2a2a');
+    grad.addColorStop(1, '#1a1a1a');
   } else {
-    grad.addColorStop(0, "#5a5a5a");
-    grad.addColorStop(1, "#444");
+    grad.addColorStop(0, '#5a5a5a');
+    grad.addColorStop(1, '#444');
   }
   ctx.fillStyle = grad;
   ctx.fillRect(0, ROAD_TOP, W, ROAD_BOTTOM - ROAD_TOP);
-  ctx.fillStyle = isNight ? "#1a1a1a" : "#7a6a55";
+  ctx.fillStyle = isNight ? '#1a1a1a' : '#7a6a55';
   ctx.fillRect(0, ROAD_TOP - 6, W, 6);
   ctx.fillRect(0, ROAD_BOTTOM, W, 6);
   for (let i = 1; i < LANE_COUNT; i++) {
     const y = ROAD_TOP + i * LANE_H;
     if (i === 3) {
-      ctx.strokeStyle = "#ffcc00";
+      ctx.strokeStyle = '#ffcc00';
       ctx.lineWidth = 2;
       ctx.setLineDash([]);
     } else {
-      ctx.strokeStyle = isNight ? "rgba(255,255,255,0.25)" : "rgba(255,255,255,0.35)";
+      ctx.strokeStyle = isNight
+        ? 'rgba(255,255,255,0.25)'
+        : 'rgba(255,255,255,0.35)';
       ctx.lineWidth = 1;
       ctx.setLineDash([20, 20]);
     }
@@ -383,11 +438,11 @@ function drawRoad() {
 function drawGround() {
   const grad = ctx.createLinearGradient(0, ROAD_BOTTOM + 6, 0, H);
   if (isNight) {
-    grad.addColorStop(0, "#0d1a0d");
-    grad.addColorStop(1, "#050d05");
+    grad.addColorStop(0, '#0d1a0d');
+    grad.addColorStop(1, '#050d05');
   } else {
-    grad.addColorStop(0, "#5a8a4a");
-    grad.addColorStop(1, "#3a6a2a");
+    grad.addColorStop(0, '#5a8a4a');
+    grad.addColorStop(1, '#3a6a2a');
   }
   ctx.fillStyle = grad;
   ctx.fillRect(0, ROAD_BOTTOM + 6, W, H - ROAD_BOTTOM - 6);
@@ -397,11 +452,16 @@ function drawIntersection() {
   const iw = 80;
   const stripes = 6;
   for (let i = 0; i < stripes; i++) {
-    ctx.fillStyle = i % 2 === 0 ? (isNight ? "rgba(255,255,255,0.5)" : "rgba(255,255,255,0.7)") : "transparent";
+    ctx.fillStyle =
+      i % 2 === 0
+        ? isNight
+          ? 'rgba(255,255,255,0.5)'
+          : 'rgba(255,255,255,0.7)'
+        : 'transparent';
     const sx = INTERSECTION_X - iw / 2 + i * (iw / stripes);
     ctx.fillRect(sx, ROAD_TOP, iw / stripes, ROAD_BOTTOM - ROAD_TOP);
   }
-  ctx.strokeStyle = isNight ? "rgba(255,255,255,0.8)" : "#fff";
+  ctx.strokeStyle = isNight ? 'rgba(255,255,255,0.8)' : '#fff';
   ctx.lineWidth = 3;
   ctx.setLineDash([]);
   ctx.beginPath();
@@ -417,23 +477,25 @@ function drawIntersection() {
 function drawTrafficLight() {
   const tx = INTERSECTION_X - 44;
   const ty = ROAD_TOP - 80;
-  const ph = 90, pw = 24;
-  ctx.fillStyle = isNight ? "#555" : "#777";
+  const ph = 90,
+    pw = 24;
+  ctx.fillStyle = isNight ? '#555' : '#777';
   ctx.fillRect(tx + pw / 2 - 3, ty + ph, 6, 80);
-  ctx.fillStyle = "#111";
-  ctx.strokeStyle = "#333";
+  ctx.fillStyle = '#111';
+  ctx.strokeStyle = '#333';
   ctx.lineWidth = 1.5;
   ctx.beginPath();
   ctx.roundRect(tx, ty, pw, ph, 5);
   ctx.fill();
   ctx.stroke();
   const lights = [
-    { col: "#ff2222", active: signal === "red" },
-    { col: "#ffcc00", active: signal === "yellow" },
-    { col: "#00ff44", active: signal === "green" },
+    { col: '#ff2222', active: signal === 'red' },
+    { col: '#ffcc00', active: signal === 'yellow' },
+    { col: '#00ff44', active: signal === 'green' },
   ];
   lights.forEach((l, i) => {
-    const lx = tx + pw / 2, ly = ty + 14 + i * 26;
+    const lx = tx + pw / 2,
+      ly = ty + 14 + i * 26;
     ctx.beginPath();
     ctx.arc(lx, ly, 8, 0, Math.PI * 2);
     if (l.active) {
@@ -441,7 +503,7 @@ function drawTrafficLight() {
       ctx.shadowColor = l.col;
       ctx.shadowBlur = 18;
     } else {
-      ctx.fillStyle = "#1a1a1a";
+      ctx.fillStyle = '#1a1a1a';
       ctx.shadowBlur = 0;
     }
     ctx.fill();
@@ -466,25 +528,25 @@ function drawCar(car) {
     ctx.scale(-1, 1);
     ctx.translate(-(x + w / 2), -(y + h / 2));
   }
-  ctx.fillStyle = collided ? "#ff4400" : color;
+  ctx.fillStyle = collided ? '#ff4400' : color;
   if (collided) {
-    ctx.shadowColor = "#ff4400";
+    ctx.shadowColor = '#ff4400';
     ctx.shadowBlur = 20;
   }
   ctx.beginPath();
   ctx.roundRect(x, y + h * 0.25, w, h * 0.75, 4);
   ctx.fill();
   ctx.shadowBlur = 0;
-  ctx.fillStyle = "#1a1a1a";
+  ctx.fillStyle = '#1a1a1a';
   ctx.beginPath();
   ctx.arc(x + w * 0.2, y + h - 5, 5, 0, Math.PI * 2);
   ctx.fill();
   ctx.beginPath();
   ctx.arc(x + w * 0.78, y + h - 5, 5, 0, Math.PI * 2);
   ctx.fill();
-  if (state === "stopping" || state === "stopped") {
-    ctx.fillStyle = "#ff0000";
-    ctx.shadowColor = "#f00";
+  if (state === 'stopping' || state === 'stopped') {
+    ctx.fillStyle = '#ff0000';
+    ctx.shadowColor = '#f00';
     ctx.shadowBlur = 14;
     ctx.beginPath();
     ctx.ellipse(x + 2, y + h * 0.55, 4, 3.5, 0, 0, Math.PI * 2);
@@ -494,16 +556,18 @@ function drawCar(car) {
   ctx.restore();
 }
 
-function toggleDayNight() { isNight = !isNight; }
+function toggleDayNight() {
+  isNight = !isNight;
+}
 function togglePause() {
   paused = !paused;
-  const btn = document.querySelector("#controls .ctrl-btn:last-child");
-  btn.textContent = paused ? "▶ Resume" : "⏸ Pause";
+  const btn = document.querySelector('#controls .ctrl-btn:last-child');
+  btn.textContent = paused ? '▶ Resume' : '⏸ Pause';
 }
 
 function startGame() {
-  document.getElementById("overlay").style.display = "none";
-  document.getElementById("stats-row").style.display = "none";
+  document.getElementById('overlay').style.display = 'none';
+  document.getElementById('stats-row').style.display = 'none';
   gameRunning = true;
   paused = false;
   initGame();
@@ -515,14 +579,14 @@ function startGame() {
 function endGame() {
   gameRunning = false;
   cancelAnimationFrame(animFrame);
-  document.getElementById("final-score").textContent = score;
-  document.getElementById("final-passed").textContent = carsPassed;
-  document.getElementById("final-collisions").textContent = collisions;
-  document.getElementById("final-level").textContent = level;
-  document.getElementById("stats-row").style.display = "flex";
-  document.querySelector("#overlay h1").textContent = "🚗 GAME OVER";
-  document.getElementById("start-btn").textContent = "PLAY AGAIN";
-  document.getElementById("overlay").style.display = "flex";
+  document.getElementById('final-score').textContent = score;
+  document.getElementById('final-passed').textContent = carsPassed;
+  document.getElementById('final-collisions').textContent = collisions;
+  document.getElementById('final-level').textContent = level;
+  document.getElementById('stats-row').style.display = 'flex';
+  document.querySelector('#overlay h1').textContent = '🚗 GAME OVER';
+  document.getElementById('start-btn').textContent = 'PLAY AGAIN';
+  document.getElementById('overlay').style.display = 'flex';
 }
 
 calcLayout();


### PR DESCRIPTION
## Description

Fixed collision detection logic that previously ignored vehicles belonging to different lanes.

### Problem

The game only checked collisions when:

```javascript
if (cars[i].lane !== cars[j].lane) continue;
```

As a result, vehicles from different lanes could visually overlap at the intersection without triggering a collision.

### Changes Made

- Removed lane-based collision restriction.
- Added collision detection based on bounding-box overlap.
- Ensured collisions are registered regardless of lane assignment.
- Preserved existing score penalty and collision counter behavior.

### Result

- Same-lane collisions continue to work.
- Cross-lane collisions are now detected.
- Intersection traffic behavior is more realistic.

Fixes #8654