### PR TITLE
perf: remove duplicate Font Awesome stylesheet in stats.html

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -5,7 +5,6 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="Real-time stats dashboard for 100 Days 100 Web Projects – category breakdown, project status, and contributor metrics.">
 <title>Project Stats — 100 Days 100 Web Projects</title>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <style>


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8816

### Summary
`stats.html` linked the same Font Awesome 6.4.2 stylesheet twice. This PR removes the plain duplicate and keeps the one with Subresource Integrity.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Removed the first, plain `<link>` to Font Awesome `all.min.css` in `stats.html`, keeping the second one that has `integrity`, `crossorigin`, and `referrerpolicy`. One render-blocking request fewer, with no change to the icons.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

What I did verify:
- Exactly one Font Awesome link remains in `stats.html` (the one with Subresource Integrity).
- The diff is a single deleted line; line endings are unchanged.

### Browser Compatibility Check
- Icons still load from the remaining stylesheet. A quick look at the stats page confirms the icons render.

### Responsive & Accessibility Checks
- No layout change.

---

## 📷 Screenshots / Video Recording
N/A (removes a duplicate request; no visual change).

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
