### PR TITLE
fix(projects): add mobile viewport meta tag to static pages missing it

### DIFF
--- a/public/Financial-Dashboard/index.html
+++ b/public/Financial-Dashboard/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Finance Dashboard</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <style>

--- a/public/MemoryCard/index.html
+++ b/public/MemoryCard/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mega Memory Match</title>
     <style>
         body { font-family: sans-serif; text-align: center; background: #2c3e50; color: white; }

--- a/public/TO_DO_LIST/index.html
+++ b/public/TO_DO_LIST/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="refresh" content="0; url=todolist.html" />
     <title>To-Do List</title>
   </head>

--- a/public/Well/index.html
+++ b/public/Well/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
         body { margin: 0; background: #000; overflow: hidden; }
         canvas { display: block; }

--- a/public/hand-gesture-controller/index.html
+++ b/public/hand-gesture-controller/index.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HCI Hand-Gesture Controller Overlay</title>
     <style>
         body {

--- a/public/quote-generator/index.html
+++ b/public/quote-generator/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Quote Generator</title>
     <link rel="stylesheet" href="style.css">
     <link rel="icon" href="favicon.png">

--- a/public/typewriter/index.html
+++ b/public/typewriter/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="refresh" content="0; url=typewriter.html" />
     <title>Typewriter</title>
   </head>

--- a/public/video-synthesis-engine/index.html
+++ b/public/video-synthesis-engine/index.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>High-Throughput AI Video Frame-Synthesizer</title>
     <style>
         body {

--- a/public/weather-app/index.html
+++ b/public/weather-app/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>WeatherLens — Dynamic Weather Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8737

### Summary
Nine static pages under `public/` had no `<meta name="viewport">`, so mobile browsers rendered them at desktop width (zoomed out, tiny text). This PR adds the standard viewport meta to each of those nine pages.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added `<meta name="viewport" content="width=device-width, initial-scale=1.0">` to the `<head>` of nine pages: Financial-Dashboard, hand-gesture-controller, MemoryCard, quote-generator, TO_DO_LIST, typewriter, video-synthesis-engine, weather-app, Well.
- The tag is placed right after the existing `<meta charset>` where present, otherwise right after `<head>`, and matches each file's indentation and self-closing style (`/>` vs `>`).
- One line added per file, nothing else changed.

Scope note: I deliberately excluded files that a naive search flags but that are not genuine misses: the seven `Contact Book/templates/*.html` inherit the viewport from `base.html` (`{% extends 'base.html' %}`); three files are empty 17-byte `<!DOCTYPE html>` stubs (a separate problem); and `pig_game/firecrackers.html` is a headless canvas effect with no `<head>`.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator checks `projects.json`, which is unrelated to this change.

What I did verify:
- After the change, none of the nine pages is missing a viewport meta.
- Each file keeps consistent CRLF line endings (the inserted line matches the file's existing newline style); the diff is exactly one added line per file.

### Browser Compatibility Check
- With the viewport meta present, these pages now lay out at device width instead of a scaled-down desktop width. A quick check of one or two on a phone or in device emulation is recommended.

### Responsive & Accessibility Checks
- Adding the viewport meta is the standard prerequisite for responsive layout on mobile; no markup or style was otherwise changed.

---

## 📷 Screenshots / Video Recording
A before/after of one page (for example quote-generator) on a mobile viewport would illustrate the fix well if desired.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
