### PR TITLE
fix: prevent duplicate attendance history records on recalculation

### DIFF
--- a/public/attendencePridictor/app.js
+++ b/public/attendencePridictor/app.js
@@ -119,7 +119,8 @@ function calculate(data) {
   const classesToTarget = calcClassesToTarget(attended, total, targetPercent);
   const futurePercent = predictFutureAttendance(attended, total, futureMisses);
   const status = getStatus(currentPercent, minPercent);
-  const shortage = currentPercent < minPercent ? (minPercent - currentPercent).toFixed(1) : 0;
+  const shortage =
+    currentPercent < minPercent ? (minPercent - currentPercent).toFixed(1) : 0;
 
   return {
     currentPercent,
@@ -143,8 +144,10 @@ function updateMeter(percent, status) {
   const offset = CIRCUMFERENCE - (percent / 100) * CIRCUMFERENCE;
   els.meterProgress.style.strokeDashoffset = offset;
   els.meterProgress.className = 'meter__progress';
-  if (status === 'warning') els.meterProgress.classList.add('meter__progress--warning');
-  if (status === 'danger') els.meterProgress.classList.add('meter__progress--danger');
+  if (status === 'warning')
+    els.meterProgress.classList.add('meter__progress--warning');
+  if (status === 'danger')
+    els.meterProgress.classList.add('meter__progress--danger');
 
   els.currentPercent.textContent = `${percent.toFixed(1)}%`;
   els.attendanceStatus.textContent = getStatusLabel(status);
@@ -158,9 +161,10 @@ function renderResults(result) {
   updateMeter(result.currentPercent, result.status);
 
   els.safeBunks.textContent = `${result.safeBunks} Classes`;
-  els.safeBunksHint.textContent = result.safeBunks > 0
-    ? `You can miss up to ${result.safeBunks} more class${result.safeBunks !== 1 ? 'es' : ''} and stay above ${result.minPercent}%`
-    : 'No safe bunks remaining — attend every class!';
+  els.safeBunksHint.textContent =
+    result.safeBunks > 0
+      ? `You can miss up to ${result.safeBunks} more class${result.safeBunks !== 1 ? 'es' : ''} and stay above ${result.minPercent}%`
+      : 'No safe bunks remaining — attend every class!';
 
   if (result.shortage > 0) {
     els.shortageCard.classList.add('stat-card--danger-border');
@@ -177,7 +181,8 @@ function renderResults(result) {
     els.recoveryHint.textContent = `Attend ${result.classesNeeded} more without missing any to reach ${result.minPercent}%`;
   } else {
     els.classesNeeded.textContent = '0 Classes';
-    els.recoveryHint.textContent = 'You meet the minimum attendance requirement';
+    els.recoveryHint.textContent =
+      'You meet the minimum attendance requirement';
   }
 
   if (result.futureMisses > 0) {
@@ -187,7 +192,8 @@ function renderResults(result) {
       `your attendance will drop to ${result.futurePercent.toFixed(1)}%` +
       (drop > 0 ? ` (−${drop.toFixed(1)}%)` : '');
   } else {
-    els.futurePrediction.textContent = 'Enter future misses above to see a prediction';
+    els.futurePrediction.textContent =
+      'Enter future misses above to see a prediction';
   }
 
   if (result.targetPercent && result.targetPercent > 0) {
@@ -239,7 +245,9 @@ function loadForm() {
     els.minAttendance.value = data.minPercent ?? 75;
     els.targetAttendance.value = data.targetPercent || '';
     els.futureMisses.value = data.futureMisses ?? 0;
-  } catch { /* ignore corrupt data */ }
+  } catch {
+    /* ignore corrupt data */
+  }
 }
 
 function getSubjects() {
@@ -264,13 +272,29 @@ function getHistory() {
 
 function addHistoryEntry(result) {
   const history = getHistory();
+
+  const lastEntry = history[history.length - 1];
+
+  if (
+    lastEntry &&
+    lastEntry.total === result.total &&
+    lastEntry.attended === result.attended &&
+    Math.abs(lastEntry.percent - result.currentPercent) < 0.01
+  ) {
+    return;
+  }
+
   history.push({
     date: new Date().toISOString(),
     percent: result.currentPercent,
     total: result.total,
     attended: result.attended,
   });
-  if (history.length > 30) history.shift();
+
+  if (history.length > 30) {
+    history.shift();
+  }
+
   localStorage.setItem(STORAGE_KEYS.history, JSON.stringify(history));
 }
 
@@ -311,10 +335,12 @@ function renderSubjects() {
       loadSubject(sub);
     });
 
-    item.querySelector('[data-action="delete"]').addEventListener('click', (e) => {
-      e.stopPropagation();
-      deleteSubject(index);
-    });
+    item
+      .querySelector('[data-action="delete"]')
+      .addEventListener('click', (e) => {
+        e.stopPropagation();
+        deleteSubject(index);
+      });
 
     els.subjectsList.appendChild(item);
   });
@@ -386,7 +412,11 @@ function renderOverviewChart(subjects, colors) {
   const data = subjects.map((s) => calcAttendance(s.attended, s.total));
   const bgColors = data.map((p, i) => {
     const status = getStatus(p, subjects[i].minPercent);
-    return status === 'safe' ? colors.safe : status === 'warning' ? colors.warning : colors.danger;
+    return status === 'safe'
+      ? colors.safe
+      : status === 'warning'
+        ? colors.warning
+        : colors.danger;
   });
 
   if (overviewChart) overviewChart.destroy();
@@ -395,13 +425,15 @@ function renderOverviewChart(subjects, colors) {
     type: 'bar',
     data: {
       labels,
-      datasets: [{
-        label: 'Attendance %',
-        data,
-        backgroundColor: bgColors,
-        borderRadius: 8,
-        borderSkipped: false,
-      }],
+      datasets: [
+        {
+          label: 'Attendance %',
+          data,
+          backgroundColor: bgColors,
+          borderRadius: 8,
+          borderSkipped: false,
+        },
+      ],
     },
     options: {
       responsive: true,
@@ -476,15 +508,17 @@ function renderTrendChart(subjects, history, colors) {
       type: 'line',
       data: {
         labels,
-        datasets: [{
-          label: 'Attendance %',
-          data,
-          borderColor: colors.primary,
-          backgroundColor: colors.primary + '33',
-          fill: true,
-          tension: 0.3,
-          pointRadius: 4,
-        }],
+        datasets: [
+          {
+            label: 'Attendance %',
+            data,
+            borderColor: colors.primary,
+            backgroundColor: colors.primary + '33',
+            fill: true,
+            tension: 0.3,
+            pointRadius: 4,
+          },
+        ],
       },
       options: chartLineOptions(colors, true),
     });
@@ -534,14 +568,21 @@ function initTheme() {
 
 /* ===== Event Handlers ===== */
 
-function handleCalculate(e) {
+function handleCalculate(e, saveHistory = true) {
   if (e) e.preventDefault();
+
   const data = getFormData();
+
   if (!validateForm(data)) return;
 
   const result = calculate(data);
+
   renderResults(result);
-  addHistoryEntry(result);
+
+  if (saveHistory) {
+    addHistoryEntry(result);
+  }
+
   saveForm();
   updateCharts();
 }
@@ -561,7 +602,9 @@ function handleSubjectSubmit(e) {
   const data = getFormData();
   const subjects = getSubjects();
 
-  const existing = subjects.findIndex((s) => s.name.toLowerCase() === name.toLowerCase());
+  const existing = subjects.findIndex(
+    (s) => s.name.toLowerCase() === name.toLowerCase()
+  );
   const entry = {
     name,
     total: data.total,
@@ -607,9 +650,17 @@ function init() {
   els.cancelSubject.addEventListener('click', () => els.subjectModal.close());
   els.clearSubjects.addEventListener('click', handleClearSubjects);
 
-  ['totalClasses', 'classesAttended', 'minAttendance', 'targetAttendance', 'futureMisses'].forEach((id) => {
+  [
+    'totalClasses',
+    'classesAttended',
+    'minAttendance',
+    'targetAttendance',
+    'futureMisses',
+  ].forEach((id) => {
     document.getElementById(id).addEventListener('input', () => {
-      if (lastResult) handleCalculate();
+      if (lastResult) {
+        handleCalculate(null, false);
+      }
     });
   });
 

--- a/public/attendencePridictor/index.html
+++ b/public/attendencePridictor/index.html
@@ -1,171 +1,248 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" data-theme="light">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Class Bunk Calculator & Attendance Predictor</title>
-  <link rel="stylesheet" href="styles.css">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js" defer></script>
-  <script src="app.js" defer></script>
-</head>
-<body>
-  <header class="header">
-    <div class="header__brand">
-      <div class="header__logo" aria-hidden="true">📚</div>
-      <div>
-        <h1 class="header__title">Attendance Predictor</h1>
-        <p class="header__subtitle">Smart bunk calculator for students</p>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Class Bunk Calculator & Attendance Predictor</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <script
+      src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"
+      defer
+    ></script>
+    <script src="app.js" defer></script>
+  </head>
+  <body>
+    <header class="header">
+      <div class="header__brand">
+        <div class="header__logo" aria-hidden="true">📚</div>
+        <div>
+          <h1 class="header__title">Attendance Predictor</h1>
+          <p class="header__subtitle">Smart bunk calculator for students</p>
+        </div>
       </div>
-    </div>
-    <button class="theme-toggle" id="themeToggle" aria-label="Toggle dark mode">
-      <span class="theme-toggle__icon theme-toggle__icon--light">☀️</span>
-      <span class="theme-toggle__icon theme-toggle__icon--dark">🌙</span>
-    </button>
-  </header>
+      <button
+        class="theme-toggle"
+        id="themeToggle"
+        aria-label="Toggle dark mode"
+      >
+        <span class="theme-toggle__icon theme-toggle__icon--light">☀️</span>
+        <span class="theme-toggle__icon theme-toggle__icon--dark">🌙</span>
+      </button>
+    </header>
 
-  <main class="container">
-    <!-- Quick Calculator -->
-    <section class="card card--hero" aria-labelledby="calculator-heading">
-      <h2 id="calculator-heading" class="card__title">Quick Calculator</h2>
-      <form id="calculatorForm" class="form-grid">
+    <main class="container">
+      <!-- Quick Calculator -->
+      <section class="card card--hero" aria-labelledby="calculator-heading">
+        <h2 id="calculator-heading" class="card__title">Quick Calculator</h2>
+        <form id="calculatorForm" class="form-grid">
+          <div class="form-group">
+            <label for="totalClasses">Total Classes Conducted</label>
+            <input
+              type="number"
+              id="totalClasses"
+              min="0"
+              placeholder="e.g. 50"
+              required
+            />
+          </div>
+          <div class="form-group">
+            <label for="classesAttended">Classes Attended</label>
+            <input
+              type="number"
+              id="classesAttended"
+              min="0"
+              placeholder="e.g. 42"
+              required
+            />
+          </div>
+          <div class="form-group">
+            <label for="minAttendance">Minimum Required (%)</label>
+            <input
+              type="number"
+              id="minAttendance"
+              min="0"
+              max="100"
+              value="75"
+              required
+            />
+          </div>
+          <div class="form-group">
+            <label for="targetAttendance"
+              >Target Attendance (%)
+              <span class="optional">optional</span></label
+            >
+            <input
+              type="number"
+              id="targetAttendance"
+              min="0"
+              max="100"
+              placeholder="e.g. 80"
+            />
+          </div>
+          <div class="form-group form-group--full">
+            <label for="futureMisses"
+              >Future Classes to Miss (for prediction)</label
+            >
+            <input
+              type="number"
+              id="futureMisses"
+              min="0"
+              value="0"
+              placeholder="e.g. 5"
+            />
+          </div>
+          <div class="form-actions form-group--full">
+            <button type="submit" class="btn btn--primary">Calculate</button>
+            <button type="button" class="btn btn--secondary" id="saveAsSubject">
+              Save as Subject
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <!-- Results Dashboard -->
+      <section class="dashboard" id="dashboard" hidden>
+        <div class="dashboard__meter card">
+          <h3 class="card__title">Current Attendance</h3>
+          <div class="meter" id="attendanceMeter">
+            <svg class="meter__svg" viewBox="0 0 200 200">
+              <circle class="meter__bg" cx="100" cy="100" r="85"></circle>
+              <circle
+                class="meter__progress"
+                id="meterProgress"
+                cx="100"
+                cy="100"
+                r="85"
+              ></circle>
+            </svg>
+            <div class="meter__value">
+              <span class="meter__percent" id="currentPercent">0%</span>
+              <span class="meter__status" id="attendanceStatus">—</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="dashboard__stats">
+          <div class="stat-card stat-card--safe">
+            <div class="stat-card__icon">✅</div>
+            <div class="stat-card__content">
+              <span class="stat-card__label">Safe Bunks Remaining</span>
+              <span class="stat-card__value" id="safeBunks">—</span>
+              <span class="stat-card__hint" id="safeBunksHint"></span>
+            </div>
+          </div>
+
+          <div class="stat-card stat-card--warning" id="shortageCard">
+            <div class="stat-card__icon">⚠️</div>
+            <div class="stat-card__content">
+              <span class="stat-card__label">Attendance Shortage</span>
+              <span class="stat-card__value" id="shortageValue">—</span>
+              <span class="stat-card__hint" id="shortageHint"></span>
+            </div>
+          </div>
+
+          <div class="stat-card stat-card--recovery">
+            <div class="stat-card__icon">📈</div>
+            <div class="stat-card__content">
+              <span class="stat-card__label"
+                >Classes Needed (No More Misses)</span
+              >
+              <span class="stat-card__value" id="classesNeeded">—</span>
+              <span class="stat-card__hint" id="recoveryHint"></span>
+            </div>
+          </div>
+
+          <div class="stat-card stat-card--prediction">
+            <div class="stat-card__icon">🔮</div>
+            <div class="stat-card__content">
+              <span class="stat-card__label">Future Prediction</span>
+              <span
+                class="stat-card__value stat-card__value--text"
+                id="futurePrediction"
+                >—</span
+              >
+            </div>
+          </div>
+
+          <div class="stat-card stat-card--target" id="targetCard" hidden>
+            <div class="stat-card__icon">🎯</div>
+            <div class="stat-card__content">
+              <span class="stat-card__label">To Reach Target</span>
+              <span class="stat-card__value" id="targetClasses">—</span>
+              <span class="stat-card__hint" id="targetHint"></span>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Subject-wise Tracking -->
+      <section class="card" aria-labelledby="subjects-heading">
+        <div class="card__header">
+          <h2 id="subjects-heading" class="card__title">
+            Subject-wise Tracking
+          </h2>
+          <button class="btn btn--ghost btn--sm" id="clearSubjects" hidden>
+            Clear All
+          </button>
+        </div>
+        <div id="subjectsList" class="subjects-list">
+          <p class="empty-state" id="subjectsEmpty">
+            No subjects saved yet. Calculate attendance and click "Save as
+            Subject".
+          </p>
+        </div>
+      </section>
+
+      <!-- Charts -->
+      <section class="charts-grid" id="chartsSection" hidden>
+        <div class="card">
+          <h3 class="card__title">Attendance Overview</h3>
+          <div class="chart-container">
+            <canvas id="overviewChart"></canvas>
+          </div>
+        </div>
+        <div class="card">
+          <h3 class="card__title">Attendance Trend</h3>
+          <div class="chart-container">
+            <canvas id="trendChart"></canvas>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <!-- Save Subject Modal -->
+    <dialog class="modal" id="subjectModal" aria-labelledby="modalTitle">
+      <form method="dialog" class="modal__content" id="subjectForm">
+        <h3 class="modal__title" id="modalTitle">Save Subject</h3>
         <div class="form-group">
-          <label for="totalClasses">Total Classes Conducted</label>
-          <input type="number" id="totalClasses" min="0" placeholder="e.g. 50" required>
+          <label for="subjectName">Subject Name</label>
+          <input
+            type="text"
+            id="subjectName"
+            placeholder="e.g. Mathematics"
+            required
+          />
         </div>
-        <div class="form-group">
-          <label for="classesAttended">Classes Attended</label>
-          <input type="number" id="classesAttended" min="0" placeholder="e.g. 42" required>
-        </div>
-        <div class="form-group">
-          <label for="minAttendance">Minimum Required (%)</label>
-          <input type="number" id="minAttendance" min="0" max="100" value="75" required>
-        </div>
-        <div class="form-group">
-          <label for="targetAttendance">Target Attendance (%) <span class="optional">optional</span></label>
-          <input type="number" id="targetAttendance" min="0" max="100" placeholder="e.g. 80">
-        </div>
-        <div class="form-group form-group--full">
-          <label for="futureMisses">Future Classes to Miss (for prediction)</label>
-          <input type="number" id="futureMisses" min="0" value="0" placeholder="e.g. 5">
-        </div>
-        <div class="form-actions form-group--full">
-          <button type="submit" class="btn btn--primary">Calculate</button>
-          <button type="button" class="btn btn--secondary" id="saveAsSubject">Save as Subject</button>
+        <div class="modal__actions">
+          <button type="button" class="btn btn--secondary" id="cancelSubject">
+            Cancel
+          </button>
+          <button type="submit" class="btn btn--primary">Save</button>
         </div>
       </form>
-    </section>
+    </dialog>
 
-    <!-- Results Dashboard -->
-    <section class="dashboard" id="dashboard" hidden>
-      <div class="dashboard__meter card">
-        <h3 class="card__title">Current Attendance</h3>
-        <div class="meter" id="attendanceMeter">
-          <svg class="meter__svg" viewBox="0 0 200 200">
-            <circle class="meter__bg" cx="100" cy="100" r="85"></circle>
-            <circle class="meter__progress" id="meterProgress" cx="100" cy="100" r="85"></circle>
-          </svg>
-          <div class="meter__value">
-            <span class="meter__percent" id="currentPercent">0%</span>
-            <span class="meter__status" id="attendanceStatus">—</span>
-          </div>
-        </div>
-      </div>
-
-      <div class="dashboard__stats">
-        <div class="stat-card stat-card--safe">
-          <div class="stat-card__icon">✅</div>
-          <div class="stat-card__content">
-            <span class="stat-card__label">Safe Bunks Remaining</span>
-            <span class="stat-card__value" id="safeBunks">—</span>
-            <span class="stat-card__hint" id="safeBunksHint"></span>
-          </div>
-        </div>
-
-        <div class="stat-card stat-card--warning" id="shortageCard">
-          <div class="stat-card__icon">⚠️</div>
-          <div class="stat-card__content">
-            <span class="stat-card__label">Attendance Shortage</span>
-            <span class="stat-card__value" id="shortageValue">—</span>
-            <span class="stat-card__hint" id="shortageHint"></span>
-          </div>
-        </div>
-
-        <div class="stat-card stat-card--recovery">
-          <div class="stat-card__icon">📈</div>
-          <div class="stat-card__content">
-            <span class="stat-card__label">Classes Needed (No More Misses)</span>
-            <span class="stat-card__value" id="classesNeeded">—</span>
-            <span class="stat-card__hint" id="recoveryHint"></span>
-          </div>
-        </div>
-
-        <div class="stat-card stat-card--prediction">
-          <div class="stat-card__icon">🔮</div>
-          <div class="stat-card__content">
-            <span class="stat-card__label">Future Prediction</span>
-            <span class="stat-card__value stat-card__value--text" id="futurePrediction">—</span>
-          </div>
-        </div>
-
-        <div class="stat-card stat-card--target" id="targetCard" hidden>
-          <div class="stat-card__icon">🎯</div>
-          <div class="stat-card__content">
-            <span class="stat-card__label">To Reach Target</span>
-            <span class="stat-card__value" id="targetClasses">—</span>
-            <span class="stat-card__hint" id="targetHint"></span>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- Subject-wise Tracking -->
-    <section class="card" aria-labelledby="subjects-heading">
-      <div class="card__header">
-        <h2 id="subjects-heading" class="card__title">Subject-wise Tracking</h2>
-        <button class="btn btn--ghost btn--sm" id="clearSubjects" hidden>Clear All</button>
-      </div>
-      <div id="subjectsList" class="subjects-list">
-        <p class="empty-state" id="subjectsEmpty">No subjects saved yet. Calculate attendance and click "Save as Subject".</p>
-      </div>
-    </section>
-
-    <!-- Charts -->
-    <section class="charts-grid" id="chartsSection" hidden>
-      <div class="card">
-        <h3 class="card__title">Attendance Overview</h3>
-        <div class="chart-container">
-          <canvas id="overviewChart"></canvas>
-        </div>
-      </div>
-      <div class="card">
-        <h3 class="card__title">Attendance Trend</h3>
-        <div class="chart-container">
-          <canvas id="trendChart"></canvas>
-        </div>
-      </div>
-    </section>
-  </main>
-
-  <!-- Save Subject Modal -->
-  <dialog class="modal" id="subjectModal" aria-labelledby="modalTitle">
-    <form method="dialog" class="modal__content" id="subjectForm">
-      <h3 class="modal__title" id="modalTitle">Save Subject</h3>
-      <div class="form-group">
-        <label for="subjectName">Subject Name</label>
-        <input type="text" id="subjectName" placeholder="e.g. Mathematics" required>
-      </div>
-      <div class="modal__actions">
-        <button type="button" class="btn btn--secondary" id="cancelSubject">Cancel</button>
-        <button type="submit" class="btn btn--primary">Save</button>
-      </div>
-    </form>
-  </dialog>
-
-  <footer class="footer">
-    <p>Class Bunk Calculator & Attendance Predictor — Plan smarter, attend better.</p>
-  </footer>
-</body>
+    <footer class="footer">
+      <p>
+        Class Bunk Calculator & Attendance Predictor — Plan smarter, attend
+        better.
+      </p>
+    </footer>
+  </body>
 </html>

--- a/public/attendencePridictor/styles.css
+++ b/public/attendencePridictor/styles.css
@@ -26,7 +26,7 @@
   --info-bg: rgba(59, 130, 246, 0.1);
 }
 
-[data-theme="dark"] {
+[data-theme='dark'] {
   --bg: #0f172a;
   --bg-card: #1e293b;
   --text: #f1f5f9;
@@ -40,7 +40,9 @@
 }
 
 /* ===== Reset & Base ===== */
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
@@ -56,7 +58,9 @@ body {
   color: var(--text);
   line-height: 1.6;
   min-height: 100vh;
-  transition: background var(--transition), color var(--transition);
+  transition:
+    background var(--transition),
+    color var(--transition);
 }
 
 /* ===== Header ===== */
@@ -106,15 +110,17 @@ body {
   align-items: center;
   justify-content: center;
   font-size: 1.25rem;
-  transition: transform var(--transition), background var(--transition);
+  transition:
+    transform var(--transition),
+    background var(--transition);
 }
 
 .theme-toggle:hover {
   transform: scale(1.05);
 }
 
-[data-theme="light"] .theme-toggle__icon--dark,
-[data-theme="dark"] .theme-toggle__icon--light {
+[data-theme='light'] .theme-toggle__icon--dark,
+[data-theme='dark'] .theme-toggle__icon--light {
   display: none;
 }
 
@@ -135,11 +141,17 @@ body {
   border-radius: var(--radius-lg);
   padding: 1.5rem;
   box-shadow: var(--shadow);
-  transition: background var(--transition), border-color var(--transition);
+  transition:
+    background var(--transition),
+    border-color var(--transition);
 }
 
 .card--hero {
-  background: linear-gradient(135deg, var(--bg-card) 0%, var(--primary-light) 100%);
+  background: linear-gradient(
+    135deg,
+    var(--bg-card) 0%,
+    var(--primary-light) 100%
+  );
 }
 
 .card__header {
@@ -195,7 +207,9 @@ body {
   color: var(--text);
   font-family: var(--font);
   font-size: 0.95rem;
-  transition: border-color var(--transition), box-shadow var(--transition);
+  transition:
+    border-color var(--transition),
+    box-shadow var(--transition);
 }
 
 .form-group input:focus {
@@ -219,7 +233,9 @@ body {
   font-weight: 500;
   cursor: pointer;
   border: none;
-  transition: background var(--transition), transform var(--transition);
+  transition:
+    background var(--transition),
+    transform var(--transition);
 }
 
 .btn:active {
@@ -309,7 +325,9 @@ body {
   stroke-linecap: round;
   stroke-dasharray: 534;
   stroke-dashoffset: 534;
-  transition: stroke-dashoffset 0.8s ease, stroke 0.4s ease;
+  transition:
+    stroke-dashoffset 0.8s ease,
+    stroke 0.4s ease;
 }
 
 .meter__progress--warning {
@@ -412,11 +430,21 @@ body {
   color: var(--text-muted);
 }
 
-.stat-card--safe .stat-card__value { color: var(--safe); }
-.stat-card--warning .stat-card__value { color: var(--warning); }
-.stat-card--recovery .stat-card__value { color: var(--info); }
-.stat-card--prediction .stat-card__value { color: var(--primary); }
-.stat-card--target .stat-card__value { color: var(--safe); }
+.stat-card--safe .stat-card__value {
+  color: var(--safe);
+}
+.stat-card--warning .stat-card__value {
+  color: var(--warning);
+}
+.stat-card--recovery .stat-card__value {
+  color: var(--info);
+}
+.stat-card--prediction .stat-card__value {
+  color: var(--primary);
+}
+.stat-card--target .stat-card__value {
+  color: var(--safe);
+}
 
 .stat-card--danger-border {
   border-color: var(--danger);
@@ -446,7 +474,9 @@ body {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   cursor: pointer;
-  transition: border-color var(--transition), background var(--transition);
+  transition:
+    border-color var(--transition),
+    background var(--transition);
 }
 
 .subject-item:hover {


### PR DESCRIPTION
## Pull Request Description

### Related Issue

Closes #8991

### Summary

This PR fixes an issue where attendance history entries were created on every recalculation and input update, resulting in duplicate records and misleading trend chart data.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Prevented history creation during automatic recalculations.
- Added duplicate-entry detection before saving history.
- Ensured attendance trends only record meaningful attendance changes.
- Preserved real-time prediction updates without polluting history data.

## Testing

- [x] Calculated attendance and verified history entry creation.
- [x] Modified Future Misses multiple times.
- [x] Confirmed no duplicate history records were added.
- [x] Refreshed the page and verified trend chart accuracy.
- [x] Verified normal calculations still update history correctly.

## Result

Attendance history now records only meaningful attendance changes, preventing duplicate entries and keeping the Attendance Trend chart accurate and reliable.