### PR TITLE
chore: remove broken docker:* npm scripts (no Dockerfile in repo)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,6 @@
     "lint": "eslint --no-config-lookup -c eslint.config.js .",
     "lint:all": "npx -y htmlhint '**/*.html' --ignore 'node_modules/**,**/node_modules/**'",
     "format": "prettier --config .prettierrc --write .",
-    "docker:build": "docker build -t 100days-web .",
-    "docker:run": "docker run --rm -p 8080:80 100days-web",
-    "docker:up": "docker compose up --build -d",
-    "docker:down": "docker compose down",
     "prepare": "husky"
   },
   "repository": {


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8844

### Summary
The `docker:build`, `docker:run`, `docker:up`, and `docker:down` scripts in `package.json` reference a Dockerfile and a compose file that no longer exist, so they are broken. This PR removes them.

The CI side of #8844 (the `docker-build` and `security-scan` jobs) was already resolved upstream, since the whole `ci.yml` workflow was removed. This PR finishes the cleanup by removing the matching broken npm scripts.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [x] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Removed the `docker:build`, `docker:run`, `docker:up`, and `docker:down` scripts from `package.json`.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

What I did verify:
- `package.json` is still valid JSON after the change, and no `docker:*` scripts remain.
- There is no Dockerfile or docker-compose file in the repository, so these scripts could not work.

### Browser Compatibility Check
- Not applicable (tooling only).

### Responsive & Accessibility Checks
- Not applicable.

---

## 📷 Screenshots / Video Recording
N/A.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
