### PR TITLE
fix(contributors): add keyboard accessibility to profile and certificate modals

### DIFF
--- a/contributors/contributor.html
+++ b/contributors/contributor.html
@@ -174,14 +174,14 @@
     </footer>
 
     <div id="profileModal" class="modal-overlay">
-      <div class="modal-content">
+      <div class="modal-content" role="dialog" aria-modal="true" aria-label="Contributor profile">
         <button id="closeModal" aria-label="Close profile modal">&times;</button>
         <div id="modalBody">Loading...</div>
       </div>
     </div>
 
     <div id="certificateModal" class="modal-overlay">
-      <div class="modal-content">
+      <div class="modal-content" role="dialog" aria-modal="true" aria-label="Certificate">
         <button id="closeCertificate" aria-label="Close certificate modal">&times;</button>
         <div id="certificateBody">Loading Certificate...</div>
       </div>

--- a/contributors/contributor.js
+++ b/contributors/contributor.js
@@ -9,11 +9,73 @@ const GITHUB_API_BASE = "https://api.github.com";
 const REQUEST_TIMEOUT = 10000;
 const MAX_RETRIES = 3;
 
-closeModal?.addEventListener("click", () => {
-  if (modal) {
-    modal.style.display = "none";
+function createModalA11y(modalEl, closeBtn) {
+  if (!modalEl) {
+    return { activate() {}, close() {} };
   }
-});
+
+  let lastFocused = null;
+  const focusableSelector =
+    'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+  const getFocusable = () =>
+    Array.from(modalEl.querySelectorAll(focusableSelector)).filter(
+      (el) => el.offsetParent !== null,
+    );
+
+  function close() {
+    modalEl.style.display = "none";
+    document.removeEventListener("keydown", onKeydown);
+    if (lastFocused && typeof lastFocused.focus === "function") {
+      lastFocused.focus();
+    }
+    lastFocused = null;
+  }
+
+  function onKeydown(e) {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+      return;
+    }
+    if (e.key !== "Tab") {
+      return;
+    }
+    const focusable = getFocusable();
+    if (!focusable.length) {
+      e.preventDefault();
+      return;
+    }
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  function activate() {
+    lastFocused = document.activeElement;
+    document.addEventListener("keydown", onKeydown);
+    (closeBtn || getFocusable()[0] || modalEl).focus();
+  }
+
+  closeBtn?.addEventListener("click", close);
+  modalEl.addEventListener("click", (e) => {
+    if (e.target === modalEl) {
+      close();
+    }
+  });
+
+  return { activate, close };
+}
+
+const profileModalA11y = createModalA11y(modal, closeModal);
+// Certificate modal has no open trigger yet; wire its close and backdrop so it will not trap focus once one is added.
+createModalA11y(certificateModal, closeCertificate);
 
 async function githubFetch(url, options = {}, retries = MAX_RETRIES) {
   const controller = new AbortController();
@@ -66,12 +128,6 @@ async function githubFetch(url, options = {}, retries = MAX_RETRIES) {
   }
 }
 
-window.addEventListener("click", (e) => {
-  if (modal && e.target === modal) {
-    modal.style.display = "none";
-  }
-});
-
 function saveCache(key, data) {
   localStorage.setItem(
     key,
@@ -114,6 +170,7 @@ async function openProfile(username) {
   modal.style.alignItems = "center";
 
   modalBody.innerHTML = "<p>Loading...</p>";
+  profileModalA11y.activate();
 
   try {
     const response = await fetch(`https://api.github.com/users/${username}`);


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8738
Also wires the certificate modal close reported as Bug 3 of #4926.

### Summary
The Contributors page modals were not keyboard accessible: no Escape to close, no focus trap, no focus return, and the profile modal never moved focus into itself. The certificate modal close button was also never wired. This PR introduces a small reusable accessible-modal helper and applies it to both modals.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `contributors/contributor.js`: added `createModalA11y(modalEl, closeBtn)`, which wires the close button and backdrop click, traps Tab / Shift+Tab within the modal, closes on Escape, moves focus into the modal on open, and returns focus to the opener on close. It replaces the previous single close handler and the window-level backdrop handler.
- Applied it to the profile modal (activated inside `openProfile`) and to the certificate modal (wires its close and backdrop, so the certificate modal is no longer unclosable and will not trap focus once an open trigger is added).
- `contributors/contributor.html`: added `role="dialog"`, `aria-modal="true"`, and an `aria-label` to both modal content containers.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator checks `projects.json`, which is unrelated to this change.

What I did verify:
- `node --check contributors/contributor.js` passes.
- Both files keep consistent CRLF line endings.
- Logic walk-through: opening a profile stores the trigger and focuses the close button; Escape, the close button, and a backdrop click all close the modal and return focus to the trigger; Tab and Shift+Tab cycle within the modal.

### Browser Compatibility Check
- Open a contributor profile and confirm: Escape closes it, Tab stays inside, and focus returns to the "View Details" button after closing. A quick manual pass with the keyboard is recommended.

### Responsive & Accessibility Checks
- This is the accessibility change itself: keyboard operable modals with `role="dialog"` / `aria-modal`, focus trap, focus return, and Escape support.

---

## 📷 Screenshots / Video Recording
A short screen capture of keyboard-only navigation (open, Tab within, Escape to close, focus returning to the trigger) would demonstrate this well.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
