### PR TITLE
fix: prevent recipe card overflow off left edge with box-sizing fix

### DIFF
--- a/public/recipe/style.css
+++ b/public/recipe/style.css
@@ -415,6 +415,10 @@ select option {
     transition: .3s;
     cursor: pointer;
     transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s ease;
+        cursor: pointer;
+    max-width: 100%;
+    box-sizing: border-box;
+
 }
 
 .recipe-card:hover {
@@ -538,6 +542,7 @@ select option {
     max-width: 900px;
     margin: 40px auto;
     padding-bottom: 80px;
+    box-sizing: border-box;
 }
 
 .recipe-image {


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #7759

### Summary
Fixed the Recipe card overflowing off the left edge in Recipezzz. The `.recipe-container` and `.recipe-card` elements lacked `box-sizing: border-box`, causing padding to add on top of the defined width and push the card past its container. Added `box-sizing: border-box` and a `max-width: 100%` safeguard on the card to keep it correctly contained within the page on all screen sizes.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 🛠️ Changes Made
- Added `box-sizing: border-box` to `.recipe-container` so padding no longer adds extra width beyond the defined container width
- Added `max-width: 100%` and `box-sizing: border-box` to `.recipe-card` to prevent it from overflowing the container on narrow viewports

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [ ] Tested and verified in **Google Chrome**

### Responsive & Accessibility Checks
- [x] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports



---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.