### PR TITLE
feat(learning): persist quiz best scores and attempt history

### DIFF
--- a/learning/learning.js
+++ b/learning/learning.js
@@ -7,6 +7,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   const STORAGE_KEY = 'learningProgress';
   const BOOKMARKS_KEY = 'learningBookmarks';
   const STREAK_KEY = 'learningStreak';
+  const QUIZ_KEY = 'learningQuizScores';
+  let quizScores = {};
+  try {
+    quizScores = JSON.parse(localStorage.getItem(QUIZ_KEY)) || {};
+  } catch {
+    quizScores = {};
+  }
 
   let bookmarks = [];
 
@@ -1143,6 +1150,26 @@ list.appendChild(item);
      ============================================================ */
   let persistentResultsLog = []; 
 
+  function saveQuizScore(categoryId, correct, total) {
+    if (!total) return { best: { correct: 0, total: 0, pct: 0 }, attempts: 0 };
+    const pct = Math.round((correct / total) * 100);
+    const entry = quizScores[categoryId] || { best: { correct: 0, total: total, pct: 0 }, attempts: [] };
+    entry.attempts.push({ correct: correct, total: total, pct: pct, date: Date.now() });
+    if (entry.attempts.length > 20) {
+      entry.attempts = entry.attempts.slice(-20);
+    }
+    if (pct > entry.best.pct || (pct === entry.best.pct && correct > entry.best.correct)) {
+      entry.best = { correct: correct, total: total, pct: pct };
+    }
+    quizScores[categoryId] = entry;
+    try {
+      localStorage.setItem(QUIZ_KEY, JSON.stringify(quizScores));
+    } catch (e) {
+      console.error(e);
+    }
+    return { best: entry.best, attempts: entry.attempts.length };
+  }
+
   function launchQuiz(categoryId, quizTitle, subQuestionsArray) {
     document.getElementById('topicNavigation').style.display = 'none';
     
@@ -1253,6 +1280,9 @@ list.appendChild(item);
       const wrongAnswersCount = totalQuestions - correctAnswersCount;
       const percentage = Math.round((correctAnswersCount / totalQuestions) * 100);
 
+      const fullCorrect = persistentResultsLog.filter(r => r.isCorrect).length;
+      const quizStats = saveQuizScore(categoryId, fullCorrect, persistentResultsLog.length);
+
       let badge = '';
       if (percentage === 100) badge = '🏆 Perfect Score';
       else if (percentage >= 80) badge = '⭐ Excellent';
@@ -1291,6 +1321,8 @@ list.appendChild(item);
             <p style="margin: 0.4rem 0; display: flex; justify-content: space-between; gap: 2rem;"><span>✅ Correct:</span> <strong style="color: #10b981;">${correctAnswersCount}</strong></p>
             <p style="margin: 0.4rem 0; display: flex; justify-content: space-between; gap: 2rem;"><span>❌ Wrong:</span> <strong style="color: #ef4444;">${wrongAnswersCount}</strong></p>
             <p style="margin: 0.4rem 0; display: flex; justify-content: space-between; gap: 2rem; border-top: 1px solid rgba(255,255,255,0.08); padding-top: 0.4rem; margin-top: 0.4rem;"><span>📊 Score:</span> <strong style="color: #3b82f6;">${percentage}%</strong></p>
+            <p style="margin: 0.4rem 0; display: flex; justify-content: space-between; gap: 2rem;"><span>🏆 Best:</span> <strong style="color: #f59e0b;">${quizStats.best.correct}/${quizStats.best.total} (${quizStats.best.pct}%)</strong></p>
+            <p style="margin: 0.4rem 0; display: flex; justify-content: space-between; gap: 2rem;"><span>🔁 Attempts:</span> <strong style="color: rgba(255,255,255,0.75);">${quizStats.attempts}</strong></p>
           </div>
           
           <div class="quiz-result-actions" style="display: flex; flex-direction: row; flex-wrap: nowrap; gap: 10px; justify-content: center; align-items: center; width: 100%; max-width: 560px; margin: 0 auto; box-sizing: border-box;">


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8875

### Summary
Learning portal quizzes showed a score on completion but never saved it. This PR persists each quiz's best score and attempt history in `localStorage` and shows them on the result card.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added a `learningQuizScores` localStorage store, loaded on start (with a safe parse).
- Added `saveQuizScore(categoryId, correct, total)`, which records each attempt (correct, total, percentage, timestamp), keeps the most recent 20, and updates the best result.
- `showResult` now saves the attempt using the full quiz log, and the result card shows a "Best" line and an "Attempts" line.

The saved score is computed from the full results log (`persistentResultsLog`), independent of the on-screen score, so the persisted best reflects the overall quiz result.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

What I did verify:
- `node --check learning/learning.js` passes.
- Logic walk-through: a first attempt sets the best to that score; later attempts update the best only when they beat it; the attempt list is capped at 20; the store is written under `learningQuizScores`. The localStorage read and write are wrapped in try/catch so private-mode browsers do not throw.
- Line endings are unchanged (CRLF).

### Browser Compatibility Check
- Finish a quiz, then reload and finish it again: the result card shows the best score and the attempt count, and they persist across reloads. A quick manual check is recommended.

### Responsive & Accessibility Checks
- No layout change beyond two extra lines in the existing result stats box.

---

## 📷 Screenshots / Video Recording
A screenshot of the result card showing the new Best and Attempts lines would be a good addition.

---

## Note
This file is also touched by a couple of other quiz-related branches (for example the "Retake Wrong" score fix). They change different lines of `showResult`; whichever merges second may need a trivial rebase.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
