### PR TITLE
fix(a11y): chart text alternatives, decorative icons, heading/label fixes

### DIFF
--- a/404.html
+++ b/404.html
@@ -187,10 +187,10 @@
 
         <div class="buttons">
             <a href="/" class="btn btn-primary">
-                <i class="fas fa-home"></i> Back to Homepage
+                <i class="fas fa-home" aria-hidden="true"></i> Back to Homepage
             </a>
             <a href="/contributors/contributor.html" class="btn btn-secondary">
-                <i class="fas fa-users"></i> Contributors
+                <i class="fas fa-users" aria-hidden="true"></i> Contributors
             </a>
         </div>
 

--- a/contributors/contributor.css
+++ b/contributors/contributor.css
@@ -83,7 +83,8 @@ body {
   margin-bottom: 5rem;
 }
 
-.contributor-header h1 {
+.contributor-header h1,
+.contributor-header h2 {
   font-family: 'Orbitron', sans-serif;
   font-size: clamp(2.5rem, 6vw, 4rem);
   font-weight: 900;
@@ -131,7 +132,7 @@ body {
   color: var(--accent-color);
 }
 
-.stat-item label {
+.stat-item span {
   font-size: 0.75rem;
   color: var(--text-secondary);
   text-transform: uppercase;

--- a/contributors/contributor.html
+++ b/contributors/contributor.html
@@ -52,27 +52,27 @@
       <div class="stats-overview">
         <div class="stat-item">
           <div class="value" id="starCount">...</div>
-          <label>Stars</label>
+          <span>Stars</span>
         </div>
         <div class="stat-item">
           <div class="value" id="forkCount">...</div>
-          <label>Forks</label>
+          <span>Forks</span>
         </div>
         <div class="stat-item">
           <div class="value" id="issueCount">...</div>
-          <label>Open Issues</label>
+          <span>Open Issues</span>
         </div>
         <div class="stat-item">
           <div class="value" id="prCount">...</div>
-          <label>Pull Requests</label>
+          <span>Pull Requests</span>
         </div>
         <div class="stat-item">
           <div class="value" id="totalCommits">...</div>
-          <label>Total Commits</label>
+          <span>Total Commits</span>
         </div>
         <div class="stat-item">
           <div class="value" id="contributorCount">...</div>
-          <label>Contributors</label>
+          <span>Contributors</span>
         </div>
       </div>
 
@@ -104,7 +104,7 @@
       <div id="contributors" class="contributors-grid"></div>
 
       <div class="contributor-header" style="margin-top: 5rem">
-        <h1>Project Stargazers</h1>
+        <h2>Project Stargazers</h2>
         <p class="subtitle">The community supporting our growth</p>
       </div>
       <div id="stargazersError" class="hidden api-error">

--- a/stats.html
+++ b/stats.html
@@ -165,7 +165,7 @@ body.light-theme {
       <div class="card-title">Category Breakdown</div>
       <div class="card-badge" id="catBadge">0 categories</div>
     </div>
-    <div class="chart-wrap"><canvas id="catChart"></canvas></div>
+    <div class="chart-wrap"><canvas id="catChart" role="img" aria-label="Projects by category"></canvas></div>
   </div>
 
   <div class="card chart-card">
@@ -173,7 +173,7 @@ body.light-theme {
       <div class="card-title">Technology Stack</div>
       <div class="card-badge">by project count</div>
     </div>
-    <div class="chart-wrap"><canvas id="techChart"></canvas></div>
+    <div class="chart-wrap"><canvas id="techChart" role="img" aria-label="Top technologies by project count"></canvas></div>
   </div>
 
   <div class="card chart-card wide">
@@ -181,7 +181,7 @@ body.light-theme {
       <div class="card-title">Difficulty Progression</div>
       <div class="card-badge" id="diffBadge">Day 1 → N</div>
     </div>
-    <div class="chart-wrap"><canvas id="diffChart"></canvas></div>
+    <div class="chart-wrap"><canvas id="diffChart" role="img" aria-label="Cumulative projects by difficulty over time"></canvas></div>
   </div>
 </main>
 
@@ -286,6 +286,7 @@ function render(data){
   catChart.data.labels = catEntries.map(e=>e[0]);
   catChart.data.datasets[0].data = catEntries.map(e=>e[1]);
   catChart.update();
+  $('catChart').setAttribute('aria-label', 'Projects by category. ' + (catEntries.map(e => e[0] + ': ' + e[1]).join(', ') || 'No data') + '.');
   $('catBadge').textContent = `${catEntries.length} categories`;
 
   // Tech stack (top 10)
@@ -299,6 +300,7 @@ function render(data){
   techChart.data.datasets[0].data = techEntries.map(e=>e[1]);
   techChart.data.datasets[0].backgroundColor = techEntries.map((_,i)=>PALETTE[i%PALETTE.length]);
   techChart.update();
+  $('techChart').setAttribute('aria-label', 'Top technologies by project count. ' + (techEntries.map(e => e[0] + ': ' + e[1]).join(', ') || 'No data') + '.');
 
   // Difficulty progression — cumulative over projectNo
   const sorted = [...filtered].sort((a,b)=>(a.projectNo||0)-(b.projectNo||0));
@@ -317,6 +319,7 @@ function render(data){
   diffChart.data.datasets[1].data = iArr;
   diffChart.data.datasets[2].data = aArr;
   diffChart.update();
+  $('diffChart').setAttribute('aria-label', 'Cumulative projects by difficulty. Beginner ' + (bArr[bArr.length - 1] || 0) + ', Intermediate ' + (iArr[iArr.length - 1] || 0) + ', Advanced ' + (aArr[aArr.length - 1] || 0) + '.');
   $('diffBadge').textContent = `Day 1 → ${labels[labels.length-1] || 0}`;
 
   setStatus(`Showing ${total} of ${data.length} projects`, 'ready');


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8741

### Summary
A small set of accessibility fixes across three pages: text alternatives for the stats charts, hiding decorative icons on the 404 page, and correcting heading and label semantics on the Contributors page.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- `stats.html`: gave each chart canvas `role="img"` and a base `aria-label`, and update that label with the actual data after each chart renders (for example "Projects by category. Game: 40, Tool: 31, ..."). This gives screen reader users a text alternative for the colour-only charts.
- `404.html`: added `aria-hidden="true"` to the two decorative icons that sit beside their own visible link text.
- `contributors/contributor.html`: changed the second `<h1>` ("Project Stargazers") to `<h2>` so the page has a single top-level heading, and replaced the six misused `<label>` captions in the stats overview with `<span>`.
- `contributors/contributor.css`: extended `.contributor-header h1` to also cover `h2`, and changed `.stat-item label` to `.stat-item span`, so the markup changes above keep their existing styling.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator checks `projects.json`, which is unrelated to this change.

What I did verify:
- Extracted and syntax-checked the inline script in `stats.html` (`node --check`) after adding the `aria-label` updates.
- The Contributors heading and caption changes are paired with the CSS selector updates, so they render the same as before.
- All four files keep consistent CRLF line endings.

### Browser Compatibility Check
- The Stargazers heading and the stat captions look unchanged; the 404 buttons look unchanged; the charts are unchanged visually. A quick screen reader pass over the charts and the Contributors outline is recommended.

### Responsive & Accessibility Checks
- This is the accessibility change itself (1.4.1 / 1.1.1 chart alternatives, decorative icons hidden, 1.3.1 heading and label semantics). No layout changes.

---

## 📷 Screenshots / Video Recording
N/A (semantic changes; visuals are unchanged).

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
