### PR TITLE
fix(time-capsule): preserve revealed capsules after refresh

### DIFF
--- a/public/Time-Capsule/script.js
+++ b/public/Time-Capsule/script.js
@@ -61,17 +61,27 @@ document.addEventListener('DOMContentLoaded', () => {
   function checkCapsules() {
     const capsules = getCapsules();
     const now = Date.now();
+    let stateChanged = false;
+    let newlyRevealed = false;
 
-    const dueCapsules = capsules.filter((capsule) => now >= capsule.revealAt);
+    capsules.forEach((capsule) => {
+      if (now >= capsule.revealAt && !capsule.revealed) {
+        capsule.revealed = true;
+        stateChanged = true;
+        newlyRevealed = true;
+      }
+    });
 
-    const pendingCapsules = capsules.filter(
-      (capsule) => now < capsule.revealAt
-    );
+    if (stateChanged) {
+      saveCapsules(capsules);
+    }
 
-    if (dueCapsules.length > 0) {
+    const revealedCapsules = capsules.filter((capsule) => capsule.revealed);
+
+    if (revealedCapsules.length > 0) {
       revealedMessage.innerHTML = '';
 
-      dueCapsules.forEach((capsule, index) => {
+      revealedCapsules.forEach((capsule, index) => {
         const wrapper = document.createElement('div');
 
         const title = document.createElement('strong');
@@ -87,15 +97,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
         revealedMessage.appendChild(wrapper);
 
-        if (index < dueCapsules.length - 1) {
+        if (index < revealedCapsules.length - 1) {
           revealedMessage.appendChild(document.createElement('hr'));
         }
       });
 
-      messageReveal.classList.remove('hidden');
-      capsuleReveal.classList.add('hidden');
-
-      saveCapsules(pendingCapsules);
+      if (newlyRevealed || capsuleReveal.classList.contains('hidden')) {
+        messageReveal.classList.remove('hidden');
+        capsuleReveal.classList.add('hidden');
+      }
     }
   }
 
@@ -129,6 +139,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const newCapsule = {
       message,
       revealAt,
+      revealed: false,
     };
 
     const capsules = getCapsules();


### PR DESCRIPTION
## Related Issue

Closes #8635

---

## Description

This PR fixes a data-loss issue in the Time Capsule project where revealed capsules were permanently removed from localStorage immediately after being opened.

Previously:

* Capsules reaching their reveal date were displayed once.
* Revealed capsules were removed from localStorage.
* Refreshing the page caused revealed messages to disappear permanently.
* Users could not access previously revealed capsules again.

### Fix Implemented

* Added a `revealed` flag to capsule objects.
* Revealed capsules are now marked as revealed instead of being deleted.
* The complete capsule collection is preserved in localStorage.
* Previously revealed capsules are rendered again after page reload.
* Newly revealed capsules continue to appear automatically when their reveal time is reached.

### Benefits

* Prevents irreversible user data loss.
* Preserves revealed messages across refreshes and navigation.
* Maintains expected Time Capsule behavior while keeping historical messages accessible.

---

## Verification

### Tested

1. Created a capsule with a short reveal time.
2. Waited for the capsule to reveal.
3. Refreshed the page.
4. Confirmed the revealed message remained visible.
5. Created an additional capsule.
6. Verified countdown behavior remained functional.
7. Waited for the second capsule to reveal.
8. Confirmed both revealed capsules were displayed correctly.

### Result

✅ Revealed capsules persist after refresh

✅ No user data loss

✅ Existing countdown functionality remains intact
