### PR TITLE
fix(learning): score Retake Wrong over the retaken questions only

### DIFF
--- a/learning/learning.js
+++ b/learning/learning.js
@@ -1166,7 +1166,7 @@ list.appendChild(item);
         explanation: q.explanation || '',
         userAnswer: null,
         isCorrect: false,
-        wasTestedThisRun: false
+        wasTestedThisRun: true
       }));
     } else {
       persistentResultsLog.forEach(item => {
@@ -1248,8 +1248,9 @@ list.appendChild(item);
     function showResult() {
       document.getElementById('topicNavigation').style.display = 'flex';
       
-      const totalQuestions = persistentResultsLog.length;
-      const correctAnswersCount = persistentResultsLog.filter(r => r.isCorrect).length;
+      const runResults = persistentResultsLog.filter(r => r.wasTestedThisRun);
+      const totalQuestions = runResults.length;
+      const correctAnswersCount = runResults.filter(r => r.isCorrect).length;
       const wrongAnswersCount = totalQuestions - correctAnswersCount;
       const percentage = Math.round((correctAnswersCount / totalQuestions) * 100);
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8646

### Summary
The quiz result screen scored over the entire question pool instead of the questions actually asked in the current run, so "Retake Wrong" credited the questions that were not retaken. The code already tracked the current run with a `wasTestedThisRun` flag, but the scorer ignored it and the full-quiz path never set it. This PR completes that flag's intended use.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `learning/learning.js`, `launchQuiz`: a full quiz now marks its questions `wasTestedThisRun: true` (was `false` and never updated).
- `learning/learning.js`, `showResult`: the score, correct/wrong counts, and percentage are computed from `persistentResultsLog.filter(r => r.wasTestedThisRun)` instead of the whole log, so a retake scores only the retaken questions. The full log is still kept for the Review screen.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change.

What I did verify:
- `node --check learning/learning.js` passes.
- Simulated the scoring for a 10-question quiz with 3 wrong, then a Retake-Wrong where 1 of the 3 is answered correctly:
  - before: `8/10 (80%)` (credited the 7 not retaken),
  - after: `1/3 (33%)` (only the retaken questions).
- For a full quiz, all questions are marked `wasTestedThisRun: true`, so the score is over the full pool as before.

### Browser Compatibility Check
- The result screen now shows the retaken score for "Retake Wrong"; full-quiz scoring is unchanged.

### Responsive & Accessibility Checks
- N/A: no layout changes.

---

## 📷 Screenshots / Video Recording
N/A.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
