### PR TITLE
feat: add robots.txt and sitemap.xml for the main site pages

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+# https://www.robotstxt.org/robotstxt.html
+User-agent: *
+Allow: /
+
+Sitemap: https://100-days-100-web-project.vercel.app/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://100-days-100-web-project.vercel.app/</loc>
+  </url>
+  <url>
+    <loc>https://100-days-100-web-project.vercel.app/contributors/contributor.html</loc>
+  </url>
+  <url>
+    <loc>https://100-days-100-web-project.vercel.app/learning/learning.html</loc>
+  </url>
+  <url>
+    <loc>https://100-days-100-web-project.vercel.app/stats.html</loc>
+  </url>
+  <url>
+    <loc>https://100-days-100-web-project.vercel.app/contact-us.html</loc>
+  </url>
+  <url>
+    <loc>https://100-days-100-web-project.vercel.app/tracker.html</loc>
+  </url>
+</urlset>


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8853

### Summary
The site had no `robots.txt` and no `sitemap.xml`, so search engines had no crawl guidance or sitemap. This PR adds both, using the canonical deployment URL.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added `robots.txt` that allows crawling and points to the sitemap.
- Added `sitemap.xml` listing the main hub pages (home, contributors, learning, stats, contact, tracker), using the canonical `https://100-days-100-web-project.vercel.app/` URL from the README.

The service worker registration issue (#5295) is intentionally not part of this PR.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

What I did verify:
- `sitemap.xml` is well-formed XML with six `<url>` entries that point to existing hub pages.
- `robots.txt` follows the standard format and references the sitemap at the canonical URL.

### Browser Compatibility Check
- Not applicable (crawler-facing files). After deploy, `/robots.txt` and `/sitemap.xml` will be reachable at the site root.

### Responsive & Accessibility Checks
- Not applicable.

---

## 📷 Screenshots / Video Recording
N/A (SEO files).

---

## Note
The homepage project grid is rendered by JavaScript, so the individual project pages are not in the static HTML for non-JS crawlers. A project-level sitemap generated from `projects.json` would be a good follow-up; this PR covers the main hub pages.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
