### PR TITLE
perf(contributors): remove unused jsPDF and html2canvas libraries

### DIFF
--- a/contributors/contributor.html
+++ b/contributors/contributor.html
@@ -197,8 +197,6 @@
     </button>
     <div class="toast" id="toast"></div>
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
     
 
     <!-- ── LOAD NAVBAR INJECTION SCRIPT LAST ── -->


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8839

### Summary
The Contributors page eagerly loaded jsPDF and html2canvas (about 550KB) on every visit, but nothing uses them: the certificate-export feature they were meant for is not implemented. This PR removes the two unused script tags.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Removed the `jspdf.umd.min.js` and `html2canvas.min.js` script tags from `contributors/contributor.html`.

A repo-wide search finds no references to `jsPDF` or `html2canvas` in any script, and the certificate modal that would have used them is never opened (see #8738). If a certificate-export feature is added later, these libraries should be loaded on demand at export time rather than eagerly on page load.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

What I did verify:
- A repo-wide search for `jspdf` and `html2canvas` (excluding the two script tags themselves) returns no matches, so nothing on the page uses them.
- After the change, there are no remaining references to either library in `contributor.html`.
- Line endings are unchanged (CRLF).

### Browser Compatibility Check
- The Contributors page behaves exactly the same; it just no longer downloads two unused libraries.

### Responsive & Accessibility Checks
- No layout or behaviour change.

---

## 📷 Screenshots / Video Recording
N/A (removes two unused network requests; no visual change).

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
