### PR TITLE
fix: Fixed the overlapping back to home button and the sidebar-header

### DIFF
--- a/public/image-particle-engine/index.html
+++ b/public/image-particle-engine/index.html
@@ -75,12 +75,6 @@
                     <i class="ri-download-2-line"></i> Save Frame
                 </button>
             </div>
-
-            <div class="sidebar-footer">
-                <a href="../../index.html" class="back-link">
-                    <i class="ri-arrow-left-line"></i> Back to Hub
-                </a>
-            </div>
         </aside>
 
         <!-- Main Canvas Area -->

--- a/public/image-particle-engine/style.css
+++ b/public/image-particle-engine/style.css
@@ -31,28 +31,30 @@ body {
 
 /* Sidebar */
 .sidebar {
-    width: 320px;
-    background: var(--bg-glass);
-    backdrop-filter: blur(20px);
-    border-right: 1px solid var(--border);
-    padding: 2rem;
-    display: flex;
-    flex-direction: column;
-    z-index: 100;
-    overflow-y: auto;
+width: 320px;
+background: var(--bg-glass);
+backdrop-filter: blur(20px);
+border-right: 1px solid var(--border);
+padding: 2rem;
+display: flex;
+flex-direction: column;
+z-index: 100;
+overflow-y: auto;
 }
 
 .sidebar-header {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    margin-bottom: 2.5rem;
+   display: flex;
+   align-items: center;
+   gap: 1rem;
+   margin-bottom: 2.5rem;
+   position:relative;
+   top:25px;
 }
 
 .logo-icon {
-    font-size: 2.5rem;
-    color: var(--primary);
-    filter: drop-shadow(0 0 10px var(--primary-glow));
+   font-size: 2.5rem;
+   color: var(--primary);
+   filter: drop-shadow(0 0 10px var(--primary-glow));
 }
 
 h1 {


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8990 

### Summary
This PR fixes the overlapping of the back to home button and the sidebar header logo and title. This will give better visibility to the title of the project.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Fixed the positioning of the sidebar header
- Fixed the title and button overlap

---

## 📷 Screenshots / Video Recording

Before
<img width="647" height="606" alt="Screenshot 2026-06-19 102038" src="https://github.com/user-attachments/assets/aae575b1-afa2-46cb-9e79-4328f645eebf" />
After
<img width="1513" height="625" alt="Screenshot 2026-06-19 175944" src="https://github.com/user-attachments/assets/875eeb52-fc2e-4db6-be2c-337ebd2454f6" />


---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
