### PR TITLE
fix(learning): guard localStorage JSON.parse so corrupted data does not blank the portal

### DIFF
--- a/learning/learning.js
+++ b/learning/learning.js
@@ -10,15 +10,23 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   let bookmarks = [];
 
+  // Safely parse JSON from storage so corrupted data cannot crash the portal
+  const safeParse = (value, fallback) => {
+    if (!value) return fallback;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return fallback;
+    }
+  };
+
   function loadBookmarks() {
   const saved =
     localStorage.getItem(
       BOOKMARKS_KEY
     );
 
-  bookmarks = saved
-    ? JSON.parse(saved)
-    : [];
+  bookmarks = safeParse(saved, []);
 }
 
 function saveBookmarks() {
@@ -219,8 +227,9 @@ function toggleBookmark(topic) {
 
   function loadProgress() {
     const saved = localStorage.getItem(STORAGE_KEY);
-    if (saved) {
-      learningProgress = JSON.parse(saved);
+    const parsed = safeParse(saved, null);
+    if (parsed) {
+      learningProgress = parsed;
     }
   }
 
@@ -235,11 +244,7 @@ function toggleBookmark(topic) {
       .split('T')[0];
 
   let streak =
-    JSON.parse(
-      localStorage.getItem(
-        STREAK_KEY
-      )
-    ) || {
+    safeParse(localStorage.getItem(STREAK_KEY), null) || {
       current: 0,
       best: 0,
       lastVisit: null


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8644

### Summary
The learning portal read progress, bookmarks, and streak data from `localStorage` with unguarded `JSON.parse` during init, so any corrupted value crashed the whole portal to a blank page. This PR parses storage through a small safe helper that falls back to a default.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `learning/learning.js`: added a `safeParse(value, fallback)` helper (try/catch around `JSON.parse`) and used it in the three places that read storage: `loadBookmarks` (`learningBookmarks`), `loadProgress` (`learningProgress`), and `updateLearningStreak` (`learningStreak`). Corrupted or invalid JSON now falls back to the default instead of throwing.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change.

What I did verify:
- `node --check learning/learning.js` passes.
- The only remaining `JSON.parse` is inside `safeParse`; all three call sites use the helper.
- Verified the helper's behaviour: valid JSON parses normally, invalid JSON (e.g. `'{bad'`) returns the fallback, and a missing value returns the fallback.

### Browser Compatibility Check
- The portal now loads even if a learning storage key contains invalid JSON (previously a blank page).

### Responsive & Accessibility Checks
- N/A: no layout changes.

---

## 📷 Screenshots / Video Recording
N/A.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
