### PR TITLE
perf: enable browser caching for static media in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,6 +10,10 @@
         {
           "key": "Content-Type",
           "value": "text/css; charset=utf-8"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
         }
       ]
     },
@@ -19,16 +23,52 @@
         {
           "key": "Content-Type",
           "value": "application/javascript; charset=utf-8"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(html|json|md|txt|xml|csv|map|webmanifest|wasm)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=0, must-revalidate"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(woff|woff2|ttf|otf|eot)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=2592000"
+        }
+      ]
+    },
+    {
+      "source": "/(.*)\\.(png|jpg|jpeg|gif|svg|webp|avif|ico|bmp|mp3|mp4|webm|ogg|wav)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=604800"
         }
       ]
     },
     {
       "source": "/(.*)",
       "headers": [
-        {
-          "key": "Cache-Control",
-          "value": "public, max-age=0, must-revalidate"
-        },
         {
           "key": "X-Content-Type-Options",
           "value": "nosniff"


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8743

### Summary
`vercel.json` set `Cache-Control: public, max-age=0, must-revalidate` on the catch-all `/(.*)`, so every asset, including images and fonts, was revalidated on every request. This PR restructures the header rules so static media is cached by the browser while code and data keep revalidating.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
Restructured the `headers` array into non-overlapping rules so each path gets `Cache-Control` from exactly one rule:

- CSS and JS: `public, max-age=0, must-revalidate` (added alongside the existing Content-Type).
- HTML, JSON, Markdown, and similar text/data (`html|json|md|txt|xml|csv|map|webmanifest|wasm`) and the site root `/`: `public, max-age=0, must-revalidate`.
- Fonts (`woff|woff2|ttf|otf|eot`): `public, max-age=2592000` (30 days).
- Images, audio, video (`png|jpg|jpeg|gif|svg|webp|avif|ico|bmp|mp3|mp4|webm|ogg|wav`): `public, max-age=604800` (7 days).
- The catch-all `/(.*)` now carries only the security headers.

### Why this shape
- The repo does not hash asset filenames, so CSS, JS, and HTML cannot be cached long-term (a deploy would serve stale code). They keep revalidating.
- Vercel applies the headers from all matching rules, so two rules setting `Cache-Control` would both be sent. Keeping the rules non-overlapping (catch-all sets security only) guarantees one `Cache-Control` per path.
- `stale-while-revalidate` is omitted because Vercel strips it from the browser response without a `CDN-Cache-Control` header.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

Note: that validator checks `projects.json`, which is unrelated to this change.

What I did verify:
- `vercel.json` is valid JSON.
- I simulated the rule matching for representative paths and confirmed each resolves to exactly one `Cache-Control` value:
  - `/style.css`, `/index.js`, `/index.html`, `/projects.json`, `/learning/registry.json`, `/` -> `max-age=0, must-revalidate`
  - `/assets/x.woff2` -> `max-age=2592000`
  - `/public/p/img.png`, `/public/g/victory.mp3` -> `max-age=604800`
- Recommended follow-up: confirm the response headers on a Vercel preview deployment (check the `Cache-Control` header on an image vs. an HTML page), since header behaviour is best validated on the platform itself.

### Browser Compatibility Check
- Code and data still revalidate, so deploys are picked up immediately. Repeat visits reuse cached images and fonts.

### Responsive & Accessibility Checks
- Not applicable (deployment configuration only).

---

## 📷 Screenshots / Video Recording
N/A (configuration change; best confirmed via response headers on a preview deployment).

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
