### PR TITLE
fix(learning): require an explicit click to mark a topic complete

### DIFF
--- a/learning/learning.js
+++ b/learning/learning.js
@@ -304,6 +304,25 @@ function renderStreak() {
     updateProgressUI();
   }
 
+  // Completion requires an explicit click, not just opening the topic
+  function renderCompleteButton(topicKey) {
+    const done = learningProgress.completedTopics.includes(topicKey);
+    const bar = document.createElement('div');
+    bar.style.cssText = 'display:flex; justify-content:center; margin:2.5rem 0 1rem;';
+    const btn = document.createElement('button');
+    btn.textContent = done ? '✓ Completed' : 'Mark as Complete';
+    btn.style.cssText = 'padding:0.7rem 1.5rem; border:none; border-radius:8px; font-weight:600; font-size:0.95rem; cursor:pointer; color:#fff; background:' + (done ? '#10b981' : '#3b82f6') + ';';
+    btn.disabled = done;
+    btn.addEventListener('click', () => {
+      markTopicCompleted(topicKey);
+      btn.textContent = '✓ Completed';
+      btn.style.background = '#10b981';
+      btn.disabled = true;
+    });
+    bar.appendChild(btn);
+    contentViewport.appendChild(bar);
+  }
+
   function updateProgressUI() {
     const total = allTopics.filter((t) => t.id !== 'quiz').length;
     const completed = learningProgress.completedTopics.length;
@@ -935,7 +954,7 @@ list.appendChild(item);
       window.scrollTo({ top: 0, behavior: 'instant' });
 
       updateNavigationFooter();
-      markTopicCompleted(`${topic.categoryId}-${topic.id}`);
+      renderCompleteButton(`${topic.categoryId}-${topic.id}`);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8648

### Summary
A topic was marked completed simply by opening it, so the "Completed" count and Overall Progress could reach 100% by clicking through the sidebar without reading anything. This PR makes completion require an explicit action: a "Mark as Complete" button at the end of the topic.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `learning/learning.js`: removed the automatic `markTopicCompleted(...)` call that fired whenever a topic was opened.
- `learning/learning.js`: added `renderCompleteButton(topicKey)`, which appends a "Mark as Complete" button at the end of the topic content (and shows "✓ Completed" / disabled when the topic is already done). Clicking it calls the existing `markTopicCompleted`, which updates the progress count and percentage. The button uses inline styles, matching the existing quiz-screen pattern, so no stylesheet change is needed.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change.

What I did verify:
- `node --check learning/learning.js` passes.
- `markTopicCompleted` is now only invoked from the button's click handler; opening a topic no longer marks it complete.
- An already-completed topic renders the button in the disabled "✓ Completed" state.

### Browser Compatibility Check
- The topic view now ends with a Mark-as-Complete button; opening topics no longer changes the progress count on its own. A quick manual click-through is recommended to confirm the button looks right in both themes.

### Responsive & Accessibility Checks
- The control is a native `<button>` (keyboard-focusable and clickable); no layout changes elsewhere.

---

## 📷 Screenshots / Video Recording
A screenshot of the new "Mark as Complete" button at the end of a topic would be a nice addition.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
