### PR TITLE
ci: fix validate-projects push trigger to match the Main branch

### DIFF
--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - Main
 
 jobs:
   validate-schema:


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8851

### Summary
The "Validate projects.json Schema" workflow filtered its push trigger on lowercase `main`, but the default branch is `Main`. Because branch names are case-sensitive, the push trigger never fired. This PR changes it to `Main`.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [x] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- In `.github/workflows/validate-projects.yml`, changed the push branch filter from `main` to `Main`.

The `pull_request` trigger already runs validation on PRs; this makes the push trigger fire on merges and direct pushes to `Main` as well.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

What I did verify:
- The default branch is `Main` (capital M), and every other workflow uses `Main` for its branch filter.
- This is a one-line trigger change; the job itself is unchanged.

### Browser Compatibility Check
- Not applicable (CI configuration).

### Responsive & Accessibility Checks
- Not applicable.

---

## 📷 Screenshots / Video Recording
N/A (CI trigger change).

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
