### PR TITLE
fix(projects): use relative asset paths in static projects so they load on subpath hosts

### DIFF
--- a/public/AI-Tools-Hub/index.html
+++ b/public/AI-Tools-Hub/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AI Tools Hub - Discover the Best AI Tools</title>
-    <link rel="stylesheet" href="/public/AI-Tools-Hub/style.css?v=6">
+    <link rel="stylesheet" href="style.css?v=6">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
@@ -475,6 +475,6 @@
         <span id="toast-message"></span>
     </div>
 
-    <script src="/public/AI-Tools-Hub/script.js?v=5"></script>
+    <script src="script.js?v=5"></script>
 </body>
 </html>

--- a/public/Breakout-game/index.html
+++ b/public/Breakout-game/index.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="/public/Breakout-game/styles.css" />
+    <link rel="stylesheet" href="styles.css" />
     <link rel="icon" href="../favv.png" type="image/x-icon" />
-    <script src="/public/Breakout-game/script.js" defer></script>
+    <script src="script.js" defer></script>
     <title>🎮 Breakout Game - Ultimate Edition</title>
 </head>
 <body data-theme="dark">

--- a/public/Complaint_Management_System/index.html
+++ b/public/Complaint_Management_System/index.html
@@ -11,7 +11,7 @@
     <!-- Icons -->
     <script src="https://unpkg.com/@phosphor-icons/web"></script>
     <!-- Custom Styles -->
-    <link rel="stylesheet" href="/public/Complaint_Management_System/style.css">
+    <link rel="stylesheet" href="style.css">
 </head>
 <body data-theme="light">
     <!-- Background Effects -->
@@ -365,6 +365,6 @@
     </div>
 
     <!-- Scripts -->
-    <script src="/public/Complaint_Management_System/script.js" type="module"></script>
+    <script src="script.js" type="module"></script>
 </body>
 </html>

--- a/public/CpuScheduler/index.html
+++ b/public/CpuScheduler/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>CPU Scheduler Simulator</title>
-  <link rel="stylesheet" href="/public/CpuScheduler/style.css" />
+  <link rel="stylesheet" href="style.css" />
 </head>
 <body>
 
@@ -197,6 +197,6 @@
 <!-- Toast notification -->
 <div class="toast" id="toast"></div>
 
-<script src="/public/CpuScheduler/script.js"></script>
+<script src="script.js"></script>
 </body>
 </html>

--- a/public/Flappy-bird-main/index.html
+++ b/public/Flappy-bird-main/index.html
@@ -32,6 +32,6 @@
       <span>Mode: <span id="modeDisplay">Medium</span></span>
     </section>
 
-    <script src="/public/Flappy-bird-main/script.js"></script>
+    <script src="script.js"></script>
   </body>
 </html>

--- a/public/ImageCompressor/index.html
+++ b/public/ImageCompressor/index.html
@@ -18,7 +18,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jszip/3.10.1/jszip.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script>
     <!-- Custom CSS -->
-    <link rel="stylesheet" href="/public/ImageCompressor/style.css?v=4">
+    <link rel="stylesheet" href="style.css?v=4">
 </head>
 <body>
     <div class="app-background"></div>
@@ -159,6 +159,6 @@
     <!-- Toast Notifications -->
     <div id="toastContainer" class="toast-container"></div>
 
-    <script type="module" src="/public/ImageCompressor/js/main.js?v=4"></script>
+    <script type="module" src="js/main.js?v=4"></script>
 </body>
 </html>

--- a/public/Medical_App/remedies.html
+++ b/public/Medical_App/remedies.html
@@ -186,7 +186,7 @@
         
         <script src="js/darkmode.js"></script>
 
-        <a href="/public/Medical_App/index.html" class="page-link">
+        <a href="index.html" class="page-link">
             ← Back to Consultation
         </a>
 

--- a/public/MemoryGame/index.html
+++ b/public/MemoryGame/index.html
@@ -6,7 +6,7 @@
   <title>Memory Match</title>
   <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;700;800&family=DM+Mono:wght@400;500&family=Orbitron:wght@700;900&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
-  <link rel="stylesheet" href="/public/MemoryGame/style.css">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
 <a href="/" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 16px;border-radius:8px;background:#1e293b;color:#3b82f6;border:1px solid #3b82f6;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;transition:all 0.2s ease;" onmouseover="this.style.background='#3b82f6';this.style.color='#fff'" onmouseout="this.style.background='#1e293b';this.style.color='#3b82f6'">← Back to Home</a>
@@ -92,9 +92,9 @@
   <div class="toast" id="toast"></div>
 
   <audio id="victorySound" preload="auto">
-    <source src="/public/MemoryGame/victory.mp3" type="audio/mpeg">
+    <source src="victory.mp3" type="audio/mpeg">
   </audio>
 
-  <script src="/public/MemoryGame/script.js"></script>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/public/Mood_Based_Music_Recommender/settings.html
+++ b/public/Mood_Based_Music_Recommender/settings.html
@@ -10,7 +10,7 @@
     <title>MoodMusic – Settings</title>
     <link
       rel="stylesheet"
-      href="/public/Mood_Based_Music_Recommender/settings.css"
+      href="settings.css"
     />
     <link
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
@@ -780,6 +780,6 @@
       <span id="toastMsg">Settings saved!</span>
     </div>
 
-    <script src="/public/Mood_Based_Music_Recommender/settings.js"></script>
+    <script src="settings.js"></script>
   </body>
 </html>

--- a/public/N_Queen/index.html
+++ b/public/N_Queen/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>N-Queens Interactive Game</title>
-  <link rel="stylesheet" href="/public/N_Queen/style.css">
+  <link rel="stylesheet" href="style.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;800&display=swap" rel="stylesheet">
@@ -90,6 +90,6 @@ Main
 
  
     
-  <script src="/public/N_Queen/script.js" defer></script>
+  <script src="script.js" defer></script>
 </body>
 </html>

--- a/public/Placement-Predictor/index.html
+++ b/public/Placement-Predictor/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Placement Predictor</title>
-  <link rel="icon" type="image/png" href="/public/Placement-Predictor/logo.png">
+  <link rel="icon" type="image/png" href="logo.png">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="/public/Placement-Predictor/style.css"/>
+  <link rel="stylesheet" href="style.css"/>
 </head>
 <body>
 
@@ -27,7 +27,7 @@
   <div class="container">
     <!-- Perfectly Centered Hero Illustration -->
     <div class="hero-wrapper">
-      <img src="/public/Placement-Predictor/hero_illustration.png" alt="Placement Predictor Career Success" class="hero-image">
+      <img src="hero_illustration.png" alt="Placement Predictor Career Success" class="hero-image">
     </div>
 
     <h1 class="main-title">Placement Predictor</h1>
@@ -215,6 +215,6 @@
 
   </div>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-  <script src="/public/Placement-Predictor/script.js"></script>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/public/Word_jumble/index.html
+++ b/public/Word_jumble/index.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Word Jumble</title>
-    <link rel="stylesheet" href="/public/Word_jumble/style.css">
+    <link rel="stylesheet" href="style.css">
 </head>
 
 <body>
@@ -80,7 +80,7 @@
             </div>
         </div>
     </main>
-    <script src="/public/Word_jumble/script.js"></script>
+    <script src="script.js"></script>
     <footer class="footer glass-panel">
         <div class="footer-content">
             <p>© 2026 Word Jumble — Built with HTML, CSS & JS</p>

--- a/public/leetcode-progress-tracker/index.html
+++ b/public/leetcode-progress-tracker/index.html
@@ -6,7 +6,7 @@
 
   <title>LeetCode Progress Tracker</title>
 
-  <link rel="stylesheet" href="/public/leetcode-progress-tracker/style.css"/>
+  <link rel="stylesheet" href="style.css"/>
 
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
@@ -288,7 +288,7 @@
 
   </div>
 
-  <script src="/public/leetcode-progress-tracker/script.js"></script>
+  <script src="script.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8735

### Summary
Thirteen static projects referenced their own CSS / JS / media (and one in-page link) with absolute root paths like `/public/<Project>/style.css`. The showcase deploys to a subpath on GitHub Pages (no custom domain), so those paths drop the `/100_days_100_web_project/` prefix and 404, leaving the projects unstyled or non-interactive. This PR makes the references relative to each project folder so they load on the deployed subpath host. Same class as #3181 (fixed for other projects via #3222); these 13 were still affected.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Stripped the `/public/<Project>/` prefix from 27 `href` / `src` references across 13 HTML files, making each reference relative to its own project folder (for example `/public/Breakout-game/styles.css` becomes `styles.css`, and `/public/ImageCompressor/js/main.js` becomes `js/main.js`). Query strings such as `?v=6` are preserved.
- No content, markup, or behaviour changes beyond the asset paths.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator checks `projects.json`, which is unrelated to this change.

What I did verify:
- Every rewritten reference was checked against disk: the relative target exists for all 27 references (a reference was only rewritten when its same-folder target was confirmed to exist).
- After the change there are zero remaining `/public/...` absolute references in `public/*.html`.
- The diff is exactly 27 lines changed across 13 files (one per reference); subfolder, media, and query-string cases were checked individually.

### Browser Compatibility Check
- Serving the repo root and opening, for example, `/100_days_100_web_project/public/Breakout-game/index.html` now loads the stylesheet and script (no 404). A quick check of a couple of these projects on a subpath deploy is recommended.

### Responsive & Accessibility Checks
- No layout or behaviour change; this only corrects asset URLs.

---

## 📷 Screenshots / Video Recording
N/A (asset URL fix; no visual change beyond the assets now loading on the deployed host).

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
