### PR TITLE
fix: prevent duplicate favorite colors during rapid save actions

### DIFF
--- a/public/colorpop/app.js
+++ b/public/colorpop/app.js
@@ -4,15 +4,16 @@ let state = {
     { hex: '#DEB887', locked: false },
     { hex: '#C59B76', locked: false },
     { hex: '#A07855', locked: false },
-    { hex: '#6B4C35', locked: false }
+    { hex: '#6B4C35', locked: false },
   ],
   activeIndex: 0, // Currently active color index in palette (0-4)
   favorites: [],
-  soundEnabled: true
+  soundEnabled: true,
 };
 
 // --- AUDIO FEEDBACK (Web Audio API) ---
 let audioCtx = null;
+let isSavingFavorite = false;
 
 function initAudio() {
   if (!audioCtx) {
@@ -53,11 +54,13 @@ function playSound(type) {
         osc2.type = 'sine';
         osc2.frequency.setValueAtTime(1046.5, audioCtx.currentTime); // C6
         gain2.gain.setValueAtTime(0.08, audioCtx.currentTime);
-        gain2.gain.exponentialRampToValueAtTime(0.001, audioCtx.currentTime + 0.15);
+        gain2.gain.exponentialRampToValueAtTime(
+          0.001,
+          audioCtx.currentTime + 0.15
+        );
         osc2.start();
         osc2.stop(audioCtx.currentTime + 0.15);
       }, 70);
-
     } else if (type === 'generate') {
       // Soft wave sweep
       const osc = audioCtx.createOscillator();
@@ -74,7 +77,6 @@ function playSound(type) {
 
       osc.start(now);
       osc.stop(now + 0.15);
-
     } else if (type === 'favorite') {
       // Sweet ascending major chord arpeggio
       const notes = [523.25, 659.25, 783.99]; // C5, E5, G5
@@ -94,7 +96,7 @@ function playSound(type) {
       });
     }
   } catch (e) {
-    console.warn("Audio Context block or unsupported:", e);
+    console.warn('Audio Context block or unsupported:', e);
   }
 }
 
@@ -115,38 +117,63 @@ function hslToHex(h, s, l) {
   s /= 100;
   l /= 100;
   let c = (1 - Math.abs(2 * l - 1)) * s;
-  let x = c * (1 - Math.abs((h / 60) % 2 - 1));
+  let x = c * (1 - Math.abs(((h / 60) % 2) - 1));
   let m = l - c / 2;
-  let r = 0, g = 0, b = 0;
+  let r = 0,
+    g = 0,
+    b = 0;
   if (0 <= h && h < 60) {
-    r = c; g = x; b = 0;
+    r = c;
+    g = x;
+    b = 0;
   } else if (60 <= h && h < 120) {
-    r = x; g = c; b = 0;
+    r = x;
+    g = c;
+    b = 0;
   } else if (120 <= h && h < 180) {
-    r = 0; g = c; b = x;
+    r = 0;
+    g = c;
+    b = x;
   } else if (180 <= h && h < 240) {
-    r = 0; g = x; b = c;
+    r = 0;
+    g = x;
+    b = c;
   } else if (240 <= h && h < 300) {
-    r = x; g = 0; b = c;
+    r = x;
+    g = 0;
+    b = c;
   } else if (300 <= h && h < 360) {
-    r = c; g = 0; b = x;
+    r = c;
+    g = 0;
+    b = x;
   }
-  let rHex = Math.round((r + m) * 255).toString(16).padStart(2, '0');
-  let gHex = Math.round((g + m) * 255).toString(16).padStart(2, '0');
-  let bHex = Math.round((b + m) * 255).toString(16).padStart(2, '0');
+  let rHex = Math.round((r + m) * 255)
+    .toString(16)
+    .padStart(2, '0');
+  let gHex = Math.round((g + m) * 255)
+    .toString(16)
+    .padStart(2, '0');
+  let bHex = Math.round((b + m) * 255)
+    .toString(16)
+    .padStart(2, '0');
   return `#${rHex}${gHex}${bHex}`.toUpperCase();
 }
 
 // Convert Hex to RGB array
 function hexToRgb(hex) {
   const shorthandRegex = /^#?([a-f\d])([a-f\d])([a-f\d])$/i;
-  const fullHex = hex.replace(shorthandRegex, (m, r, g, b) => r + r + g + g + b + b);
+  const fullHex = hex.replace(
+    shorthandRegex,
+    (m, r, g, b) => r + r + g + g + b + b
+  );
   const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(fullHex);
-  return result ? [
-    parseInt(result[1], 16),
-    parseInt(result[2], 16),
-    parseInt(result[3], 16)
-  ] : [0, 0, 0];
+  return result
+    ? [
+        parseInt(result[1], 16),
+        parseInt(result[2], 16),
+        parseInt(result[3], 16),
+      ]
+    : [0, 0, 0];
 }
 
 // Convert RGB to HSL string
@@ -154,8 +181,11 @@ function rgbToHslStr(r, g, b) {
   r /= 255;
   g /= 255;
   b /= 255;
-  const max = Math.max(r, g, b), min = Math.min(r, g, b);
-  let h, s, l = (max + min) / 2;
+  const max = Math.max(r, g, b),
+    min = Math.min(r, g, b);
+  let h,
+    s,
+    l = (max + min) / 2;
 
   if (max === min) {
     h = s = 0; // achromatic
@@ -163,9 +193,15 @@ function rgbToHslStr(r, g, b) {
     const d = max - min;
     s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
     switch (max) {
-      case r: h = (g - b) / d + (g < b ? 6 : 0); break;
-      case g: h = (b - r) / d + 2; break;
-      case b: h = (r - g) / d + 4; break;
+      case r:
+        h = (g - b) / d + (g < b ? 6 : 0);
+        break;
+      case g:
+        h = (b - r) / d + 2;
+        break;
+      case b:
+        h = (r - g) / d + 4;
+        break;
     }
     h /= 6;
   }
@@ -175,7 +211,7 @@ function rgbToHslStr(r, g, b) {
 
 // WCAG Contrast Compliance Evaluator
 function getLuminance(r, g, b) {
-  const a = [r, g, b].map(v => {
+  const a = [r, g, b].map((v) => {
     v /= 255;
     return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
   });
@@ -195,7 +231,8 @@ function evaluateContrast(bgHex) {
   const contrastWithBlack = getContrastRatio(bgHex, '#000000');
 
   // Decide best text color
-  const textColor = contrastWithWhite >= contrastWithBlack ? '#FFFFFF' : '#000000';
+  const textColor =
+    contrastWithWhite >= contrastWithBlack ? '#FFFFFF' : '#000000';
   const bestRatio = Math.max(contrastWithWhite, contrastWithBlack);
 
   let label = 'Low Contrast';
@@ -216,7 +253,7 @@ function evaluateContrast(bgHex) {
     textColor,
     label,
     ratingClass,
-    ratio: bestRatio.toFixed(1)
+    ratio: bestRatio.toFixed(1),
   };
 }
 
@@ -226,10 +263,10 @@ function copyToClipboard(text) {
     return navigator.clipboard.writeText(text);
   } else {
     // Fallback
-    const textArea = document.createElement("textarea");
+    const textArea = document.createElement('textarea');
     textArea.value = text;
-    textArea.style.position = "fixed";
-    textArea.style.left = "-999999px";
+    textArea.style.position = 'fixed';
+    textArea.style.left = '-999999px';
     document.body.appendChild(textArea);
     textArea.focus();
     textArea.select();
@@ -296,9 +333,10 @@ function showToast(message, type = 'success') {
   const toast = document.createElement('div');
   toast.className = `toast ${type === 'error' ? 'toast-error' : ''}`;
 
-  const iconHtml = type === 'success'
-    ? `<span class="toast-icon"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg></span>`
-    : `<span class="toast-icon error"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg></span>`;
+  const iconHtml =
+    type === 'success'
+      ? `<span class="toast-icon"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"></polyline></svg></span>`
+      : `<span class="toast-icon error"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg></span>`;
 
   toast.innerHTML = `${iconHtml}<span>${message}</span>`;
   toastContainer.appendChild(toast);
@@ -313,7 +351,7 @@ function showToast(message, type = 'success') {
 function generatePalette(playChime = true) {
   const mode = generationModeSelect ? generationModeSelect.value : 'random';
 
-  state.palette.forEach(color => {
+  state.palette.forEach((color) => {
     if (!color.locked) {
       if (mode === 'nude') {
         const h = Math.floor(Math.random() * (45 - 12 + 1)) + 12; // 12 to 45 (nude terracotta to sand skin beige)
@@ -346,23 +384,48 @@ function toggleLock(index, event) {
 
 // Save Favorites locally
 function saveFavoriteColor(hex) {
-  const normalizedHex = hex.toUpperCase();
-  if (state.favorites.includes(normalizedHex)) {
-    showToast(`${normalizedHex} is already in your favorites!`, 'error');
+  if (isSavingFavorite) {
     return;
   }
+
+  isSavingFavorite = true;
+
+  const normalizedHex = hex.toUpperCase();
+
+  const alreadyExists = state.favorites.some(
+    (color) => color.toUpperCase() === normalizedHex
+  );
+
+  if (alreadyExists) {
+    showToast(`${normalizedHex} is already in your favorites!`, 'error');
+
+    isSavingFavorite = false;
+    return;
+  }
+
   state.favorites.unshift(normalizedHex);
-  localStorage.setItem('colorpop_favorites', JSON.stringify(state.favorites));
+
+  localStorage.setItem(
+    'colorpop_favorites',
+    JSON.stringify(state.favorites)
+  );
+
   playSound('favorite');
+
   showToast(`Saved ${normalizedHex} to favorites!`);
+
   updateUI();
+
+  setTimeout(() => {
+    isSavingFavorite = false;
+  }, 300);
 }
 
 // Delete Favorite
 function deleteFavorite(hex, event) {
   if (event) event.stopPropagation();
   const normalizedHex = hex.toUpperCase();
-  state.favorites = state.favorites.filter(c => c !== normalizedHex);
+  state.favorites = state.favorites.filter((c) => c !== normalizedHex);
   localStorage.setItem('colorpop_favorites', JSON.stringify(state.favorites));
   showToast(`Removed ${normalizedHex}`);
   updateUI();
@@ -413,17 +476,17 @@ function toggleModal(modal, show) {
 
 // Tab controller inside Export Modal
 function switchTab(tabId) {
-  tabButtons.forEach(btn => {
+  tabButtons.forEach((btn) => {
     btn.classList.toggle('active', btn.dataset.tab === tabId);
   });
-  tabContents.forEach(content => {
+  tabContents.forEach((content) => {
     content.classList.toggle('active', content.id === `tab-${tabId}`);
   });
 }
 
 // Generate Exporter code content
 function generateExportCodes() {
-  const colors = state.palette.map(c => c.hex);
+  const colors = state.palette.map((c) => c.hex);
 
   // CSS Export Code
   let cssText = `:root {\n`;
@@ -533,7 +596,7 @@ function updateUI() {
     emptyFavoritesState.classList.add('hidden');
     clearAllFavoritesBtn.classList.remove('hidden');
 
-    state.favorites.forEach(favHex => {
+    state.favorites.forEach((favHex) => {
       const chip = document.createElement('div');
       chip.className = 'favorite-chip';
       chip.style.backgroundColor = favHex;
@@ -612,10 +675,10 @@ saveActiveBtn.addEventListener('click', () => {
 });
 
 clearAllFavoritesBtn.addEventListener('click', () => {
-  if (confirm("Are you sure you want to clear all saved colors?")) {
+  if (confirm('Are you sure you want to clear all saved colors?')) {
     state.favorites = [];
     localStorage.removeItem('colorpop_favorites');
-    showToast("Cleared all saved colors");
+    showToast('Cleared all saved colors');
     updateUI();
   }
 });
@@ -630,7 +693,7 @@ exportModal.addEventListener('click', (e) => {
   if (e.target === exportModal) toggleModal(exportModal, false);
 });
 
-tabButtons.forEach(btn => {
+tabButtons.forEach((btn) => {
   btn.addEventListener('click', () => switchTab(btn.dataset.tab));
 });
 
@@ -640,18 +703,23 @@ copyCodeBtn.addEventListener('click', () => {
   let codeText = '';
 
   if (activeTabId === 'css') codeText = exportCssCode.textContent;
-  else if (activeTabId === 'tailwind') codeText = exportTailwindCode.textContent;
+  else if (activeTabId === 'tailwind')
+    codeText = exportTailwindCode.textContent;
   else if (activeTabId === 'json') codeText = exportJsonCode.textContent;
 
   copyToClipboard(codeText).then(() => {
     playSound('copy');
-    showToast("Export template copied!");
+    showToast('Export template copied!');
   });
 });
 
 // Keyboard Shortcuts Modal Events
-keyboardHintBtn.addEventListener('click', () => toggleModal(keyboardModal, true));
-closeKeyboardBtn.addEventListener('click', () => toggleModal(keyboardModal, false));
+keyboardHintBtn.addEventListener('click', () =>
+  toggleModal(keyboardModal, true)
+);
+closeKeyboardBtn.addEventListener('click', () =>
+  toggleModal(keyboardModal, false)
+);
 keyboardModal.addEventListener('click', (e) => {
   if (e.target === keyboardModal) toggleModal(keyboardModal, false);
 });
@@ -659,7 +727,10 @@ keyboardModal.addEventListener('click', (e) => {
 // Keyboard Shortcut Bindings
 document.addEventListener('keydown', (e) => {
   // Prevent shortcut firing if user is inside forms or inputs (though colorpop has no standard text inputs)
-  if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA') {
+  if (
+    document.activeElement.tagName === 'INPUT' ||
+    document.activeElement.tagName === 'TEXTAREA'
+  ) {
     return;
   }
 

--- a/public/colorpop/index.html
+++ b/public/colorpop/index.html
@@ -1,141 +1,224 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ColorPop — Premium Hex Code & Palette Generator</title>
+    <meta
+      name="description"
+      content="Generate beautiful color palettes, lock your favorites, check WCAG contrast compliance, and export to CSS, Tailwind, or JSON. ColorPop makes designing easy."
+    />
+    <!-- Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;700&display=swap"
+      rel="stylesheet"
+    />
+    <!-- Stylesheet -->
+    <link rel="stylesheet" href="style.css" />
+  </head>
 
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>ColorPop — Premium Hex Code & Palette Generator</title>
-  <meta name="description"
-    content="Generate beautiful color palettes, lock your favorites, check WCAG contrast compliance, and export to CSS, Tailwind, or JSON. ColorPop makes designing easy.">
-  <!-- Google Fonts -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link
-    href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;700&display=swap"
-    rel="stylesheet">
-  <!-- Stylesheet -->
-  <link rel="stylesheet" href="style.css">
-</head>
+  <body>
+    <!-- Animated Mesh Background Elements -->
+    <div class="mesh-bg">
+      <div class="glow-orb orb-1" id="orb-1"></div>
+      <div class="glow-orb orb-2" id="orb-2"></div>
+      <div class="glow-orb orb-3" id="orb-3"></div>
+      <div class="glow-orb orb-4" id="orb-4"></div>
+    </div>
 
-<body>
-
-  <!-- Animated Mesh Background Elements -->
-  <div class="mesh-bg">
-    <div class="glow-orb orb-1" id="orb-1"></div>
-    <div class="glow-orb orb-2" id="orb-2"></div>
-    <div class="glow-orb orb-3" id="orb-3"></div>
-    <div class="glow-orb orb-4" id="orb-4"></div>
-  </div>
-
-  <div class="app-wrapper">
-    <!-- Header -->
-    <header class="app-header">
-      <div class="brand">
-        <div class="brand-logo">
-          <span class="dot d1"></span>
-          <span class="dot d2"></span>
-          <span class="dot d3"></span>
+    <div class="app-wrapper">
+      <!-- Header -->
+      <header class="app-header">
+        <div class="brand">
+          <div class="brand-logo">
+            <span class="dot d1"></span>
+            <span class="dot d2"></span>
+            <span class="dot d3"></span>
+          </div>
+          <h1>Color<span>Pop</span></h1>
         </div>
-        <h1>Color<span>Pop</span></h1>
-      </div>
-      <div class="header-actions">
-        <button id="keyboard-hint-btn" class="icon-btn" title="Keyboard Shortcuts">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
-            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="2" y="4" width="20" height="16" rx="2" ry="2"></rect>
-            <line x1="6" y1="8" x2="6" y2="8"></line>
-            <line x1="10" y1="8" x2="10" y2="8"></line>
-            <line x1="14" y1="8" x2="14" y2="8"></line>
-            <line x1="18" y1="8" x2="18" y2="8"></line>
-            <line x1="6" y1="12" x2="6" y2="12"></line>
-            <line x1="18" y1="12" x2="18" y2="12"></line>
-            <line x1="6" y1="16" x2="6" y2="16"></line>
-            <line x1="18" y1="16" x2="18" y2="16"></line>
-            <line x1="10" y1="16" x2="14" y2="16"></line>
-          </svg>
-        </button>
-        <button id="sound-toggle-btn" class="icon-btn" title="Toggle Sound Chimes">
-          <svg id="sound-on-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"
-            fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
-            <path d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"></path>
-          </svg>
-          <svg id="sound-off-icon" xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"
-            fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-            class="hidden">
-            <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
-            <line x1="23" y1="9" x2="17" y2="15"></line>
-            <line x1="17" y1="9" x2="23" y2="15"></line>
-          </svg>
-        </button>
-      </div>
-    </header>
+        <div class="header-actions">
+          <button
+            id="keyboard-hint-btn"
+            class="icon-btn"
+            title="Keyboard Shortcuts"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="2" y="4" width="20" height="16" rx="2" ry="2"></rect>
+              <line x1="6" y1="8" x2="6" y2="8"></line>
+              <line x1="10" y1="8" x2="10" y2="8"></line>
+              <line x1="14" y1="8" x2="14" y2="8"></line>
+              <line x1="18" y1="8" x2="18" y2="8"></line>
+              <line x1="6" y1="12" x2="6" y2="12"></line>
+              <line x1="18" y1="12" x2="18" y2="12"></line>
+              <line x1="6" y1="16" x2="6" y2="16"></line>
+              <line x1="18" y1="16" x2="18" y2="16"></line>
+              <line x1="10" y1="16" x2="14" y2="16"></line>
+            </svg>
+          </button>
+          <button
+            id="sound-toggle-btn"
+            class="icon-btn"
+            title="Toggle Sound Chimes"
+          >
+            <svg
+              id="sound-on-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+              <path
+                d="M19.07 4.93a10 10 0 0 1 0 14.14M15.54 8.46a5 5 0 0 1 0 7.07"
+              ></path>
+            </svg>
+            <svg
+              id="sound-off-icon"
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              class="hidden"
+            >
+              <polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"></polygon>
+              <line x1="23" y1="9" x2="17" y2="15"></line>
+              <line x1="17" y1="9" x2="23" y2="15"></line>
+            </svg>
+          </button>
+        </div>
+      </header>
 
-    <!-- Main Layout Grid -->
-    <main class="app-main">
+      <!-- Main Layout Grid -->
+      <main class="app-main">
+        <!-- Core Palette & Preview Section -->
+        <section class="generator-container">
+          <!-- Large Preview Card -->
+          <div class="hero-preview" id="hero-preview-card">
+            <div class="hero-color-block" id="hero-color-display">
+              <!-- Dynamic Pick Color Picker overlay -->
+              <label
+                for="color-picker-input"
+                class="picker-overlay-label"
+                title="Custom color picker"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 14.7255 3.09032 17.1962 4.85857 19C5.3541 19.5 5.25 20.5 4.5 21C3.5 21.6667 2 22 2 22C2 22 5.5 22 7.5 21.5C8 21.375 9 21.5 9.5 22C10.25 22.5 11.25 22 12 22Z"
+                  ></path>
+                  <circle cx="7.5" cy="10.5" r="1.5"></circle>
+                  <circle cx="11.5" cy="7.5" r="1.5"></circle>
+                  <circle cx="16.5" cy="9.5" r="1.5"></circle>
+                  <circle cx="15.5" cy="14.5" r="1.5"></circle>
+                </svg>
+                <input
+                  type="color"
+                  id="color-picker-input"
+                  class="hidden-picker"
+                />
+              </label>
 
-      <!-- Core Palette & Preview Section -->
-      <section class="generator-container">
+              <!-- Contrast Compliance Badge -->
+              <div class="contrast-badge" id="contrast-badge">
+                <span class="contrast-label">Contrast</span>
+                <span class="contrast-value" id="contrast-val">AAA Pass</span>
+              </div>
 
-        <!-- Large Preview Card -->
-        <div class="hero-preview" id="hero-preview-card">
-          <div class="hero-color-block" id="hero-color-display">
-            <!-- Dynamic Pick Color Picker overlay -->
-            <label for="color-picker-input" class="picker-overlay-label" title="Custom color picker">
-              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none"
-                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path
-                  d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 14.7255 3.09032 17.1962 4.85857 19C5.3541 19.5 5.25 20.5 4.5 21C3.5 21.6667 2 22 2 22C2 22 5.5 22 7.5 21.5C8 21.375 9 21.5 9.5 22C10.25 22.5 11.25 22 12 22Z">
-                </path>
-                <circle cx="7.5" cy="10.5" r="1.5"></circle>
-                <circle cx="11.5" cy="7.5" r="1.5"></circle>
-                <circle cx="16.5" cy="9.5" r="1.5"></circle>
-                <circle cx="15.5" cy="14.5" r="1.5"></circle>
-              </svg>
-              <input type="color" id="color-picker-input" class="hidden-picker">
-            </label>
-
-            <!-- Contrast Compliance Badge -->
-            <div class="contrast-badge" id="contrast-badge">
-              <span class="contrast-label">Contrast</span>
-              <span class="contrast-value" id="contrast-val">AAA Pass</span>
-            </div>
-
-            <!-- Active Hex Info -->
-            <div class="active-hex-info">
-              <span class="active-hex-value" id="active-hex-text">#6C5DD3</span>
-              <div class="color-specs">
-                <span class="color-spec-pill" id="rgb-spec-text">rgb(108, 93, 211)</span>
-                <span class="color-spec-pill" id="hsl-spec-text">hsl(248, 57%, 60%)</span>
+              <!-- Active Hex Info -->
+              <div class="active-hex-info">
+                <span class="active-hex-value" id="active-hex-text"
+                  >#6C5DD3</span
+                >
+                <div class="color-specs">
+                  <span class="color-spec-pill" id="rgb-spec-text"
+                    >rgb(108, 93, 211)</span
+                  >
+                  <span class="color-spec-pill" id="hsl-spec-text"
+                    >hsl(248, 57%, 60%)</span
+                  >
+                </div>
               </div>
             </div>
+
+            <!-- Hero Actions -->
+            <div class="hero-actions">
+              <button id="copy-active-btn" class="btn btn-secondary">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+                  <path
+                    d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+                  ></path>
+                </svg>
+                <span>Copy Hex</span>
+              </button>
+              <button id="save-active-btn" class="btn btn-primary">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="18"
+                  height="18"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"
+                  ></path>
+                </svg>
+                <span>Save Favorite</span>
+              </button>
+            </div>
           </div>
 
-          <!-- Hero Actions -->
-          <div class="hero-actions">
-            <button id="copy-active-btn" class="btn btn-secondary">
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
-                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-                <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-              </svg>
-              <span>Copy Hex</span>
-            </button>
-            <button id="save-active-btn" class="btn btn-primary">
-              <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
-                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"></path>
-              </svg>
-              <span>Save Favorite</span>
-            </button>
-          </div>
-        </div>
-
-        <!-- 5-Color Palette Section -->
-        <div class="palette-wrapper">
-          <div class="palette-grid" id="palette-grid">
-            <!-- Dynamically populated 5 vertical blocks -->
-            <!-- Sample Structure of a block:
+          <!-- 5-Color Palette Section -->
+          <div class="palette-wrapper">
+            <div class="palette-grid" id="palette-grid">
+              <!-- Dynamically populated 5 vertical blocks -->
+              <!-- Sample Structure of a block:
             <div class="palette-card">
               <div class="color-block" style="background-color: #..."></div>
               <div class="card-controls">
@@ -144,159 +227,225 @@
                 <button class="copy-btn"><svg>...</svg></button>
               </div>
             </div>
-            -->
-          </div>
+            --></div>
 
-          <!-- Generator Control Buttons -->
-          <div class="generator-controls">
-            <div class="select-wrapper">
-              <select id="generation-mode" class="select-input" title="Palette Generation Style">
-                <option value="nude" selected>Nude & Earthy</option>
-                <option value="random">Random Vibes</option>
-                <option value="pastel">Soft Pastel</option>
-              </select>
-              <div class="select-arrow"></div>
+            <!-- Generator Control Buttons -->
+            <div class="generator-controls">
+              <div class="select-wrapper">
+                <select
+                  id="generation-mode"
+                  class="select-input"
+                  title="Palette Generation Style"
+                >
+                  <option value="nude" selected>Nude & Earthy</option>
+                  <option value="random">Random Vibes</option>
+                  <option value="pastel">Soft Pastel</option>
+                </select>
+                <div class="select-arrow"></div>
+              </div>
+              <button id="generate-btn" class="btn btn-large btn-generate">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M21.5 2v6h-6M21.34 15.57a10 10 0 1 1-.57-8.38l5.67-5.67"
+                  ></path>
+                </svg>
+                <span>Generate Palette</span>
+                <span class="btn-shortcut">Space</span>
+              </button>
+              <button id="open-export-btn" class="btn btn-large btn-export">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="20"
+                  height="20"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <path
+                    d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8M16 6l-4-4-4 4M12 2v13"
+                  ></path>
+                </svg>
+                <span>Export</span>
+              </button>
             </div>
-            <button id="generate-btn" class="btn btn-large btn-generate">
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
-                stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M21.5 2v6h-6M21.34 15.57a10 10 0 1 1-.57-8.38l5.67-5.67"></path>
-              </svg>
-              <span>Generate Palette</span>
-              <span class="btn-shortcut">Space</span>
-            </button>
-            <button id="open-export-btn" class="btn btn-large btn-export">
-              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
-                stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8M16 6l-4-4-4 4M12 2v13"></path>
-              </svg>
-              <span>Export</span>
-            </button>
           </div>
-        </div>
-      </section>
+        </section>
 
-      <!-- Sidebar: Favorites Drawer -->
-      <aside class="favorites-sidebar">
-        <div class="sidebar-header">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
-            stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
-            <path
-              d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z">
-            </path>
-          </svg>
-          <h2>Saved Colors</h2>
-          <span class="count-badge" id="favorites-count">0</span>
-        </div>
+        <!-- Sidebar: Favorites Drawer -->
+        <aside class="favorites-sidebar">
+          <div class="sidebar-header">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path
+                d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
+              ></path>
+            </svg>
+            <h2>Saved Colors</h2>
+            <span class="count-badge" id="favorites-count">0</span>
+          </div>
 
-        <!-- Scrollable Favorites list -->
-        <div class="favorites-container">
-          <div class="favorites-grid-list" id="favorites-grid-list">
-            <!-- Filled dynamically -->
-            <div class="empty-favorites-state" id="empty-favorites">
-              <div class="empty-icon">🎨</div>
-              <p>No favorites saved yet.</p>
-              <span class="subtitle">Click "Save Favorite" or hover over palette colors to bookmark them.</span>
+          <!-- Scrollable Favorites list -->
+          <div class="favorites-container">
+            <div class="favorites-grid-list" id="favorites-grid-list">
+              <!-- Filled dynamically -->
+              <div class="empty-favorites-state" id="empty-favorites">
+                <div class="empty-icon">🎨</div>
+                <p>No favorites saved yet.</p>
+                <span class="subtitle"
+                  >Click "Save Favorite" or hover over palette colors to
+                  bookmark them.</span
+                >
+              </div>
             </div>
           </div>
-        </div>
 
-        <button id="clear-all-favorites" class="btn btn-text hidden">Clear All Saved</button>
-      </aside>
+          <button id="clear-all-favorites" class="hidden btn btn-text">
+            Clear All Saved
+          </button>
+        </aside>
+      </main>
 
-    </main>
+      <!-- Footer -->
+      <footer class="app-footer">
+        <p>ColorPop © 2026. Designed for creative developers & designers.</p>
+      </footer>
+    </div>
 
-    <!-- Footer -->
-    <footer class="app-footer">
-      <p>ColorPop © 2026. Designed for creative developers & designers.</p>
-    </footer>
-  </div>
-
-  <!-- Dialog / Export Modal -->
-  <div class="modal-overlay hidden" id="export-modal">
-    <div class="modal-card">
-      <div class="modal-header">
-        <h3>Export Palette</h3>
-        <button id="close-modal-btn" class="icon-btn">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
-            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="18" y1="6" x2="6" y2="18"></line>
-            <line x1="6" y1="6" x2="18" y2="18"></line>
-          </svg>
-        </button>
-      </div>
-      <div class="modal-tabs">
-        <button class="tab-btn active" data-tab="css">CSS Variables</button>
-        <button class="tab-btn" data-tab="tailwind">Tailwind CSS</button>
-        <button class="tab-btn" data-tab="json">JSON</button>
-      </div>
-      <div class="modal-body">
-        <div class="tab-content active" id="tab-css">
-          <pre><code id="export-css-code"></code></pre>
+    <!-- Dialog / Export Modal -->
+    <div class="hidden modal-overlay" id="export-modal">
+      <div class="modal-card">
+        <div class="modal-header">
+          <h3>Export Palette</h3>
+          <button id="close-modal-btn" class="icon-btn">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
         </div>
-        <div class="tab-content" id="tab-tailwind">
-          <pre><code id="export-tailwind-code"></code></pre>
+        <div class="modal-tabs">
+          <button class="tab-btn active" data-tab="css">CSS Variables</button>
+          <button class="tab-btn" data-tab="tailwind">Tailwind CSS</button>
+          <button class="tab-btn" data-tab="json">JSON</button>
         </div>
-        <div class="tab-content" id="tab-json">
-          <pre><code id="export-json-code"></code></pre>
+        <div class="modal-body">
+          <div class="tab-content active" id="tab-css">
+            <pre><code id="export-css-code"></code></pre>
+          </div>
+          <div class="tab-content" id="tab-tailwind">
+            <pre><code id="export-tailwind-code"></code></pre>
+          </div>
+          <div class="tab-content" id="tab-json">
+            <pre><code id="export-json-code"></code></pre>
+          </div>
         </div>
-      </div>
-      <div class="modal-footer">
-        <button id="copy-code-btn" class="btn btn-primary">
-          <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
-            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
-            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
-          </svg>
-          <span>Copy to Clipboard</span>
-        </button>
+        <div class="modal-footer">
+          <button id="copy-code-btn" class="btn btn-primary">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
+              <path
+                d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"
+              ></path>
+            </svg>
+            <span>Copy to Clipboard</span>
+          </button>
+        </div>
       </div>
     </div>
-  </div>
 
-  <!-- Keyboard Shortcuts Modal -->
-  <div class="modal-overlay hidden" id="keyboard-modal">
-    <div class="modal-card modal-small">
-      <div class="modal-header">
-        <h3>Keyboard Shortcuts</h3>
-        <button id="close-keyboard-btn" class="icon-btn">
-          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none"
-            stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <line x1="18" y1="6" x2="6" y2="18"></line>
-            <line x1="6" y1="6" x2="18" y2="18"></line>
-          </svg>
-        </button>
-      </div>
-      <div class="modal-body keyboard-shortcuts-list">
-        <div class="shortcut-row">
-          <kbd>Spacebar</kbd>
-          <span>Generate new color palette</span>
+    <!-- Keyboard Shortcuts Modal -->
+    <div class="hidden modal-overlay" id="keyboard-modal">
+      <div class="modal-card modal-small">
+        <div class="modal-header">
+          <h3>Keyboard Shortcuts</h3>
+          <button id="close-keyboard-btn" class="icon-btn">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
         </div>
-        <div class="shortcut-row">
-          <kbd>1</kbd> - <kbd>5</kbd>
-          <span>Toggle Lock status of color slot 1 to 5</span>
-        </div>
-        <div class="shortcut-row">
-          <kbd>C</kbd>
-          <span>Copy active preview color to clipboard</span>
-        </div>
-        <div class="shortcut-row">
-          <kbd>S</kbd>
-          <span>Save active color to favorites</span>
-        </div>
-        <div class="shortcut-row">
-          <kbd>E</kbd>
-          <span>Open Palette Export dialog</span>
+        <div class="modal-body keyboard-shortcuts-list">
+          <div class="shortcut-row">
+            <kbd>Spacebar</kbd>
+            <span>Generate new color palette</span>
+          </div>
+          <div class="shortcut-row">
+            <kbd>1</kbd> - <kbd>5</kbd>
+            <span>Toggle Lock status of color slot 1 to 5</span>
+          </div>
+          <div class="shortcut-row">
+            <kbd>C</kbd>
+            <span>Copy active preview color to clipboard</span>
+          </div>
+          <div class="shortcut-row">
+            <kbd>S</kbd>
+            <span>Save active color to favorites</span>
+          </div>
+          <div class="shortcut-row">
+            <kbd>E</kbd>
+            <span>Open Palette Export dialog</span>
+          </div>
         </div>
       </div>
     </div>
-  </div>
 
-  <!-- Toast Notification Container -->
-  <div class="toast-container" id="toast-container"></div>
+    <!-- Toast Notification Container -->
+    <div class="toast-container" id="toast-container"></div>
 
-  <!-- Script File -->
-  <script src="app.js"></script>
-</body>
-
+    <!-- Script File -->
+    <script src="app.js"></script>
+  </body>
 </html>

--- a/public/colorpop/style.css
+++ b/public/colorpop/style.css
@@ -12,7 +12,7 @@
   --text-secondary: #94a3b8;
   --text-muted: #64748b;
 
-  --accent-color: #6C5DD3;
+  --accent-color: #6c5dd3;
   --accent-color-hover: #5a4cb3;
   --accent-success: #10b981;
   --accent-danger: #ef4444;
@@ -21,9 +21,12 @@
   --radius-lg: 24px;
   --radius-md: 16px;
   --radius-sm: 10px;
-  --shadow-sm: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-  --shadow-md: 0 10px 15px -3px rgba(0, 0, 0, 0.2), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-  --shadow-lg: 0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
+  --shadow-sm:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-md:
+    0 10px 15px -3px rgba(0, 0, 0, 0.2), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --shadow-lg:
+    0 20px 25px -5px rgba(0, 0, 0, 0.3), 0 10px 10px -5px rgba(0, 0, 0, 0.04);
 
   --glass-blur: blur(24px);
   --transition-smooth: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
@@ -244,7 +247,6 @@ body {
 }
 
 @keyframes logo-pop {
-
   0%,
   100% {
     transform: scale(1);
@@ -531,7 +533,9 @@ body {
 
 .palette-card.active-selected {
   border-color: var(--text-primary);
-  box-shadow: 0 0 0 2px var(--text-primary), var(--shadow-lg);
+  box-shadow:
+    0 0 0 2px var(--text-primary),
+    var(--shadow-lg);
 }
 
 .palette-card .color-block {
@@ -587,11 +591,10 @@ body {
   color: #f59e0b;
   /* Yellow Lock color */
   background: rgba(245, 158, 11, 0.1);
-  animation: padlock-shake 0.3s cubic-bezier(.36, .07, .19, .97) both;
+  animation: padlock-shake 0.3s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
 }
 
 @keyframes padlock-shake {
-
   10%,
   90% {
     transform: translate3d(-1px, 0, 0);
@@ -682,7 +685,11 @@ body {
 }
 
 .btn-generate:hover {
-  background: linear-gradient(135deg, var(--accent-color-hover) 0%, #9333ea 100%);
+  background: linear-gradient(
+    135deg,
+    var(--accent-color-hover) 0%,
+    #9333ea 100%
+  );
   box-shadow: 0 8px 30px rgba(108, 93, 211, 0.4);
 }
 
@@ -771,7 +778,6 @@ body {
 }
 
 @keyframes pulse-icon {
-
   0%,
   100% {
     transform: scale(1);
@@ -1066,7 +1072,9 @@ kbd {
   background: rgba(15, 23, 42, 0.95);
   border: 1px solid rgba(16, 185, 129, 0.3);
   /* green border for success copy */
-  box-shadow: var(--shadow-lg), 0 0 15px rgba(16, 185, 129, 0.1);
+  box-shadow:
+    var(--shadow-lg),
+    0 0 15px rgba(16, 185, 129, 0.1);
   color: var(--text-primary);
   padding: 14px 20px;
   border-radius: var(--radius-md);
@@ -1076,7 +1084,9 @@ kbd {
   font-size: 13px;
   font-weight: 600;
   pointer-events: auto;
-  animation: toast-in 0.35s cubic-bezier(0.34, 1.56, 0.64, 1), toast-out 0.3s 2.5s forwards ease-in;
+  animation:
+    toast-in 0.35s cubic-bezier(0.34, 1.56, 0.64, 1),
+    toast-out 0.3s 2.5s forwards ease-in;
 }
 
 .toast.toast-error {


### PR DESCRIPTION
## Related Issue

Closes #8995

## Summary

This PR fixes an issue where rapidly clicking the "Save Favorite" button could add the same color multiple times to the favorites list before the UI finished updating.

## Changes Made

- Added save-action locking to prevent repeated submissions.
- Strengthened duplicate validation before inserting favorites.
- Prevented identical colors from being stored multiple times.
- Preserved existing favorite management behavior.
- Improved consistency of saved color data.

## Testing

- [x] Saved a new color successfully.
- [x] Rapidly clicked Save Favorite multiple times.
- [x] Verified only one favorite entry was created.
- [x] Confirmed duplicate warning message appears.
- [x] Verified favorites persist correctly in localStorage.
- [x] Confirmed deletion and re-saving still works.

## Result

Favorite colors can now only be saved once, preventing duplicate entries caused by rapid consecutive save actions.