### PR TITLE
fix(connect4): cancel pending AI move on game reset

### DIFF
--- a/public/Connect4/src/App.jsx
+++ b/public/Connect4/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { motion } from "framer-motion";
 
 const ROWS = 6;
@@ -15,6 +15,16 @@ export default function App() {
   const [winner, setWinner] = useState(null);
   const [gameMode, setGameMode] = useState("pvp");
   const [aiThinking, setAiThinking] = useState(false);
+
+  const aiTimeoutRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (aiTimeoutRef.current) {
+        clearTimeout(aiTimeoutRef.current);
+      }
+    };
+  }, []);
 
   const checkWinner = (grid, row, col, color) => {
     const directions = [
@@ -107,7 +117,11 @@ export default function App() {
     ) {
       setAiThinking(true);
 
-      setTimeout(() => {
+      if (aiTimeoutRef.current) {
+        clearTimeout(aiTimeoutRef.current);
+      }
+
+      aiTimeoutRef.current = setTimeout(() => {
         aiMove(newBoard);
         setAiThinking(false);
       }, 500);
@@ -193,6 +207,10 @@ export default function App() {
   };
 
   const resetGame = () => {
+    if (aiTimeoutRef.current) {
+      clearTimeout(aiTimeoutRef.current);
+      aiTimeoutRef.current = null;
+    }
     setBoard(createBoard());
     setWinner(null);
     setPlayer("red");


### PR DESCRIPTION
## Related Issue

Closes #8634

## Description

This PR fixes a race condition in Connect4 VS AI mode where a pending AI move could execute after the game was restarted.

The AI turn was scheduled using a delayed timeout. If the user restarted the game before the timeout completed, the callback still executed using stale board state and restored a partially played game.

## Changes Made

* Added timeout tracking using React `useRef`.
* Cleared pending AI timeout during game reset.
* Added cleanup on component unmount.
* Preserved existing AI behavior and gameplay flow.

## Root Cause

The AI move was scheduled through `setTimeout()` and captured a stale board snapshot in its closure. Restarting the game reset the board state, but the timeout callback remained active and later overwrote the fresh state with the stale board.

## Verification

* Restart immediately after making a move → board remains empty.
* Normal AI turns still execute correctly.
* Repeated restarts no longer restore stale board state.
* No regressions observed in normal gameplay.

## Type of Change

* [x] Bug Fix

## Checklist

* [x] Tested locally
* [x] Fixes the reported issue
* [x] No unrelated files modified
