### PR TITLE
feat(home): make Recently Viewed durable (remove 1-hour expiry, keep MRU)

### DIFF
--- a/index.js
+++ b/index.js
@@ -570,7 +570,6 @@ let showAllBookmarks = false;
 let showAllRecent = false;
 
 const INITIAL_VISIBLE_ITEMS = 3;
-const ONE_HOUR_MS = 60 * 60 * 1000;
 
 function migrateRecentProjects() {
   if (recentProjects.length === 0) return;
@@ -586,7 +585,7 @@ function migrateRecentProjects() {
         name: project[1],
         url: project[2],
         tags: project[3],
-        timestamp: Date.now() - ONE_HOUR_MS / 2,
+        timestamp: Date.now(),
       };
     }
     return project;
@@ -601,30 +600,6 @@ function migrateRecentProjects() {
 
 // Migrate on load
 migrateRecentProjects();
-
-function cleanupExpiredRecentProjects() {
-  const initialLength = recentProjects.length;
-  recentProjects = getRecentProjectsWithinWindow();
-
-  if (recentProjects.length !== initialLength) {
-    try {
-      localStorage.setItem("recentProjects", JSON.stringify(recentProjects));
-    } catch (error) {
-      console.warn("Could not save recent projects to localStorage:", error.message);
-    }
-    renderRecentProjects();
-  }
-}
-
-// Clean up every 5 minutes — clear previous interval to prevent timer leaks
-var recentProjectsTimer = null;
-function startRecentProjectsCleanup() {
-  if (recentProjectsTimer !== null) {
-    clearInterval(recentProjectsTimer);
-  }
-  recentProjectsTimer = setInterval(cleanupExpiredRecentProjects, 5 * 60 * 1000);
-}
-startRecentProjectsCleanup();
 
 const CATEGORY_LABEL = {
   beginner: "Beginner",
@@ -1222,17 +1197,6 @@ function loadBookmarksFromURL() {
   );
 }
 
-function getRecentProjectsWithinWindow() {
-  const now = Date.now();
-
-  return recentProjects.filter((item) => {
-    const timestamp = item.timestamp || Date.now();
-    const age = now - timestamp;
-
-    return age <= ONE_HOUR_MS;
-  });
-}
-
 function trackRecentProject(project) {
   let projectObj;
   if (Array.isArray(project)) {
@@ -1365,10 +1329,10 @@ function renderRecentProjects() {
 
   recentGrid.innerHTML = "";
 
-  const validRecent = getRecentProjectsWithinWindow();
+  const validRecent = recentProjects;
 
   if (validRecent.length === 0) {
-    recentGrid.innerHTML = `<p class="empty-state">No recently viewed projects within the last hour.</p>`;
+    recentGrid.innerHTML = `<p class="empty-state">No recently viewed projects yet.</p>`;
     return;
   }
 
@@ -1489,7 +1453,7 @@ function renderRecommendationsForProject(project) {
 }
 
 function renderRecommendationsForLatestRecentProject() {
-  const validRecent = getRecentProjectsWithinWindow();
+  const validRecent = recentProjects;
   if (validRecent.length === 0) {
     renderRecommendationsForProject(null);
     return;
@@ -1499,8 +1463,6 @@ function renderRecommendationsForLatestRecentProject() {
   renderRecommendationsForProject(latestProject);
 }
 
-// Clean up after grid references are initialized.
-cleanupExpiredRecentProjects();
 renderRecommendationsForLatestRecentProject();
 
 /* ============================================================


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8856

### Summary
The homepage "Recently Viewed" list deleted any project viewed more than an hour ago, so it was empty after an hour. This PR removes the 1-hour expiry and keeps the list as a durable most-recently-used list.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Removed the time-based expiry: the `getRecentProjectsWithinWindow` filter, the `cleanupExpiredRecentProjects` function, the 5-minute `startRecentProjectsCleanup` interval (and its timer), the init-time cleanup call, and the now-unused `ONE_HOUR_MS` constant.
- The display and the recommendations now use the full `recentProjects` list.
- Updated the empty-state copy to "No recently viewed projects yet."

`trackRecentProject` is unchanged: it still deduplicates by project, puts the newest first, and caps the list at 20, which is exactly the most-recently-used behaviour we want.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

What I did verify:
- `node --check index.js` passes.
- No references to the removed expiry symbols remain (`ONE_HOUR_MS`, `getRecentProjectsWithinWindow`, `cleanupExpiredRecentProjects`, `startRecentProjectsCleanup`, `recentProjectsTimer`).
- The MRU logic in `trackRecentProject` (dedupe, newest first, cap at 20) is unchanged.
- Line endings are unchanged (CRLF).

### Browser Compatibility Check
- View a few projects, then reload (or come back later): the "Recently Viewed" list persists, showing the most recent projects. A quick manual check is recommended.

### Responsive & Accessibility Checks
- No layout change.

---

## 📷 Screenshots / Video Recording
N/A (behaviour change in how long recents persist).

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
