### PR TITLE
fix(a11y): announce stats status, label nav, fix muted text contrast

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -25,7 +25,7 @@
   --accent3:#f59e0b;
 
   --text:#e2e8f0;
-  --muted:#64748b;
+  --muted:#828d9f;
 
   --font-head:'Orbitron',sans-serif;
   --font-body:'Exo 2',sans-serif;
@@ -46,6 +46,7 @@ body.light-theme {
   --bg: #eef2f7;
   --surface: #ffffff;
   --surface2: #f8fafc;
+  --muted: #5d6776;
 }
 
 .theme-btn {
@@ -113,7 +114,7 @@ body.light-theme {
 </head>
 <body>
 
-<nav class="navbar">
+<nav class="navbar" aria-label="Primary">
   <a class="navbar-brand" href="./index.html">
     <span>100 DAYS · 100 PROJECTS</span>
   </a>
@@ -128,7 +129,7 @@ body.light-theme {
   <div class="hero-eyebrow"><span class="live-dot"></span>Live Dashboard</div>
   <h1>Project Stats</h1>
   <p>Real-time breakdown of <strong id="heroCount">…</strong> web projects — categories, technologies and difficulty curve. Auto-refreshes every 10s.</p>
-  <div class="hero-status" id="heroStatus" data-state="loading">Loading stats…</div>
+  <div class="hero-status" id="heroStatus" role="status" data-state="loading">Loading stats…</div>
   <div class="filter-row" id="filterRow">
     <div class="pill active" data-filter="all">All Projects</div>
   </div>


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8740

### Summary
Three accessibility fixes on `stats.html`: announce the dynamic status region, give the navigation landmark a name, and bring the muted text colour up to a passing contrast ratio in both themes.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added `role="status"` to `#heroStatus`, so the "Loading stats..." / refresh messages set by `setStatus()` are announced politely (WCAG 4.1.3).
- Added `aria-label="Primary"` to `<nav class="navbar">` so the landmark has an accessible name.
- Fixed muted text contrast (WCAG 1.4.3). `--muted` was `#64748b`, shared by both themes:
  - Dark `:root`: changed to `#828d9f` (about 5.1:1 on the dark surfaces it is used on).
  - Light theme: added a `--muted: #5d6776` override (about 5.1:1 on the light backgrounds, including `--bg` `#eef2f7` where the hero paragraph sits, which the old value failed at 4.23:1).

The metric numbers auto-refresh every 10s and were intentionally not made individual live regions (that would announce all of them each refresh); the single status region covers the refresh announcement.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator checks `projects.json`, which is unrelated to this change.

What I did verify:
- Contrast ratios were computed with the WCAG formula. Dark `#828d9f`: 5.13:1 on `#1a1a26` and 5.29:1 on `#111827`. Light `#5d6776`: 5.09:1 on `#eef2f7`, 5.47:1 on `#f8fafc`, 5.73:1 on `#ffffff`. All are at or above 4.5:1.
- The file keeps consistent CRLF line endings; only four lines changed.

### Browser Compatibility Check
- The status region updates are announced by screen readers; the nav has a name; muted text is readable in both themes. A quick check with a screen reader and a contrast tool is recommended.

### Responsive & Accessibility Checks
- This is the accessibility change itself (4.1.3, 1.4.3, and a named navigation landmark). No layout changes.

---

## 📷 Screenshots / Video Recording
N/A (semantic and colour-contrast changes; best confirmed with a screen reader and a contrast checker).

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
