### PR TITLE
fix: preserve payment status after equal split recalculation

### DIFF
--- a/public/Bill-Splitter/app.js
+++ b/public/Bill-Splitter/app.js
@@ -4,8 +4,11 @@
    never via innerHTML, preventing DOM-based XSS (CodeQL CWE-79).
 ================================ */
 
-const $ = id => document.getElementById(id);
+const $ = (id) => document.getElementById(id);
 let CURRENCY = '₹';
+
+// Preserve payment tracker state between recalculations
+let eqPaidState = {};
 
 /* ============================================================
    SAFE DOM HELPER
@@ -15,9 +18,11 @@ let CURRENCY = '₹';
 function el(tag, className, ...children) {
   const e = document.createElement(tag);
   if (className) e.className = className;
-  children.forEach(child => {
+  children.forEach((child) => {
     if (child === null || child === undefined) return;
-    e.appendChild(typeof child === 'string' ? document.createTextNode(child) : child);
+    e.appendChild(
+      typeof child === 'string' ? document.createTextNode(child) : child
+    );
   });
   return e;
 }
@@ -44,16 +49,22 @@ currencyToggle.addEventListener('click', (e) => {
   currencyDropdown.classList.toggle('open');
 });
 
-document.addEventListener('click', () => currencyDropdown.classList.remove('open'));
-currencyDropdown.addEventListener('click', e => e.stopPropagation());
+document.addEventListener('click', () =>
+  currencyDropdown.classList.remove('open')
+);
+currencyDropdown.addEventListener('click', (e) => e.stopPropagation());
 
-document.querySelectorAll('.currency-opt').forEach(btn => {
+document.querySelectorAll('.currency-opt').forEach((btn) => {
   btn.addEventListener('click', () => {
     CURRENCY = btn.dataset.symbol;
     $('currencySymbolDisplay').textContent = CURRENCY;
-    document.querySelectorAll('.currency-opt').forEach(b => b.classList.remove('active'));
+    document
+      .querySelectorAll('.currency-opt')
+      .forEach((b) => b.classList.remove('active'));
     btn.classList.add('active');
-    document.querySelectorAll('.currency-label').forEach(e => e.textContent = CURRENCY);
+    document
+      .querySelectorAll('.currency-label')
+      .forEach((e) => (e.textContent = CURRENCY));
     currencyDropdown.classList.remove('open');
     localStorage.setItem('swp-currency', CURRENCY);
     showToast(`Currency set to ${btn.dataset.code}`);
@@ -65,8 +76,10 @@ const savedCurrency = localStorage.getItem('swp-currency');
 if (savedCurrency) {
   CURRENCY = savedCurrency;
   $('currencySymbolDisplay').textContent = CURRENCY;
-  document.querySelectorAll('.currency-label').forEach(e => e.textContent = CURRENCY);
-  document.querySelectorAll('.currency-opt').forEach(b => {
+  document
+    .querySelectorAll('.currency-label')
+    .forEach((e) => (e.textContent = CURRENCY));
+  document.querySelectorAll('.currency-opt').forEach((b) => {
     b.classList.toggle('active', b.dataset.symbol === CURRENCY);
   });
 }
@@ -86,10 +99,14 @@ darkToggle.addEventListener('click', () => applyTheme(!isDark()));
 /* ============================================================
    TAB SWITCHING
 ============================================================ */
-document.querySelectorAll('.tab').forEach(tab => {
+document.querySelectorAll('.tab').forEach((tab) => {
   tab.addEventListener('click', () => {
-    document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
-    document.querySelectorAll('.tab-content').forEach(tc => tc.classList.remove('active'));
+    document
+      .querySelectorAll('.tab')
+      .forEach((t) => t.classList.remove('active'));
+    document
+      .querySelectorAll('.tab-content')
+      .forEach((tc) => tc.classList.remove('active'));
     tab.classList.add('active');
     $('tab-' + tab.dataset.tab).classList.add('active');
     updateStickyBar();
@@ -99,12 +116,14 @@ document.querySelectorAll('.tab').forEach(tab => {
 /* ============================================================
    TIP PRESET BUTTONS (scoped per card)
 ============================================================ */
-document.querySelectorAll('.tip-presets').forEach(group => {
+document.querySelectorAll('.tip-presets').forEach((group) => {
   const card = group.closest('.card');
   const tipInput = card ? card.querySelector('[id$="-tip"]') : null;
-  group.querySelectorAll('.tip-btn').forEach(btn => {
+  group.querySelectorAll('.tip-btn').forEach((btn) => {
     btn.addEventListener('click', () => {
-      group.querySelectorAll('.tip-btn').forEach(b => b.classList.remove('active'));
+      group
+        .querySelectorAll('.tip-btn')
+        .forEach((b) => b.classList.remove('active'));
       btn.classList.add('active');
       if (tipInput) tipInput.value = btn.dataset.tip;
       updateStickyBar();
@@ -112,12 +131,12 @@ document.querySelectorAll('.tip-presets').forEach(group => {
   });
 });
 
-document.querySelectorAll('[id$="-tip"], [id$="-tax"]').forEach(input => {
+document.querySelectorAll('[id$="-tip"], [id$="-tax"]').forEach((input) => {
   input.addEventListener('input', () => {
     const card = input.closest('.card');
     if (!card) return;
     if (input.id.endsWith('-tip')) {
-      card.querySelectorAll('.tip-btn').forEach(btn => {
+      card.querySelectorAll('.tip-btn').forEach((btn) => {
         btn.classList.toggle('active', btn.dataset.tip == input.value);
       });
     }
@@ -134,31 +153,38 @@ function updateStickyBar() {
   const stickyTotal = $('stickyTotal');
   const stickyBtn = $('stickyCalcBtn');
 
-  if (window.innerWidth > 600) { bar.style.display = 'none'; return; }
+  if (window.innerWidth > 600) {
+    bar.style.display = 'none';
+    return;
+  }
   bar.style.display = 'flex';
 
   if (activeTab === 'equal') {
     const bill = parseFloat($('eq-bill').value) || 0;
-    const tip = bill * (parseFloat($('eq-tip').value) || 0) / 100;
-    const tax = bill * (parseFloat($('eq-tax').value) || 0) / 100;
+    const tip = (bill * (parseFloat($('eq-tip').value) || 0)) / 100;
+    const tax = (bill * (parseFloat($('eq-tax').value) || 0)) / 100;
     stickyTotal.textContent = `Total: ${fmt(bill + tip + tax)}`;
     stickyBtn.onclick = () => $('eq-calc').click();
   } else if (activeTab === 'unequal') {
     const bill = parseFloat($('uq-bill').value) || 0;
-    const tip = bill * (parseFloat($('uq-tip').value) || 0) / 100;
-    const tax = bill * (parseFloat($('uq-tax').value) || 0) / 100;
+    const tip = (bill * (parseFloat($('uq-tip').value) || 0)) / 100;
+    const tax = (bill * (parseFloat($('uq-tax').value) || 0)) / 100;
     stickyTotal.textContent = `Total: ${fmt(bill + tip + tax)}`;
     stickyBtn.onclick = () => $('uq-calc').click();
   } else if (activeTab === 'items') {
-    const total = [...$('it-items').querySelectorAll('.item-price')]
-      .reduce((s, i) => s + (parseFloat(i.value) || 0), 0);
+    const total = [...$('it-items').querySelectorAll('.item-price')].reduce(
+      (s, i) => s + (parseFloat(i.value) || 0),
+      0
+    );
     stickyTotal.textContent = `Items: ${fmt(total)}`;
     stickyBtn.onclick = () => $('it-calc').click();
   }
 }
 
 window.addEventListener('resize', updateStickyBar);
-document.querySelectorAll('input').forEach(i => i.addEventListener('input', updateStickyBar));
+document
+  .querySelectorAll('input')
+  .forEach((i) => i.addEventListener('input', updateStickyBar));
 
 /* ============================================================
    PARTICIPANT HELPERS
@@ -172,13 +198,16 @@ function addParticipantTag(container, name = '') {
   const input = document.createElement('input');
   input.type = 'text';
   input.placeholder = 'Name';
-  input.value = name;                     // .value is safe — not rendered as HTML
+  input.value = name; // .value is safe — not rendered as HTML
 
   const removeBtn = document.createElement('button');
   removeBtn.className = 'remove-p';
   removeBtn.setAttribute('aria-label', 'Remove');
   removeBtn.textContent = '×';
-  removeBtn.addEventListener('click', () => { div.remove(); refreshItemSharers(); });
+  removeBtn.addEventListener('click', () => {
+    div.remove();
+    refreshItemSharers();
+  });
 
   div.appendChild(input);
   div.appendChild(removeBtn);
@@ -194,7 +223,7 @@ function addParticipantRow(container, name = '') {
   nameInput.type = 'text';
   nameInput.placeholder = 'Name';
   nameInput.className = 'p-name';
-  nameInput.value = name;                 // .value is safe
+  nameInput.value = name; // .value is safe
 
   const prefixDiv = document.createElement('div');
   prefixDiv.className = 'input-prefix sm';
@@ -229,16 +258,24 @@ function addParticipantRow(container, name = '') {
 }
 
 function getParticipantNames(container, selector = 'input[type="text"]') {
-  return [...container.querySelectorAll(selector)].map(i => i.value.trim() || 'Person');
+  return [...container.querySelectorAll(selector)].map(
+    (i) => i.value.trim() || 'Person'
+  );
 }
 
 /* Wire existing remove buttons in static HTML */
-document.querySelectorAll('.remove-p').forEach(btn => {
-  btn.addEventListener('click', () => btn.closest('.participant-tag, .participant-row')?.remove());
+document.querySelectorAll('.remove-p').forEach((btn) => {
+  btn.addEventListener('click', () =>
+    btn.closest('.participant-tag, .participant-row')?.remove()
+  );
 });
 
-$('eq-add-p').addEventListener('click', () => addParticipantTag($('eq-participants')));
-$('uq-add-p').addEventListener('click', () => addParticipantRow($('uq-participants')));
+$('eq-add-p').addEventListener('click', () =>
+  addParticipantTag($('eq-participants'))
+);
+$('uq-add-p').addEventListener('click', () =>
+  addParticipantRow($('uq-participants'))
+);
 $('it-add-p').addEventListener('click', () => {
   addParticipantTag($('it-participants'));
   refreshItemSharers();
@@ -253,7 +290,7 @@ function makeSettleRow(from, to, amount) {
 
   const fromSpan = document.createElement('span');
   fromSpan.className = 'settle-from';
-  fromSpan.textContent = from;            // user name → textContent only
+  fromSpan.textContent = from; // user name → textContent only
 
   const arrowSpan = document.createElement('span');
   arrowSpan.className = 'settle-arrow';
@@ -261,11 +298,11 @@ function makeSettleRow(from, to, amount) {
 
   const toSpan = document.createElement('span');
   toSpan.className = 'settle-to';
-  toSpan.textContent = to;               // user name → textContent only
+  toSpan.textContent = to; // user name → textContent only
 
   const amtSpan = document.createElement('span');
   amtSpan.className = 'settle-amt';
-  amtSpan.textContent = fmt(amount);     // formatted number — safe, but using textContent anyway
+  amtSpan.textContent = fmt(amount); // formatted number — safe, but using textContent anyway
 
   d.appendChild(fromSpan);
   d.appendChild(arrowSpan);
@@ -287,10 +324,11 @@ $('eq-calc').addEventListener('click', () => {
   const names = getParticipantNames($('eq-participants'));
   const occasion = $('eq-occasion').value.trim();
 
-  if (!bill || !names.length) return showToast('Enter a bill amount and at least one person.', 'error');
+  if (!bill || !names.length)
+    return showToast('Enter a bill amount and at least one person.', 'error');
 
-  const tip = bill * tipPct / 100;
-  const tax = bill * taxPct / 100;
+  const tip = (bill * tipPct) / 100;
+  const tax = (bill * taxPct) / 100;
   const total = bill + tip + tax;
   let per = total / names.length;
   if (roundUp) per = Math.ceil(per);
@@ -307,18 +345,27 @@ $('eq-calc').addEventListener('click', () => {
 
   // Payment status breakdown — safe DOM construction only
   const bd = $('eq-breakdown');
-  bd.innerHTML = '';                      // clearing container is safe (no user data)
+  bd.innerHTML = '';
+
+  // Preserve existing payment states
   const paidState = {};
 
+  // Remove states for participants no longer present
+  Object.keys(eqPaidState).forEach((savedName) => {
+    if (!names.includes(savedName)) {
+      delete eqPaidState[savedName];
+    }
+  });
+
   names.forEach((name) => {
-    paidState[name] = false;
+    paidState[name] = eqPaidState[name] || false;
 
     const d = document.createElement('div');
     d.className = 'breakdown-item';
 
     const nameSpan = document.createElement('span');
     nameSpan.className = 'breakdown-name';
-    nameSpan.textContent = name;          // user name → textContent only
+    nameSpan.textContent = name; // user name → textContent only
 
     const rightDiv = document.createElement('div');
     rightDiv.className = 'breakdown-right';
@@ -333,11 +380,23 @@ $('eq-calc').addEventListener('click', () => {
     paidBtn.textContent = 'Mark paid';
     paidBtn.addEventListener('click', function () {
       paidState[name] = !paidState[name];
+
+      // Persist state globally
+      eqPaidState[name] = paidState[name];
+
       this.classList.toggle('is-paid', paidState[name]);
       this.textContent = paidState[name] ? '✓ Paid' : 'Mark paid';
       d.classList.toggle('is-paid-row', paidState[name]);
+
       updatePaidCount(paidState, names.length);
     });
+
+    // Restore previous status after recalculation
+    if (paidState[name]) {
+      paidBtn.classList.add('is-paid');
+      paidBtn.textContent = '✓ Paid';
+      d.classList.add('is-paid-row');
+    }
 
     rightDiv.appendChild(amtSpan);
     rightDiv.appendChild(paidBtn);
@@ -350,13 +409,26 @@ $('eq-calc').addEventListener('click', () => {
   $('eq-results').style.display = 'block';
   $('eq-results').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
 
-  window._eqResult = { type: 'Equal Split', bill, tip, tax, total, per, names, tipPct, taxPct, roundUp, occasion };
+  window._eqResult = {
+    type: 'Equal Split',
+    bill,
+    tip,
+    tax,
+    total,
+    per,
+    names,
+    tipPct,
+    taxPct,
+    roundUp,
+    occasion,
+  };
 });
 
 function updatePaidCount(paidState, total) {
   const paid = Object.values(paidState).filter(Boolean).length;
   $('eq-paid-count').textContent = `${paid} / ${total} paid`;
-  $('eq-paid-count').className = `paid-count${paid === total ? ' all-paid' : ''}`;
+  $('eq-paid-count').className =
+    `paid-count${paid === total ? ' all-paid' : ''}`;
 }
 
 function animateValue(el, start, end, duration, isRounded = false) {
@@ -379,9 +451,10 @@ function updateUqRemain() {
   const bill = parseFloat($('uq-bill').value) || 0;
   const tipPct = parseFloat($('uq-tip').value) || 0;
   const taxPct = parseFloat($('uq-tax').value) || 0;
-  const total = bill + bill * tipPct / 100 + bill * taxPct / 100;
-  const entered = [...$('uq-participants').querySelectorAll('.p-amount')]
-    .reduce((s, i) => s + (parseFloat(i.value) || 0), 0);
+  const total = bill + (bill * tipPct) / 100 + (bill * taxPct) / 100;
+  const entered = [
+    ...$('uq-participants').querySelectorAll('.p-amount'),
+  ].reduce((s, i) => s + (parseFloat(i.value) || 0), 0);
   const remain = total - entered;
   const info = $('uq-settle-info');
   const bar = $('uq-running-bar');
@@ -392,16 +465,22 @@ function updateUqRemain() {
     const pct = Math.min((entered / total) * 100, 100);
     bar.style.display = 'block';
     fill.style.width = pct + '%';
-    fill.style.background = remain > 0.005 ? 'var(--yellow)' : remain < -0.005 ? 'var(--accent)' : 'var(--green)';
+    fill.style.background =
+      remain > 0.005
+        ? 'var(--yellow)'
+        : remain < -0.005
+          ? 'var(--accent)'
+          : 'var(--green)';
     label.textContent = pct.toFixed(0) + '% assigned';
 
     info.style.display = 'block';
     // All values here are numbers / formatted strings — safe, using textContent
-    $('uq-remain-label').textContent = remain > 0.005
-      ? `⚠️ Unassigned: ${fmt(remain)} remaining`
-      : remain < -0.005
-      ? `⚠️ Over by ${fmt(Math.abs(remain))}`
-      : `✅ Fully assigned`;
+    $('uq-remain-label').textContent =
+      remain > 0.005
+        ? `⚠️ Unassigned: ${fmt(remain)} remaining`
+        : remain < -0.005
+          ? `⚠️ Over by ${fmt(Math.abs(remain))}`
+          : `✅ Fully assigned`;
   } else {
     info.style.display = 'none';
     bar.style.display = 'none';
@@ -419,35 +498,38 @@ $('uq-calc').addEventListener('click', () => {
   const tipPct = parseFloat($('uq-tip').value) || 0;
   const taxPct = parseFloat($('uq-tax').value) || 0;
   const roundUp = $('uq-roundup').checked;
-  const total = bill + bill * tipPct / 100 + bill * taxPct / 100;
+  const total = bill + (bill * tipPct) / 100 + (bill * taxPct) / 100;
   if (!bill) return showToast('Enter a bill amount.', 'error');
 
   const rows = [...$('uq-participants').querySelectorAll('.participant-row')];
   if (!rows.length) return showToast('Add at least one participant.', 'error');
 
-  const participants = rows.map(r => ({
+  const participants = rows.map((r) => ({
     name: r.querySelector('.p-name')?.value.trim() || 'Person',
-    paid: parseFloat(r.querySelector('.p-amount')?.value) || 0
+    paid: parseFloat(r.querySelector('.p-amount')?.value) || 0,
   }));
 
   const sumPaid = participants.reduce((s, p) => s + p.paid, 0);
-  const people = participants.map(p => ({
+  const people = participants.map((p) => ({
     name: p.name,
-    owes: sumPaid > 0 ? (p.paid / sumPaid) * total : total / participants.length
+    owes:
+      sumPaid > 0 ? (p.paid / sumPaid) * total : total / participants.length,
   }));
 
-  if (roundUp) people.forEach(p => p.owes = Math.ceil(p.owes));
+  if (roundUp) people.forEach((p) => (p.owes = Math.ceil(p.owes)));
 
-  const settlements = settleDebts(people.map(p => ({ name: p.name, balance: p.paid - p.owes })));
+  const settlements = settleDebts(
+    people.map((p) => ({ name: p.name, balance: p.paid - p.owes }))
+  );
 
   // Summary — all formatted numbers, safe
   $('uq-subtotal').textContent = fmt(bill);
-  $('uq-tip-display').textContent = fmt(bill * tipPct / 100);
-  $('uq-tax-display').textContent = fmt(bill * taxPct / 100);
+  $('uq-tip-display').textContent = fmt((bill * tipPct) / 100);
+  $('uq-tax-display').textContent = fmt((bill * taxPct) / 100);
   $('uq-total-display').textContent = fmt(total);
 
   const sl = $('uq-settlement');
-  sl.innerHTML = '';                      // clearing container — safe
+  sl.innerHTML = ''; // clearing container — safe
 
   if (settlements.length === 0) {
     const d = document.createElement('div');
@@ -457,14 +539,22 @@ $('uq-calc').addEventListener('click', () => {
     d.appendChild(sp);
     sl.appendChild(d);
   } else {
-    settlements.forEach(s => sl.appendChild(makeSettleRow(s.from, s.to, s.amount)));
+    settlements.forEach((s) =>
+      sl.appendChild(makeSettleRow(s.from, s.to, s.amount))
+    );
   }
 
   $('uq-results').style.display = 'block';
   $('uq-results').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   window._uqResult = {
-    type: 'Custom Split', bill, tipPct, taxPct, total, settlements, people,
-    occasion: $('uq-occasion').value.trim()
+    type: 'Custom Split',
+    bill,
+    tipPct,
+    taxPct,
+    total,
+    settlements,
+    people,
+    occasion: $('uq-occasion').value.trim(),
   };
 });
 
@@ -472,14 +562,17 @@ $('uq-calc').addEventListener('click', () => {
    SETTLEMENT ALGORITHM (simplify debts)
 ============================================================ */
 function settleDebts(balances) {
-  const creditors = [], debtors = [];
-  balances.forEach(b => {
+  const creditors = [],
+    debtors = [];
+  balances.forEach((b) => {
     if (b.balance > 0.005) creditors.push({ ...b });
-    else if (b.balance < -0.005) debtors.push({ ...b, balance: Math.abs(b.balance) });
+    else if (b.balance < -0.005)
+      debtors.push({ ...b, balance: Math.abs(b.balance) });
   });
   const txns = [];
   while (creditors.length && debtors.length) {
-    const c = creditors[0], d = debtors[0];
+    const c = creditors[0],
+      d = debtors[0];
     const amount = Math.min(c.balance, d.balance);
     txns.push({ from: d.name, to: c.name, amount: +amount.toFixed(2) });
     c.balance -= amount;
@@ -494,13 +587,16 @@ function settleDebts(balances) {
    ITEMS SPLIT
 ============================================================ */
 function getItParticipants() {
-  return [...$('it-participants').querySelectorAll('input[type="text"]')]
-    .map(i => i.value.trim() || 'Person');
+  return [...$('it-participants').querySelectorAll('input[type="text"]')].map(
+    (i) => i.value.trim() || 'Person'
+  );
 }
 
 function updateItemsLiveTotal() {
-  const total = [...$('it-items').querySelectorAll('.item-price')]
-    .reduce((s, i) => s + (parseFloat(i.value) || 0), 0);
+  const total = [...$('it-items').querySelectorAll('.item-price')].reduce(
+    (s, i) => s + (parseFloat(i.value) || 0),
+    0
+  );
   $('it-live-amount').textContent = fmt(total);
   updateStickyBar();
 }
@@ -513,13 +609,13 @@ function makeSharerLabel(name, checked) {
   const cb = document.createElement('input');
   cb.type = 'checkbox';
   cb.checked = checked;
-  cb.dataset.name = name;                 // stored in dataset, not rendered as HTML
+  cb.dataset.name = name; // stored in dataset, not rendered as HTML
   cb.addEventListener('change', (e) => {
     lbl.classList.toggle('checked', e.target.checked);
   });
 
   lbl.appendChild(cb);
-  lbl.appendChild(document.createTextNode(name));  // name → text node only
+  lbl.appendChild(document.createTextNode(name)); // name → text node only
   return lbl;
 }
 
@@ -536,7 +632,7 @@ function addItem(name = '', price = '') {
   nameInput.type = 'text';
   nameInput.placeholder = 'Item name';
   nameInput.className = 'item-name';
-  nameInput.value = name;                 // .value is safe
+  nameInput.value = name; // .value is safe
 
   const prefixDiv = document.createElement('div');
   prefixDiv.className = 'input-prefix sm';
@@ -561,7 +657,10 @@ function addItem(name = '', price = '') {
   removeBtn.className = 'remove-p';
   removeBtn.setAttribute('aria-label', 'Remove item');
   removeBtn.textContent = '×';
-  removeBtn.addEventListener('click', () => { div.remove(); updateItemsLiveTotal(); });
+  removeBtn.addEventListener('click', () => {
+    div.remove();
+    updateItemsLiveTotal();
+  });
 
   header.appendChild(nameInput);
   header.appendChild(prefixDiv);
@@ -570,7 +669,7 @@ function addItem(name = '', price = '') {
   // ── Sharers ──
   const sharersDiv = document.createElement('div');
   sharersDiv.className = 'item-sharers';
-  names.forEach(n => sharersDiv.appendChild(makeSharerLabel(n, true)));
+  names.forEach((n) => sharersDiv.appendChild(makeSharerLabel(n, true)));
 
   div.appendChild(header);
   div.appendChild(sharersDiv);
@@ -580,61 +679,75 @@ function addItem(name = '', price = '') {
 
 function refreshItemSharers() {
   const names = getItParticipants();
-  $('it-items').querySelectorAll('.item-row').forEach(row => {
-    const existing = {};
-    row.querySelectorAll('.sharer-check').forEach(lbl => {
-      existing[lbl.querySelector('input').dataset.name] = lbl.classList.contains('checked');
-    });
+  $('it-items')
+    .querySelectorAll('.item-row')
+    .forEach((row) => {
+      const existing = {};
+      row.querySelectorAll('.sharer-check').forEach((lbl) => {
+        existing[lbl.querySelector('input').dataset.name] =
+          lbl.classList.contains('checked');
+      });
 
-    const sharersDiv = row.querySelector('.item-sharers');
-    sharersDiv.innerHTML = '';            // clearing container — safe
-    names.forEach(n => {
-      const isChecked = existing[n] !== false;
-      sharersDiv.appendChild(makeSharerLabel(n, isChecked));
+      const sharersDiv = row.querySelector('.item-sharers');
+      sharersDiv.innerHTML = ''; // clearing container — safe
+      names.forEach((n) => {
+        const isChecked = existing[n] !== false;
+        sharersDiv.appendChild(makeSharerLabel(n, isChecked));
+      });
     });
-  });
 }
 
 $('it-add-item').addEventListener('click', () => addItem());
 $('it-participants').addEventListener('change', refreshItemSharers);
 
 // Add 2 default items
-addItem(); addItem();
+addItem();
+addItem();
 
 $('it-calc').addEventListener('click', () => {
   const names = getItParticipants();
   const tipPct = parseFloat($('it-tip').value) || 0;
   const taxPct = parseFloat($('it-tax').value) || 0;
 
-  const items = [...$('it-items').querySelectorAll('.item-row')].map(row => {
-    const itemName = row.querySelector('.item-name').value.trim() || 'Item';
-    const price = parseFloat(row.querySelector('.item-price').value) || 0;
-    const sharers = [...row.querySelectorAll('.sharer-check.checked input')].map(i => i.dataset.name);
-    return { name: itemName, price, sharers };
-  }).filter(i => i.price > 0);
+  const items = [...$('it-items').querySelectorAll('.item-row')]
+    .map((row) => {
+      const itemName = row.querySelector('.item-name').value.trim() || 'Item';
+      const price = parseFloat(row.querySelector('.item-price').value) || 0;
+      const sharers = [
+        ...row.querySelectorAll('.sharer-check.checked input'),
+      ].map((i) => i.dataset.name);
+      return { name: itemName, price, sharers };
+    })
+    .filter((i) => i.price > 0);
 
-  if (!items.length) return showToast('Add at least one item with a price.', 'error');
+  if (!items.length)
+    return showToast('Add at least one item with a price.', 'error');
 
   const totals = {};
-  names.forEach(n => totals[n] = { items: [], subtotal: 0 });
+  names.forEach((n) => (totals[n] = { items: [], subtotal: 0 }));
 
-  items.forEach(item => {
+  items.forEach((item) => {
     if (!item.sharers.length) return;
     const share = item.price / item.sharers.length;
-    item.sharers.forEach(n => {
+    item.sharers.forEach((n) => {
       if (!totals[n]) totals[n] = { items: [], subtotal: 0 };
       totals[n].items.push({ name: item.name, amount: share });
       totals[n].subtotal += share;
     });
   });
 
-  const grandSubtotal = Object.values(totals).reduce((s, p) => s + p.subtotal, 0);
-  const tipTotal = grandSubtotal * tipPct / 100;
-  const taxTotal = grandSubtotal * taxPct / 100;
+  const grandSubtotal = Object.values(totals).reduce(
+    (s, p) => s + p.subtotal,
+    0
+  );
+  const tipTotal = (grandSubtotal * tipPct) / 100;
+  const taxTotal = (grandSubtotal * taxPct) / 100;
 
-  Object.keys(totals).forEach(n => {
-    const tipShare = grandSubtotal > 0 ? (totals[n].subtotal / grandSubtotal) * tipTotal : 0;
-    const taxShare = grandSubtotal > 0 ? (totals[n].subtotal / grandSubtotal) * taxTotal : 0;
+  Object.keys(totals).forEach((n) => {
+    const tipShare =
+      grandSubtotal > 0 ? (totals[n].subtotal / grandSubtotal) * tipTotal : 0;
+    const taxShare =
+      grandSubtotal > 0 ? (totals[n].subtotal / grandSubtotal) * taxTotal : 0;
     totals[n].total = totals[n].subtotal + tipShare + taxShare;
     totals[n].tipShare = tipShare;
     totals[n].taxShare = taxShare;
@@ -642,7 +755,7 @@ $('it-calc').addEventListener('click', () => {
 
   // ── Per-person breakdown cards — fully safe DOM construction ──
   const bd = $('it-breakdown');
-  bd.innerHTML = '';                      // clearing container — safe
+  bd.innerHTML = ''; // clearing container — safe
 
   Object.entries(totals).forEach(([personName, data]) => {
     if (!data.items.length) return;
@@ -656,7 +769,7 @@ $('it-calc').addEventListener('click', () => {
 
     const nameSpan = document.createElement('span');
     nameSpan.className = 'ppi-name';
-    nameSpan.textContent = personName;    // user name → textContent only
+    nameSpan.textContent = personName; // user name → textContent only
 
     const totalSpan = document.createElement('span');
     totalSpan.className = 'ppi-total';
@@ -669,11 +782,11 @@ $('it-calc').addEventListener('click', () => {
     const itemsDiv = document.createElement('div');
     itemsDiv.className = 'ppi-items';
 
-    data.items.forEach(i => {
+    data.items.forEach((i) => {
       const row = document.createElement('div');
       row.className = 'ppi-item';
       const iName = document.createElement('span');
-      iName.textContent = i.name;         // item name → textContent only
+      iName.textContent = i.name; // item name → textContent only
       const iAmt = document.createElement('span');
       iAmt.textContent = fmt(i.amount);
       row.appendChild(iName);
@@ -688,7 +801,8 @@ $('it-calc').addEventListener('click', () => {
       lbl.textContent = `Tip (${tipPct}%)`;
       const amt = document.createElement('span');
       amt.textContent = fmt(data.tipShare);
-      row.appendChild(lbl); row.appendChild(amt);
+      row.appendChild(lbl);
+      row.appendChild(amt);
       itemsDiv.appendChild(row);
     }
 
@@ -699,7 +813,8 @@ $('it-calc').addEventListener('click', () => {
       lbl.textContent = `Tax (${taxPct}%)`;
       const amt = document.createElement('span');
       amt.textContent = fmt(data.taxShare);
-      row.appendChild(lbl); row.appendChild(amt);
+      row.appendChild(lbl);
+      row.appendChild(amt);
       itemsDiv.appendChild(row);
     }
 
@@ -709,16 +824,22 @@ $('it-calc').addEventListener('click', () => {
   });
 
   // Settlement
-  const maxPayer = Object.entries(totals).reduce((a, b) => b[1].total > a[1].total ? b : a);
+  const maxPayer = Object.entries(totals).reduce((a, b) =>
+    b[1].total > a[1].total ? b : a
+  );
   const settlements = [];
   Object.entries(totals).forEach(([pName, data]) => {
     if (pName !== maxPayer[0] && data.total > 0.005) {
-      settlements.push({ from: pName, to: maxPayer[0], amount: +data.total.toFixed(2) });
+      settlements.push({
+        from: pName,
+        to: maxPayer[0],
+        amount: +data.total.toFixed(2),
+      });
     }
   });
 
   const sl = $('it-settlement');
-  sl.innerHTML = '';                      // clearing container — safe
+  sl.innerHTML = ''; // clearing container — safe
 
   // Settlement heading — static text, not user data
   const settleHeading = document.createElement('h3');
@@ -735,14 +856,21 @@ $('it-calc').addEventListener('click', () => {
     d.appendChild(sp);
     sl.appendChild(d);
   } else {
-    settlements.forEach(s => sl.appendChild(makeSettleRow(s.from, s.to, s.amount)));
+    settlements.forEach((s) =>
+      sl.appendChild(makeSettleRow(s.from, s.to, s.amount))
+    );
   }
 
   $('it-results').style.display = 'block';
   $('it-results').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   window._itResult = {
-    type: 'Items Split', items, totals, settlements, tipPct, taxPct,
-    occasion: $('it-occasion').value.trim()
+    type: 'Items Split',
+    items,
+    totals,
+    settlements,
+    tipPct,
+    taxPct,
+    occasion: $('it-occasion').value.trim(),
   };
 });
 
@@ -754,19 +882,27 @@ $('it-bulk-paste').addEventListener('click', () => {
   $('bulkPasteArea').focus();
 });
 
-$('closeBulk').addEventListener('click', () => $('bulkModalOverlay').classList.remove('open'));
-$('bulkModalOverlay').addEventListener('click', e => {
-  if (e.target === $('bulkModalOverlay')) $('bulkModalOverlay').classList.remove('open');
+$('closeBulk').addEventListener('click', () =>
+  $('bulkModalOverlay').classList.remove('open')
+);
+$('bulkModalOverlay').addEventListener('click', (e) => {
+  if (e.target === $('bulkModalOverlay'))
+    $('bulkModalOverlay').classList.remove('open');
 });
 
 $('bulkAddBtn').addEventListener('click', () => {
-  const lines = $('bulkPasteArea').value.trim().split('\n').filter(l => l.trim());
+  const lines = $('bulkPasteArea')
+    .value.trim()
+    .split('\n')
+    .filter((l) => l.trim());
   let added = 0;
-  lines.forEach(line => {
+  lines.forEach((line) => {
     const parts = line.split(',');
     if (parts.length >= 2) {
       const itemName = parts[0].trim();
-      const price = parseFloat(parts[parts.length - 1].trim().replace(/[^\d.]/g, ''));
+      const price = parseFloat(
+        parts[parts.length - 1].trim().replace(/[^\d.]/g, '')
+      );
       if (itemName && !isNaN(price) && price > 0) {
         addItem(itemName, price);
         added++;
@@ -816,8 +952,10 @@ $('eq-copy').addEventListener('click', () => {
     `Grand Total: ${fmt(r.total)}`,
     '',
     `Each person pays: ${fmt(r.per)}`,
-    `Participants: ${r.names.join(', ')}`
-  ].filter(Boolean).join('\n');
+    `Participants: ${r.names.join(', ')}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
   copyText(lines);
 });
 
@@ -831,9 +969,11 @@ $('uq-copy').addEventListener('click', () => {
     '',
     'Settlement:',
     ...(r.settlements.length
-      ? r.settlements.map(s => `  ${s.from} → ${s.to}: ${fmt(s.amount)}`)
-      : ['  Everyone is square! ✅'])
-  ].filter(Boolean).join('\n');
+      ? r.settlements.map((s) => `  ${s.from} → ${s.to}: ${fmt(s.amount)}`)
+      : ['  Everyone is square! ✅']),
+  ]
+    .filter(Boolean)
+    .join('\n');
   copyText(lines);
 });
 
@@ -842,7 +982,8 @@ $('it-copy').addEventListener('click', () => {
   if (!r) return showToast('Calculate first!', 'error');
   const perPerson = Object.entries(r.totals)
     .filter(([, d]) => d.total > 0)
-    .map(([n, d]) => `  ${n}: ${fmt(d.total)}`).join('\n');
+    .map(([n, d]) => `  ${n}: ${fmt(d.total)}`)
+    .join('\n');
   const lines = [
     r.occasion ? `🎉 ${r.occasion}` : '',
     'SplitWise Pro — Items Split',
@@ -852,9 +993,11 @@ $('it-copy').addEventListener('click', () => {
     '',
     'Settlement:',
     ...(r.settlements.length
-      ? r.settlements.map(s => `  ${s.from} → ${s.to}: ${fmt(s.amount)}`)
-      : ['  Only one person! ✅'])
-  ].filter(Boolean).join('\n');
+      ? r.settlements.map((s) => `  ${s.from} → ${s.to}: ${fmt(s.amount)}`)
+      : ['  Only one person! ✅']),
+  ]
+    .filter(Boolean)
+    .join('\n');
   copyText(lines);
 });
 
@@ -864,13 +1007,20 @@ $('it-copy').addEventListener('click', () => {
 const HISTORY_KEY = 'swp-history';
 
 function getHistory() {
-  try { return JSON.parse(localStorage.getItem(HISTORY_KEY)) || []; }
-  catch { return []; }
+  try {
+    return JSON.parse(localStorage.getItem(HISTORY_KEY)) || [];
+  } catch {
+    return [];
+  }
 }
 
 function saveHistory(entry) {
   const hist = getHistory();
-  hist.unshift({ ...entry, id: Date.now(), date: new Date().toLocaleDateString() });
+  hist.unshift({
+    ...entry,
+    id: Date.now(),
+    date: new Date().toLocaleDateString(),
+  });
   if (hist.length > 30) hist.pop();
   localStorage.setItem(HISTORY_KEY, JSON.stringify(hist));
   renderHistory();
@@ -880,7 +1030,7 @@ function renderHistory() {
   const list = $('historyList');
   const hist = getHistory();
 
-  list.innerHTML = '';                    // clearing container — safe
+  list.innerHTML = ''; // clearing container — safe
 
   if (!hist.length) {
     // Static structure — no user data involved
@@ -906,7 +1056,7 @@ function renderHistory() {
     return;
   }
 
-  hist.forEach(h => {
+  hist.forEach((h) => {
     const item = document.createElement('div');
     item.className = 'history-item';
 
@@ -916,11 +1066,11 @@ function renderHistory() {
 
     const typeSpan = document.createElement('span');
     typeSpan.className = 'history-type';
-    typeSpan.textContent = h.type || '';  // comes from our own code, but textContent anyway
+    typeSpan.textContent = h.type || ''; // comes from our own code, but textContent anyway
 
     const dateSpan = document.createElement('span');
     dateSpan.className = 'history-date';
-    dateSpan.textContent = h.date || '';  // formatted date string — textContent
+    dateSpan.textContent = h.date || ''; // formatted date string — textContent
 
     meta.appendChild(typeSpan);
     meta.appendChild(dateSpan);
@@ -937,7 +1087,7 @@ function renderHistory() {
     // Sub row
     const subDiv = document.createElement('div');
     subDiv.className = 'history-sub';
-    subDiv.textContent = h.detail || '';  // our own formatted string — textContent
+    subDiv.textContent = h.detail || ''; // our own formatted string — textContent
 
     item.appendChild(meta);
     item.appendChild(titleDiv);
@@ -974,9 +1124,10 @@ $('eq-save').addEventListener('click', () => {
   const r = window._eqResult;
   if (!r) return showToast('Calculate first!', 'error');
   saveHistory({
-    type: r.type, occasion: r.occasion,
+    type: r.type,
+    occasion: r.occasion,
     summary: `Total ${fmt(r.total)} ÷ ${r.names.length} people`,
-    detail: `Each pays ${fmt(r.per)}`
+    detail: `Each pays ${fmt(r.per)}`,
   });
   showToast('Saved to history! 💾');
 });
@@ -985,9 +1136,10 @@ $('uq-save').addEventListener('click', () => {
   const r = window._uqResult;
   if (!r) return showToast('Calculate first!', 'error');
   saveHistory({
-    type: r.type, occasion: r.occasion,
+    type: r.type,
+    occasion: r.occasion,
     summary: `Total ${fmt(r.total)}`,
-    detail: `${r.settlements.length} settlement(s)`
+    detail: `${r.settlements.length} settlement(s)`,
   });
   showToast('Saved to history! 💾');
 });
@@ -996,9 +1148,10 @@ $('it-save').addEventListener('click', () => {
   const r = window._itResult;
   if (!r) return showToast('Calculate first!', 'error');
   saveHistory({
-    type: r.type, occasion: r.occasion,
+    type: r.type,
+    occasion: r.occasion,
     summary: `${r.items.length} items`,
-    detail: `${r.settlements.length} settlement(s)`
+    detail: `${r.settlements.length} settlement(s)`,
   });
   showToast('Saved to history! 💾');
 });
@@ -1022,7 +1175,16 @@ function generatePDF(title, lines, occasion = '') {
   doc.text('SplitWise Pro', margin, 14);
   doc.setFontSize(10);
   doc.setFont('helvetica', 'normal');
-  doc.text(new Date().toLocaleDateString('en-IN', { year: 'numeric', month: 'long', day: 'numeric' }), 210 - margin, 14, { align: 'right' });
+  doc.text(
+    new Date().toLocaleDateString('en-IN', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }),
+    210 - margin,
+    14,
+    { align: 'right' }
+  );
   if (occasion) {
     doc.setFontSize(11);
     doc.text(`Occasion: ${occasion}`, margin, 24);
@@ -1041,8 +1203,11 @@ function generatePDF(title, lines, occasion = '') {
 
   doc.setFont('helvetica', 'normal');
   doc.setFontSize(11);
-  lines.forEach(line => {
-    if (y > 270) { doc.addPage(); y = 20; }
+  lines.forEach((line) => {
+    if (y > 270) {
+      doc.addPage();
+      y = 20;
+    }
     if (line.type === 'header') {
       doc.setFont('helvetica', 'bold');
       doc.setFontSize(12);
@@ -1083,7 +1248,7 @@ $('eq-pdf').addEventListener('click', () => {
     { type: 'row', left: 'Grand Total', right: fmt(r.total) },
     { type: 'divider' },
     { type: 'header', text: 'Per Person Breakdown' },
-    ...r.names.map(n => ({ type: 'row', left: n, right: fmt(r.per) }))
+    ...r.names.map((n) => ({ type: 'row', left: n, right: fmt(r.per) })),
   ];
   generatePDF('Equal Split Summary', lines, r.occasion);
 });
@@ -1094,14 +1259,26 @@ $('uq-pdf').addEventListener('click', () => {
   const lines = [
     { type: 'header', text: 'Bill Summary' },
     { type: 'row', left: 'Subtotal', right: fmt(r.bill) },
-    { type: 'row', left: `Tip (${r.tipPct}%)`, right: fmt(r.bill * r.tipPct / 100) },
-    { type: 'row', left: `Tax (${r.taxPct}%)`, right: fmt(r.bill * r.taxPct / 100) },
+    {
+      type: 'row',
+      left: `Tip (${r.tipPct}%)`,
+      right: fmt((r.bill * r.tipPct) / 100),
+    },
+    {
+      type: 'row',
+      left: `Tax (${r.taxPct}%)`,
+      right: fmt((r.bill * r.taxPct) / 100),
+    },
     { type: 'row', left: 'Grand Total', right: fmt(r.total) },
     { type: 'divider' },
     { type: 'header', text: 'Settlement — Who Owes Whom' },
     ...(r.settlements.length
-      ? r.settlements.map(s => ({ type: 'row', left: `${s.from} → ${s.to}`, right: fmt(s.amount) }))
-      : [{ type: 'text', text: 'Everyone is square!' }])
+      ? r.settlements.map((s) => ({
+          type: 'row',
+          left: `${s.from} → ${s.to}`,
+          right: fmt(s.amount),
+        }))
+      : [{ type: 'text', text: 'Everyone is square!' }]),
   ];
   generatePDF('Custom Split Summary', lines, r.occasion);
 });
@@ -1111,15 +1288,25 @@ $('it-pdf').addEventListener('click', () => {
   if (!r) return showToast('Calculate first!', 'error');
   const lines = [
     { type: 'header', text: 'Items' },
-    ...r.items.map(i => ({ type: 'row', left: `${i.name} (${i.sharers.join(', ')})`, right: fmt(i.price) })),
+    ...r.items.map((i) => ({
+      type: 'row',
+      left: `${i.name} (${i.sharers.join(', ')})`,
+      right: fmt(i.price),
+    })),
     { type: 'divider' },
     { type: 'header', text: 'Per Person' },
-    ...Object.entries(r.totals).filter(([, d]) => d.total > 0).map(([n, d]) => ({ type: 'row', left: n, right: fmt(d.total) })),
+    ...Object.entries(r.totals)
+      .filter(([, d]) => d.total > 0)
+      .map(([n, d]) => ({ type: 'row', left: n, right: fmt(d.total) })),
     { type: 'divider' },
     { type: 'header', text: 'Settlement' },
     ...(r.settlements.length
-      ? r.settlements.map(s => ({ type: 'row', left: `${s.from} → ${s.to}`, right: fmt(s.amount) }))
-      : [{ type: 'text', text: 'Only one person!' }])
+      ? r.settlements.map((s) => ({
+          type: 'row',
+          left: `${s.from} → ${s.to}`,
+          right: fmt(s.amount),
+        }))
+      : [{ type: 'text', text: 'Only one person!' }]),
   ];
   generatePDF('Items Split Summary', lines, r.occasion);
 });
@@ -1128,18 +1315,20 @@ $('it-pdf').addEventListener('click', () => {
    QR SHARE
 ============================================================ */
 function showQR(summaryText) {
-  $('qrcode').innerHTML = '';             // clearing container — safe
+  $('qrcode').innerHTML = ''; // clearing container — safe
   const encoded = encodeURIComponent(summaryText);
   const url = `https://splitwise-pro.share/?data=${encoded.slice(0, 800)}`;
   // textContent — not rendered as HTML
-  $('qr-url-text').textContent = summaryText.slice(0, 120) + (summaryText.length > 120 ? '…' : '');
+  $('qr-url-text').textContent =
+    summaryText.slice(0, 120) + (summaryText.length > 120 ? '…' : '');
   try {
     new QRCode($('qrcode'), {
       text: url,
-      width: 220, height: 220,
+      width: 220,
+      height: 220,
       colorDark: '#1a1714',
       colorLight: '#ffffff',
-      correctLevel: QRCode.CorrectLevel.M
+      correctLevel: QRCode.CorrectLevel.M,
     });
   } catch (e) {
     const p = document.createElement('p');
@@ -1150,9 +1339,12 @@ function showQR(summaryText) {
   $('qrModalOverlay').classList.add('open');
 }
 
-$('closeQr').addEventListener('click', () => $('qrModalOverlay').classList.remove('open'));
-$('qrModalOverlay').addEventListener('click', e => {
-  if (e.target === $('qrModalOverlay')) $('qrModalOverlay').classList.remove('open');
+$('closeQr').addEventListener('click', () =>
+  $('qrModalOverlay').classList.remove('open')
+);
+$('qrModalOverlay').addEventListener('click', (e) => {
+  if (e.target === $('qrModalOverlay'))
+    $('qrModalOverlay').classList.remove('open');
 });
 
 $('eq-qr').addEventListener('click', () => {
@@ -1163,23 +1355,29 @@ $('eq-qr').addEventListener('click', () => {
     r.occasion ? r.occasion : '',
     `Total: ${fmt(r.total)}`,
     `People: ${r.names.join(', ')}`,
-    `Each pays: ${fmt(r.per)}`
-  ].filter(Boolean).join('\n');
+    `Each pays: ${fmt(r.per)}`,
+  ]
+    .filter(Boolean)
+    .join('\n');
   showQR(text);
 });
 
 $('uq-qr').addEventListener('click', () => {
   const r = window._uqResult;
   if (!r) return showToast('Calculate first!', 'error');
-  const lines = r.settlements.map(s => `${s.from} → ${s.to}: ${fmt(s.amount)}`).join('\n');
+  const lines = r.settlements
+    .map((s) => `${s.from} → ${s.to}: ${fmt(s.amount)}`)
+    .join('\n');
   const text = [
     'SplitWise Pro - Custom Split',
     r.occasion ? r.occasion : '',
     `Total: ${fmt(r.total)}`,
     '',
     'Settlement:',
-    lines || 'All square!'
-  ].filter(Boolean).join('\n');
+    lines || 'All square!',
+  ]
+    .filter(Boolean)
+    .join('\n');
   showQR(text);
 });
 
@@ -1188,33 +1386,37 @@ $('it-qr').addEventListener('click', () => {
   if (!r) return showToast('Calculate first!', 'error');
   const perPerson = Object.entries(r.totals)
     .filter(([, d]) => d.total > 0)
-    .map(([n, d]) => `${n}: ${fmt(d.total)}`).join('\n');
+    .map(([n, d]) => `${n}: ${fmt(d.total)}`)
+    .join('\n');
   const text = [
     'SplitWise Pro - Items Split',
     r.occasion ? r.occasion : '',
     '',
     'Per Person:',
-    perPerson
-  ].filter(Boolean).join('\n');
+    perPerson,
+  ]
+    .filter(Boolean)
+    .join('\n');
   showQR(text);
 });
 
 /* ============================================================
    INPUT VALIDATION — clamp negatives and over-max values
 ============================================================ */
-document.querySelectorAll('input[type="number"]').forEach(input => {
+document.querySelectorAll('input[type="number"]').forEach((input) => {
   input.addEventListener('input', () => {
     const val = parseFloat(input.value);
     if (isNaN(val)) return;
     if (val < 0) input.value = 0;
-    else if (input.max !== '' && val > parseFloat(input.max)) input.value = input.max;
+    else if (input.max !== '' && val > parseFloat(input.max))
+      input.value = input.max;
   });
 });
 
 /* ============================================================
    KEYBOARD SHORTCUTS
 ============================================================ */
-document.addEventListener('keydown', e => {
+document.addEventListener('keydown', (e) => {
   if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
     const activeTab = document.querySelector('.tab.active')?.dataset.tab;
     if (activeTab === 'equal') $('eq-calc').click();

--- a/public/Bill-Splitter/index.html
+++ b/public/Bill-Splitter/index.html
@@ -1,394 +1,579 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" data-theme="light">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>SplitWise Pro — Bill Splitter</title>
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Mono:wght@400;500&family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="style.css" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SplitWise Pro — Bill Splitter</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=DM+Mono:wght@400;500&family=Outfit:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+  </head>
+  <body>
+    <div class="noise-overlay"></div>
 
-  <div class="noise-overlay"></div>
-
-  <!-- Header -->
-  <header class="app-header">
-    <div class="header-inner">
-      <div class="logo">
-        <span class="logo-icon">÷</span>
-        <span class="logo-text">SplitWise<em>Pro</em></span>
-      </div>
-      <div class="header-actions">
-        <!-- Currency Switcher -->
-        <div class="currency-picker" id="currencyPicker">
-          <button class="btn-currency" id="currencyToggle" title="Switch currency">
-            <span id="currencySymbolDisplay">₹</span>
+    <!-- Header -->
+    <header class="app-header">
+      <div class="header-inner">
+        <div class="logo">
+          <span class="logo-icon">÷</span>
+          <span class="logo-text">SplitWise<em>Pro</em></span>
+        </div>
+        <div class="header-actions">
+          <!-- Currency Switcher -->
+          <div class="currency-picker" id="currencyPicker">
+            <button
+              class="btn-currency"
+              id="currencyToggle"
+              title="Switch currency"
+            >
+              <span id="currencySymbolDisplay">₹</span>
+            </button>
+            <div class="currency-dropdown" id="currencyDropdown">
+              <button
+                class="currency-opt active"
+                data-symbol="₹"
+                data-code="INR"
+              >
+                ₹ INR
+              </button>
+              <button class="currency-opt" data-symbol="$" data-code="USD">
+                $ USD
+              </button>
+              <button class="currency-opt" data-symbol="€" data-code="EUR">
+                € EUR
+              </button>
+              <button class="currency-opt" data-symbol="£" data-code="GBP">
+                £ GBP
+              </button>
+              <button class="currency-opt" data-symbol="¥" data-code="JPY">
+                ¥ JPY
+              </button>
+              <button class="currency-opt" data-symbol="A$" data-code="AUD">
+                A$ AUD
+              </button>
+            </div>
+          </div>
+          <button class="btn-icon" id="historyToggle" title="History">
+            <svg
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
           </button>
-          <div class="currency-dropdown" id="currencyDropdown">
-            <button class="currency-opt active" data-symbol="₹" data-code="INR">₹ INR</button>
-            <button class="currency-opt" data-symbol="$" data-code="USD">$ USD</button>
-            <button class="currency-opt" data-symbol="€" data-code="EUR">€ EUR</button>
-            <button class="currency-opt" data-symbol="£" data-code="GBP">£ GBP</button>
-            <button class="currency-opt" data-symbol="¥" data-code="JPY">¥ JPY</button>
-            <button class="currency-opt" data-symbol="A$" data-code="AUD">A$ AUD</button>
+          <button class="btn-icon" id="darkModeToggle" title="Toggle dark mode">
+            <svg
+              class="icon-sun"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <circle cx="12" cy="12" r="5" />
+              <path
+                d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"
+              />
+            </svg>
+            <svg
+              class="icon-moon"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <!-- Main Layout -->
+    <main class="app-main">
+      <!-- Tabs -->
+      <div class="tab-bar">
+        <button class="tab active" data-tab="equal">⚖️ Equal</button>
+        <button class="tab" data-tab="unequal">🎯 Custom</button>
+        <button class="tab" data-tab="items">🧾 Items</button>
+      </div>
+
+      <!-- ===== EQUAL SPLIT TAB ===== -->
+      <section class="tab-content active" id="tab-equal">
+        <div class="card">
+          <h2 class="card-title">Bill Details</h2>
+
+          <!-- Occasion Label -->
+          <div class="field">
+            <label>Occasion <span class="optional-tag">optional</span></label>
+            <input
+              type="text"
+              id="eq-occasion"
+              placeholder="e.g. Team Lunch, Birthday Dinner…"
+            />
+          </div>
+
+          <div class="field-row">
+            <div class="field">
+              <label>Total Bill</label>
+              <div class="input-prefix">
+                <span class="currency-label">₹</span>
+                <input
+                  type="number"
+                  id="eq-bill"
+                  min="0.01"
+                  step="0.01"
+                  placeholder="0.00"
+                />
+              </div>
+            </div>
+            <div class="field">
+              <label>Tip %</label>
+              <input
+                type="number"
+                id="eq-tip"
+                min="0"
+                max="100"
+                placeholder="0"
+                value="0"
+              />
+            </div>
+          </div>
+
+          <div class="tip-presets">
+            <button class="tip-btn" data-tip="5">5%</button>
+            <button class="tip-btn" data-tip="10">10%</button>
+            <button class="tip-btn" data-tip="15">15%</button>
+            <button class="tip-btn" data-tip="18">18%</button>
+            <button class="tip-btn" data-tip="20">20%</button>
+            <button class="tip-btn" data-tip="25">25%</button>
+          </div>
+
+          <!-- Tax Field -->
+          <div class="field-row">
+            <div class="field">
+              <label>Tax % <span class="optional-tag">GST/VAT</span></label>
+              <input
+                type="number"
+                id="eq-tax"
+                min="0"
+                max="100"
+                placeholder="0"
+                value="0"
+              />
+            </div>
+            <div class="field">
+              <label>Options</label>
+              <div class="toggle-row">
+                <label class="toggle-label">
+                  <input type="checkbox" id="eq-roundup" class="toggle-input" />
+                  <span class="toggle-track"></span>
+                  <span class="toggle-text">Round up</span>
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <div class="field">
+            <label>Participants</label>
+            <div class="participants-list" id="eq-participants">
+              <div class="participant-tag">
+                <input type="text" placeholder="Name" value="You" /><button
+                  class="remove-p"
+                >
+                  ×
+                </button>
+              </div>
+              <div class="participant-tag">
+                <input type="text" placeholder="Name" value="Friend" /><button
+                  class="remove-p"
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+            <button class="btn-add-p" id="eq-add-p">+ Add Person</button>
+          </div>
+
+          <button class="btn-primary" id="eq-calc">Calculate Split</button>
+        </div>
+
+        <div class="results-card" id="eq-results" style="display: none">
+          <div class="results-summary" id="eq-summary-grid">
+            <div class="summary-item">
+              <span class="summary-label">Subtotal</span>
+              <span class="summary-value" id="eq-subtotal">₹0</span>
+            </div>
+            <div class="summary-item">
+              <span class="summary-label">Tip</span>
+              <span class="summary-value" id="eq-tip-amt">₹0</span>
+            </div>
+            <div class="summary-item">
+              <span class="summary-label">Tax</span>
+              <span class="summary-value" id="eq-tax-amt">₹0</span>
+            </div>
+            <div class="summary-item total">
+              <span class="summary-label">Grand Total</span>
+              <span class="summary-value" id="eq-total">₹0</span>
+            </div>
+          </div>
+          <div class="per-person-hero">
+            <div class="per-label">Each Person Pays</div>
+            <div class="per-amount" id="eq-per-person">₹0.00</div>
+            <div class="per-occasion" id="eq-occasion-display"></div>
+          </div>
+
+          <!-- Payment Status Tracker -->
+          <div class="payment-status-section">
+            <div class="payment-status-header">
+              <span class="section-title" style="margin: 0"
+                >💳 Payment Status</span
+              >
+              <span class="paid-count" id="eq-paid-count">0 / 0 paid</span>
+            </div>
+            <div class="breakdown-list" id="eq-breakdown"></div>
+          </div>
+
+          <div class="result-actions">
+            <button class="btn-action" id="eq-pdf">📄 PDF</button>
+            <button class="btn-action" id="eq-qr">📲 QR</button>
+            <button class="btn-action" id="eq-copy">📋 Copy</button>
+            <button class="btn-action" id="eq-save">💾 Save</button>
           </div>
         </div>
-        <button class="btn-icon" id="historyToggle" title="History">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+      </section>
+
+      <!-- ===== UNEQUAL SPLIT TAB ===== -->
+      <section class="tab-content" id="tab-unequal">
+        <div class="card">
+          <h2 class="card-title">Custom Split</h2>
+
+          <div class="field">
+            <label>Occasion <span class="optional-tag">optional</span></label>
+            <input
+              type="text"
+              id="uq-occasion"
+              placeholder="e.g. Road Trip, House Party…"
+            />
+          </div>
+
+          <div class="field-row">
+            <div class="field">
+              <label>Total Bill</label>
+              <div class="input-prefix">
+                <span class="currency-label">₹</span>
+                <input
+                  type="number"
+                  id="uq-bill"
+                  min="0.01"
+                  step="0.01"
+                  placeholder="0.00"
+                />
+              </div>
+            </div>
+            <div class="field">
+              <label>Tip %</label>
+              <input
+                type="number"
+                id="uq-tip"
+                min="0"
+                max="100"
+                placeholder="0"
+                value="0"
+              />
+            </div>
+          </div>
+
+          <div class="tip-presets">
+            <button class="tip-btn" data-tip="5">5%</button>
+            <button class="tip-btn" data-tip="10">10%</button>
+            <button class="tip-btn" data-tip="15">15%</button>
+            <button class="tip-btn" data-tip="18">18%</button>
+            <button class="tip-btn" data-tip="20">20%</button>
+            <button class="tip-btn" data-tip="25">25%</button>
+          </div>
+
+          <div class="field-row">
+            <div class="field">
+              <label>Tax % <span class="optional-tag">GST/VAT</span></label>
+              <input
+                type="number"
+                id="uq-tax"
+                min="0"
+                max="100"
+                placeholder="0"
+                value="0"
+              />
+            </div>
+            <div class="field">
+              <label>&nbsp;</label>
+              <div class="toggle-row">
+                <label class="toggle-label">
+                  <input type="checkbox" id="uq-roundup" class="toggle-input" />
+                  <span class="toggle-track"></span>
+                  <span class="toggle-text">Round up</span>
+                </label>
+              </div>
+            </div>
+          </div>
+
+          <div class="field">
+            <label>Participants & Custom Amounts</label>
+            <div class="participants-list" id="uq-participants">
+              <div class="participant-row">
+                <input
+                  type="text"
+                  placeholder="Name"
+                  value="You"
+                  class="p-name"
+                />
+                <div class="input-prefix sm">
+                  <span class="currency-label">₹</span
+                  ><input
+                    type="number"
+                    placeholder="0.00"
+                    class="p-amount"
+                    min="0"
+                    step="0.01"
+                  />
+                </div>
+                <button class="remove-p">×</button>
+              </div>
+              <div class="participant-row">
+                <input
+                  type="text"
+                  placeholder="Name"
+                  value="Friend"
+                  class="p-name"
+                />
+                <div class="input-prefix sm">
+                  <span class="currency-label">₹</span
+                  ><input
+                    type="number"
+                    placeholder="0.00"
+                    class="p-amount"
+                    min="0"
+                    step="0.01"
+                  />
+                </div>
+                <button class="remove-p">×</button>
+              </div>
+            </div>
+            <button class="btn-add-p" id="uq-add-p">+ Add Person</button>
+          </div>
+
+          <div class="settle-info" id="uq-settle-info" style="display: none">
+            <span id="uq-remain-label"></span>
+          </div>
+
+          <!-- Live running total -->
+          <div class="running-total-bar" id="uq-running-bar">
+            <div
+              class="running-fill"
+              id="uq-running-fill"
+              style="width: 0%"
+            ></div>
+            <span class="running-label" id="uq-running-label">0% assigned</span>
+          </div>
+
+          <button class="btn-primary" id="uq-calc">Calculate & Settle</button>
+        </div>
+
+        <div class="results-card" id="uq-results" style="display: none">
+          <div class="results-summary" id="uq-summary-grid">
+            <div class="summary-item">
+              <span class="summary-label">Subtotal</span>
+              <span class="summary-value" id="uq-subtotal">₹0</span>
+            </div>
+            <div class="summary-item">
+              <span class="summary-label">Tip</span>
+              <span class="summary-value" id="uq-tip-display">₹0</span>
+            </div>
+            <div class="summary-item">
+              <span class="summary-label">Tax</span>
+              <span class="summary-value" id="uq-tax-display">₹0</span>
+            </div>
+            <div class="summary-item total">
+              <span class="summary-label">Grand Total</span>
+              <span class="summary-value" id="uq-total-display">₹0</span>
+            </div>
+          </div>
+          <h3 class="section-title">💸 Settlement — Who Owes Whom</h3>
+          <div class="settlement-list" id="uq-settlement"></div>
+          <div class="result-actions">
+            <button class="btn-action" id="uq-pdf">📄 PDF</button>
+            <button class="btn-action" id="uq-qr">📲 QR</button>
+            <button class="btn-action" id="uq-copy">📋 Copy</button>
+            <button class="btn-action" id="uq-save">💾 Save</button>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===== ITEMS TAB ===== -->
+      <section class="tab-content" id="tab-items">
+        <div class="card">
+          <h2 class="card-title">Split by Items</h2>
+
+          <div class="field">
+            <label>Occasion <span class="optional-tag">optional</span></label>
+            <input
+              type="text"
+              id="it-occasion"
+              placeholder="e.g. Groceries, Dinner…"
+            />
+          </div>
+
+          <div class="field">
+            <label>Participants</label>
+            <div class="participants-list" id="it-participants">
+              <div class="participant-tag">
+                <input type="text" placeholder="Name" value="You" /><button
+                  class="remove-p"
+                >
+                  ×
+                </button>
+              </div>
+              <div class="participant-tag">
+                <input type="text" placeholder="Name" value="Friend" /><button
+                  class="remove-p"
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+            <button class="btn-add-p" id="it-add-p">+ Add Person</button>
+          </div>
+
+          <div class="field-row">
+            <div class="field">
+              <label>Tip %</label>
+              <input
+                type="number"
+                id="it-tip"
+                min="0"
+                max="100"
+                placeholder="0"
+                value="0"
+              />
+            </div>
+            <div class="field">
+              <label>Tax % <span class="optional-tag">GST/VAT</span></label>
+              <input
+                type="number"
+                id="it-tax"
+                min="0"
+                max="100"
+                placeholder="0"
+                value="0"
+              />
+            </div>
+          </div>
+          <div class="tip-presets">
+            <button class="tip-btn" data-tip="5">5%</button>
+            <button class="tip-btn" data-tip="10">10%</button>
+            <button class="tip-btn" data-tip="15">15%</button>
+            <button class="tip-btn" data-tip="18">18%</button>
+            <button class="tip-btn" data-tip="20">20%</button>
+            <button class="tip-btn" data-tip="25">25%</button>
+          </div>
+
+          <div class="field">
+            <div class="items-header-row">
+              <label style="margin: 0">Items</label>
+              <button
+                class="btn-bulk-paste"
+                id="it-bulk-paste"
+                title="Paste items list"
+              >
+                📋 Bulk Add
+              </button>
+            </div>
+            <div class="items-list" id="it-items"></div>
+            <button class="btn-add-p" id="it-add-item">+ Add Item</button>
+          </div>
+
+          <!-- Live subtotal for items -->
+          <div class="items-live-total" id="it-live-total">
+            Items total: <strong id="it-live-amount">₹0.00</strong>
+          </div>
+
+          <button class="btn-primary" id="it-calc">Calculate by Items</button>
+        </div>
+
+        <div class="results-card" id="it-results" style="display: none">
+          <h3 class="section-title">🧾 Per Person Breakdown</h3>
+          <div class="per-person-items" id="it-breakdown"></div>
+          <div class="settlement-list" id="it-settlement"></div>
+          <div class="result-actions">
+            <button class="btn-action" id="it-pdf">📄 PDF</button>
+            <button class="btn-action" id="it-qr">📲 QR</button>
+            <button class="btn-action" id="it-copy">📋 Copy</button>
+            <button class="btn-action" id="it-save">💾 Save</button>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Sticky Calculate Bar (mobile) -->
+    <div class="sticky-calc-bar" id="stickyCalcBar" style="display: none">
+      <div class="sticky-total" id="stickyTotal">Total: ₹0.00</div>
+      <button class="sticky-calc-btn" id="stickyCalcBtn">Calculate →</button>
+    </div>
+
+    <!-- History Drawer -->
+    <div class="drawer-overlay" id="drawerOverlay"></div>
+    <aside class="history-drawer" id="historyDrawer">
+      <div class="drawer-header">
+        <h3>Split History</h3>
+        <button class="btn-icon" id="closeDrawer">×</button>
+      </div>
+      <div class="history-list" id="historyList"></div>
+      <button class="btn-danger" id="clearHistory">🗑 Clear All History</button>
+    </aside>
+
+    <!-- QR Modal -->
+    <div class="modal-overlay" id="qrModalOverlay">
+      <div class="modal">
+        <div class="modal-header">
+          <h3>📲 Share via QR</h3>
+          <button class="btn-icon" id="closeQr">×</button>
+        </div>
+        <p class="modal-sub">Scan to view the split summary</p>
+        <div id="qrcode"></div>
+        <p class="qr-url" id="qr-url-text"></p>
+      </div>
+    </div>
+
+    <!-- Bulk Paste Modal -->
+    <div class="modal-overlay" id="bulkModalOverlay">
+      <div class="modal">
+        <div class="modal-header">
+          <h3>📋 Bulk Add Items</h3>
+          <button class="btn-icon" id="closeBulk">×</button>
+        </div>
+        <p class="modal-sub">
+          One item per line: <code>Item Name, Price</code>
+        </p>
+        <textarea
+          id="bulkPasteArea"
+          placeholder="Butter Chicken, 350&#10;Naan x3, 90&#10;Lassi, 120"
+          rows="8"
+        ></textarea>
+        <button class="btn-primary" id="bulkAddBtn" style="margin-top: 12px">
+          Add Items
         </button>
-        <button class="btn-icon" id="darkModeToggle" title="Toggle dark mode">
-          <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="5"/><path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
-          <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
-        </button>
       </div>
     </div>
-  </header>
 
-  <!-- Main Layout -->
-  <main class="app-main">
+    <!-- Toast -->
+    <div class="toast" id="toast"></div>
 
-    <!-- Tabs -->
-    <div class="tab-bar">
-      <button class="tab active" data-tab="equal">⚖️ Equal</button>
-      <button class="tab" data-tab="unequal">🎯 Custom</button>
-      <button class="tab" data-tab="items">🧾 Items</button>
-    </div>
-
-    <!-- ===== EQUAL SPLIT TAB ===== -->
-    <section class="tab-content active" id="tab-equal">
-      <div class="card">
-        <h2 class="card-title">Bill Details</h2>
-
-        <!-- Occasion Label -->
-        <div class="field">
-          <label>Occasion <span class="optional-tag">optional</span></label>
-          <input type="text" id="eq-occasion" placeholder="e.g. Team Lunch, Birthday Dinner…" />
-        </div>
-
-        <div class="field-row">
-          <div class="field">
-            <label>Total Bill</label>
-            <div class="input-prefix">
-              <span class="currency-label">₹</span>
-              <input type="number" id="eq-bill" min="0.01" step="0.01" placeholder="0.00" />
-            </div>
-          </div>
-          <div class="field">
-            <label>Tip %</label>
-            <input type="number" id="eq-tip" min="0" max="100" placeholder="0" value="0" />
-          </div>
-        </div>
-
-        <div class="tip-presets">
-          <button class="tip-btn" data-tip="5">5%</button>
-          <button class="tip-btn" data-tip="10">10%</button>
-          <button class="tip-btn" data-tip="15">15%</button>
-          <button class="tip-btn" data-tip="18">18%</button>
-          <button class="tip-btn" data-tip="20">20%</button>
-          <button class="tip-btn" data-tip="25">25%</button>
-        </div>
-
-        <!-- Tax Field -->
-        <div class="field-row">
-          <div class="field">
-            <label>Tax % <span class="optional-tag">GST/VAT</span></label>
-            <input type="number" id="eq-tax" min="0" max="100" placeholder="0" value="0" />
-          </div>
-          <div class="field">
-            <label>Options</label>
-            <div class="toggle-row">
-              <label class="toggle-label">
-                <input type="checkbox" id="eq-roundup" class="toggle-input" />
-                <span class="toggle-track"></span>
-                <span class="toggle-text">Round up</span>
-              </label>
-            </div>
-          </div>
-        </div>
-
-        <div class="field">
-          <label>Participants</label>
-          <div class="participants-list" id="eq-participants">
-            <div class="participant-tag"><input type="text" placeholder="Name" value="You" /><button class="remove-p">×</button></div>
-            <div class="participant-tag"><input type="text" placeholder="Name" value="Friend" /><button class="remove-p">×</button></div>
-          </div>
-          <button class="btn-add-p" id="eq-add-p">+ Add Person</button>
-        </div>
-
-        <button class="btn-primary" id="eq-calc">Calculate Split</button>
-      </div>
-
-      <div class="results-card" id="eq-results" style="display:none">
-        <div class="results-summary" id="eq-summary-grid">
-          <div class="summary-item">
-            <span class="summary-label">Subtotal</span>
-            <span class="summary-value" id="eq-subtotal">₹0</span>
-          </div>
-          <div class="summary-item">
-            <span class="summary-label">Tip</span>
-            <span class="summary-value" id="eq-tip-amt">₹0</span>
-          </div>
-          <div class="summary-item">
-            <span class="summary-label">Tax</span>
-            <span class="summary-value" id="eq-tax-amt">₹0</span>
-          </div>
-          <div class="summary-item total">
-            <span class="summary-label">Grand Total</span>
-            <span class="summary-value" id="eq-total">₹0</span>
-          </div>
-        </div>
-        <div class="per-person-hero">
-          <div class="per-label">Each Person Pays</div>
-          <div class="per-amount" id="eq-per-person">₹0.00</div>
-          <div class="per-occasion" id="eq-occasion-display"></div>
-        </div>
-
-        <!-- Payment Status Tracker -->
-        <div class="payment-status-section">
-          <div class="payment-status-header">
-            <span class="section-title" style="margin:0">💳 Payment Status</span>
-            <span class="paid-count" id="eq-paid-count">0 / 0 paid</span>
-          </div>
-          <div class="breakdown-list" id="eq-breakdown"></div>
-        </div>
-
-        <div class="result-actions">
-          <button class="btn-action" id="eq-pdf">📄 PDF</button>
-          <button class="btn-action" id="eq-qr">📲 QR</button>
-          <button class="btn-action" id="eq-copy">📋 Copy</button>
-          <button class="btn-action" id="eq-save">💾 Save</button>
-        </div>
-      </div>
-    </section>
-
-    <!-- ===== UNEQUAL SPLIT TAB ===== -->
-    <section class="tab-content" id="tab-unequal">
-      <div class="card">
-        <h2 class="card-title">Custom Split</h2>
-
-        <div class="field">
-          <label>Occasion <span class="optional-tag">optional</span></label>
-          <input type="text" id="uq-occasion" placeholder="e.g. Road Trip, House Party…" />
-        </div>
-
-        <div class="field-row">
-          <div class="field">
-            <label>Total Bill</label>
-            <div class="input-prefix"><span class="currency-label">₹</span>
-              <input type="number" id="uq-bill" min="0.01" step="0.01" placeholder="0.00" />
-            </div>
-          </div>
-          <div class="field">
-            <label>Tip %</label>
-            <input type="number" id="uq-tip" min="0" max="100" placeholder="0" value="0" />
-          </div>
-        </div>
-
-        <div class="tip-presets">
-          <button class="tip-btn" data-tip="5">5%</button>
-          <button class="tip-btn" data-tip="10">10%</button>
-          <button class="tip-btn" data-tip="15">15%</button>
-          <button class="tip-btn" data-tip="18">18%</button>
-          <button class="tip-btn" data-tip="20">20%</button>
-          <button class="tip-btn" data-tip="25">25%</button>
-        </div>
-
-        <div class="field-row">
-          <div class="field">
-            <label>Tax % <span class="optional-tag">GST/VAT</span></label>
-            <input type="number" id="uq-tax" min="0" max="100" placeholder="0" value="0" />
-          </div>
-          <div class="field">
-            <label>&nbsp;</label>
-            <div class="toggle-row">
-              <label class="toggle-label">
-                <input type="checkbox" id="uq-roundup" class="toggle-input" />
-                <span class="toggle-track"></span>
-                <span class="toggle-text">Round up</span>
-              </label>
-            </div>
-          </div>
-        </div>
-
-        <div class="field">
-          <label>Participants & Custom Amounts</label>
-          <div class="participants-list" id="uq-participants">
-            <div class="participant-row">
-              <input type="text" placeholder="Name" value="You" class="p-name" />
-              <div class="input-prefix sm"><span class="currency-label">₹</span><input type="number" placeholder="0.00" class="p-amount" min="0" step="0.01" /></div>
-              <button class="remove-p">×</button>
-            </div>
-            <div class="participant-row">
-              <input type="text" placeholder="Name" value="Friend" class="p-name" />
-              <div class="input-prefix sm"><span class="currency-label">₹</span><input type="number" placeholder="0.00" class="p-amount" min="0" step="0.01" /></div>
-              <button class="remove-p">×</button>
-            </div>
-          </div>
-          <button class="btn-add-p" id="uq-add-p">+ Add Person</button>
-        </div>
-
-        <div class="settle-info" id="uq-settle-info" style="display:none">
-          <span id="uq-remain-label"></span>
-        </div>
-
-        <!-- Live running total -->
-        <div class="running-total-bar" id="uq-running-bar">
-          <div class="running-fill" id="uq-running-fill" style="width:0%"></div>
-          <span class="running-label" id="uq-running-label">0% assigned</span>
-        </div>
-
-        <button class="btn-primary" id="uq-calc">Calculate & Settle</button>
-      </div>
-
-      <div class="results-card" id="uq-results" style="display:none">
-        <div class="results-summary" id="uq-summary-grid">
-          <div class="summary-item">
-            <span class="summary-label">Subtotal</span>
-            <span class="summary-value" id="uq-subtotal">₹0</span>
-          </div>
-          <div class="summary-item">
-            <span class="summary-label">Tip</span>
-            <span class="summary-value" id="uq-tip-display">₹0</span>
-          </div>
-          <div class="summary-item">
-            <span class="summary-label">Tax</span>
-            <span class="summary-value" id="uq-tax-display">₹0</span>
-          </div>
-          <div class="summary-item total">
-            <span class="summary-label">Grand Total</span>
-            <span class="summary-value" id="uq-total-display">₹0</span>
-          </div>
-        </div>
-        <h3 class="section-title">💸 Settlement — Who Owes Whom</h3>
-        <div class="settlement-list" id="uq-settlement"></div>
-        <div class="result-actions">
-          <button class="btn-action" id="uq-pdf">📄 PDF</button>
-          <button class="btn-action" id="uq-qr">📲 QR</button>
-          <button class="btn-action" id="uq-copy">📋 Copy</button>
-          <button class="btn-action" id="uq-save">💾 Save</button>
-        </div>
-      </div>
-    </section>
-
-    <!-- ===== ITEMS TAB ===== -->
-    <section class="tab-content" id="tab-items">
-      <div class="card">
-        <h2 class="card-title">Split by Items</h2>
-
-        <div class="field">
-          <label>Occasion <span class="optional-tag">optional</span></label>
-          <input type="text" id="it-occasion" placeholder="e.g. Groceries, Dinner…" />
-        </div>
-
-        <div class="field">
-          <label>Participants</label>
-          <div class="participants-list" id="it-participants">
-            <div class="participant-tag"><input type="text" placeholder="Name" value="You" /><button class="remove-p">×</button></div>
-            <div class="participant-tag"><input type="text" placeholder="Name" value="Friend" /><button class="remove-p">×</button></div>
-          </div>
-          <button class="btn-add-p" id="it-add-p">+ Add Person</button>
-        </div>
-
-        <div class="field-row">
-          <div class="field">
-            <label>Tip %</label>
-            <input type="number" id="it-tip" min="0" max="100" placeholder="0" value="0" />
-          </div>
-          <div class="field">
-            <label>Tax % <span class="optional-tag">GST/VAT</span></label>
-            <input type="number" id="it-tax" min="0" max="100" placeholder="0" value="0" />
-          </div>
-        </div>
-        <div class="tip-presets">
-          <button class="tip-btn" data-tip="5">5%</button>
-          <button class="tip-btn" data-tip="10">10%</button>
-          <button class="tip-btn" data-tip="15">15%</button>
-          <button class="tip-btn" data-tip="18">18%</button>
-          <button class="tip-btn" data-tip="20">20%</button>
-          <button class="tip-btn" data-tip="25">25%</button>
-        </div>
-
-        <div class="field">
-          <div class="items-header-row">
-            <label style="margin:0">Items</label>
-            <button class="btn-bulk-paste" id="it-bulk-paste" title="Paste items list">📋 Bulk Add</button>
-          </div>
-          <div class="items-list" id="it-items"></div>
-          <button class="btn-add-p" id="it-add-item">+ Add Item</button>
-        </div>
-
-        <!-- Live subtotal for items -->
-        <div class="items-live-total" id="it-live-total">
-          Items total: <strong id="it-live-amount">₹0.00</strong>
-        </div>
-
-        <button class="btn-primary" id="it-calc">Calculate by Items</button>
-      </div>
-
-      <div class="results-card" id="it-results" style="display:none">
-        <h3 class="section-title">🧾 Per Person Breakdown</h3>
-        <div class="per-person-items" id="it-breakdown"></div>
-        <div class="settlement-list" id="it-settlement"></div>
-        <div class="result-actions">
-          <button class="btn-action" id="it-pdf">📄 PDF</button>
-          <button class="btn-action" id="it-qr">📲 QR</button>
-          <button class="btn-action" id="it-copy">📋 Copy</button>
-          <button class="btn-action" id="it-save">💾 Save</button>
-        </div>
-      </div>
-    </section>
-
-  </main>
-
-  <!-- Sticky Calculate Bar (mobile) -->
-  <div class="sticky-calc-bar" id="stickyCalcBar" style="display:none">
-    <div class="sticky-total" id="stickyTotal">Total: ₹0.00</div>
-    <button class="sticky-calc-btn" id="stickyCalcBtn">Calculate →</button>
-  </div>
-
-  <!-- History Drawer -->
-  <div class="drawer-overlay" id="drawerOverlay"></div>
-  <aside class="history-drawer" id="historyDrawer">
-    <div class="drawer-header">
-      <h3>Split History</h3>
-      <button class="btn-icon" id="closeDrawer">×</button>
-    </div>
-    <div class="history-list" id="historyList"></div>
-    <button class="btn-danger" id="clearHistory">🗑 Clear All History</button>
-  </aside>
-
-  <!-- QR Modal -->
-  <div class="modal-overlay" id="qrModalOverlay">
-    <div class="modal">
-      <div class="modal-header">
-        <h3>📲 Share via QR</h3>
-        <button class="btn-icon" id="closeQr">×</button>
-      </div>
-      <p class="modal-sub">Scan to view the split summary</p>
-      <div id="qrcode"></div>
-      <p class="qr-url" id="qr-url-text"></p>
-    </div>
-  </div>
-
-  <!-- Bulk Paste Modal -->
-  <div class="modal-overlay" id="bulkModalOverlay">
-    <div class="modal">
-      <div class="modal-header">
-        <h3>📋 Bulk Add Items</h3>
-        <button class="btn-icon" id="closeBulk">×</button>
-      </div>
-      <p class="modal-sub">One item per line: <code>Item Name, Price</code></p>
-      <textarea id="bulkPasteArea" placeholder="Butter Chicken, 350&#10;Naan x3, 90&#10;Lassi, 120" rows="8"></textarea>
-      <button class="btn-primary" id="bulkAddBtn" style="margin-top:12px">Add Items</button>
-    </div>
-  </div>
-
-  <!-- Toast -->
-  <div class="toast" id="toast"></div>
-
-  <script src="app.js"></script>
-</body>
+    <script src="app.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
## Pull Request Description

### Related Issue

Closes #8982

### Summary

This PR fixes an issue in the Equal Split module where payment statuses were reset whenever the split was recalculated. Previously, users had to manually mark participants as paid again after updating bill details and recalculating the split.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added persistent storage for participant payment states using `eqPaidState`.
- Preserved paid/unpaid statuses during recalculation.
- Restored existing payment states when rebuilding the payment tracker UI.
- Updated stored payment data whenever a participant's payment status changes.
- Removed obsolete payment records when participants are removed.

## Testing and Verification

### Local Validation

- [x] Application runs without errors.
- [x] Payment status persists after recalculation.

### Browser Compatibility Check

- [x] Tested and verified in Google Chrome.

### Manual Testing

- [x] Created an equal split.
- [x] Marked participants as paid.
- [x] Updated bill amount, tip, and tax values.
- [x] Recalculated the split.
- [x] Verified payment statuses remained unchanged.
- [x] Removed participants and verified stale records were cleared.


## Contributor Checklist

- [x] My code follows the project coding standards.
- [x] I have performed a self-review of my changes.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes included in this PR.

### Result

Payment statuses are now retained across Equal Split recalculations, improving usability and preventing users from repeatedly marking completed payments.