### PR TITLE
fix(learning): show an error state when the curriculum or a topic fails to load

### DIFF
--- a/learning/learning.js
+++ b/learning/learning.js
@@ -435,6 +435,10 @@ updateRecommendedTopic();
 handleRouting();
     } catch (err) {
       console.error(err);
+      if (sidebarTree) {
+        sidebarTree.innerHTML =
+          '<div class="sidebar-loading" style="color: #ef4444;">Could not load the curriculum. Please refresh to try again.</div>';
+      }
     }
   }
 
@@ -938,6 +942,10 @@ list.appendChild(item);
       markTopicCompleted(`${topic.categoryId}-${topic.id}`);
     } catch (err) {
       console.error(err);
+      if (contentViewport) {
+        contentViewport.innerHTML =
+          '<div class="loading-article"><p style="color: #ef4444;">Could not load this topic. Please check your connection and try again.</p></div>';
+      }
     }
   }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8653

### Summary
When a fetch failed in the learning portal, the catch blocks only logged to the console, so the loading skeleton stayed on screen forever. This PR replaces the skeleton with a clear error message when the curriculum index or a topic fails to load.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `learning/learning.js`, `loadRegistry` catch: if the registry fetch fails, replace the sidebar skeleton with an error message (reusing the existing `sidebar-loading` class) instead of leaving "Loading curriculum..." on screen.
- `learning/learning.js`, `loadTopic` catch: if a topic fetch fails, replace the content skeleton with an error message (reusing the existing `loading-article` class) instead of leaving "Fetching tutorial content..." on screen.
- Both still log the original error to the console for debugging.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator is unrelated to this change.

What I did verify:
- `node --check learning/learning.js` passes.
- The error messages reuse the existing skeleton CSS classes (`sidebar-loading`, `loading-article`), so they are styled consistently with the rest of the portal.

### Browser Compatibility Check
- Simulating a failed fetch (offline or a missing file) now shows an error message in place of the skeleton, in both the sidebar and the content area. A quick manual check with the network offline is recommended.

### Responsive & Accessibility Checks
- No layout changes; the error text replaces the skeleton in the same container.

---

## 📷 Screenshots / Video Recording
N/A.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
