### PR TITLE
feat(seo): add canonical link to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
       property="og:url"
       content="https://100-days-100-web-project.vercel.app/"
     />
+    <link rel="canonical" href="https://100-days-100-web-project.vercel.app/" />
    <meta
   http-equiv="Content-Security-Policy"
   content="


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8854

### Summary
`index.html` had no canonical link, even though the site is served from more than one URL. This PR adds a canonical link pointing to the URL the README and `og:url` already treat as canonical.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added `<link rel="canonical" href="https://100-days-100-web-project.vercel.app/" />` to the head of `index.html`, next to the existing `og:url` meta (which already uses the same URL).

The missing `og:image` / `twitter:image` is tracked separately in #7958 and #3105, so it is not part of this PR.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

What I did verify:
- The canonical URL matches the existing `og:url` value.
- The change is a single line added to the head; line endings are unchanged (CRLF).

### Browser Compatibility Check
- No visible change. The canonical link is metadata for search engines.

### Responsive & Accessibility Checks
- Not applicable.

---

## 📷 Screenshots / Video Recording
N/A (head metadata).

---

## Note
Other pages could each get their own canonical link as a follow-up; this PR covers the homepage, matching the reported scope.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
