### PR TITLE
fix: preserve resolution notes when reopening complaints

### DIFF
--- a/public/Complaint_Management_System/index.html
+++ b/public/Complaint_Management_System/index.html
@@ -1,370 +1,469 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Complaint Management System</title>
     <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <!-- Icons -->
     <script src="https://unpkg.com/@phosphor-icons/web"></script>
     <!-- Custom Styles -->
-    <link rel="stylesheet" href="style.css">
-</head>
-<body data-theme="light">
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body data-theme="light">
     <!-- Background Effects -->
     <div class="bg-effects">
-        <div class="glow glow-1"></div>
-        <div class="glow glow-2"></div>
+      <div class="glow glow-1"></div>
+      <div class="glow glow-2"></div>
     </div>
 
     <div class="app-container glass-panel">
-        
-        <!-- Sidebar -->
-        <aside class="sidebar">
-            <div class="brand">
-                <div class="brand-icon">
-                    <i class="ph-fill ph-shield-check"></i>
+      <!-- Sidebar -->
+      <aside class="sidebar">
+        <div class="brand">
+          <div class="brand-icon">
+            <i class="ph-fill ph-shield-check"></i>
+          </div>
+          <h2>ResolveIt</h2>
+        </div>
+
+        <nav class="nav-menu">
+          <p class="nav-label">Menu</p>
+          <button class="nav-item active" data-view="dashboard">
+            <i class="ph ph-squares-four"></i> Dashboard
+          </button>
+          <button class="nav-item" data-view="submit">
+            <i class="ph ph-plus-circle"></i> Submit Complaint
+          </button>
+          <button class="nav-item" data-view="listings">
+            <i class="ph ph-list-dashes"></i> View Complaints
+          </button>
+
+          <p class="mt-4 nav-label">Management</p>
+          <button class="nav-item" data-view="admin">
+            <i class="ph ph-lock-key"></i> Admin Panel
+          </button>
+        </nav>
+
+        <div class="sidebar-footer">
+          <button id="theme-toggle" class="nav-item">
+            <i class="ph ph-moon"></i> Dark Mode
+          </button>
+        </div>
+      </aside>
+
+      <!-- Main Content -->
+      <main class="main-content">
+        <!-- Header -->
+        <header class="top-header">
+          <div class="mobile-toggle">
+            <i class="ph ph-list"></i>
+          </div>
+          <div class="header-title">
+            <h1 id="page-title">Dashboard</h1>
+          </div>
+          <div class="header-actions">
+            <div class="user-profile">
+              <img
+                src="https://ui-avatars.com/api/?name=User&background=6366f1&color=fff"
+                alt="User"
+              />
+              <span>Current User</span>
+            </div>
+          </div>
+        </header>
+
+        <!-- Dashboard View -->
+        <section id="view-dashboard" class="view-section active fade-in">
+          <div class="stats-grid">
+            <div class="stat-card">
+              <div class="stat-icon bg-indigo"><i class="ph ph-files"></i></div>
+              <div class="stat-info">
+                <p>Total Complaints</p>
+                <h3 id="stat-total">0</h3>
+              </div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-icon bg-amber">
+                <i class="ph ph-hourglass-high"></i>
+              </div>
+              <div class="stat-info">
+                <p>Pending</p>
+                <h3 id="stat-pending">0</h3>
+              </div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-icon bg-blue">
+                <i class="ph ph-arrows-clockwise"></i>
+              </div>
+              <div class="stat-info">
+                <p>In Progress</p>
+                <h3 id="stat-progress">0</h3>
+              </div>
+            </div>
+            <div class="stat-card">
+              <div class="stat-icon bg-emerald">
+                <i class="ph ph-check-circle"></i>
+              </div>
+              <div class="stat-info">
+                <p>Resolved</p>
+                <h3 id="stat-resolved">0</h3>
+              </div>
+            </div>
+          </div>
+
+          <div class="dashboard-content">
+            <div class="card recent-complaints">
+              <div class="card-header">
+                <h3>Recent Complaints</h3>
+                <button
+                  class="btn btn-text"
+                  onclick="window.app.switchView('listings')"
+                >
+                  View All
+                </button>
+              </div>
+              <div class="table-container">
+                <table class="data-table">
+                  <thead>
+                    <tr>
+                      <th>ID</th>
+                      <th>Title</th>
+                      <th>Category</th>
+                      <th>Status</th>
+                      <th>Date</th>
+                    </tr>
+                  </thead>
+                  <tbody id="recent-table-body">
+                    <!-- Dynamic content -->
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <!-- Submit View -->
+        <section id="view-submit" class="view-section fade-in">
+          <div class="card form-card">
+            <div class="card-header">
+              <h3>File a New Complaint</h3>
+              <p class="text-muted">
+                Please provide detailed information to help us resolve your
+                issue quickly.
+              </p>
+            </div>
+            <form id="complaint-form" class="modern-form">
+              <div class="form-grid">
+                <div class="form-group span-full">
+                  <label for="title"
+                    >Complaint Title <span class="required">*</span></label
+                  >
+                  <input
+                    type="text"
+                    id="title"
+                    required
+                    placeholder="Brief summary of the issue"
+                  />
                 </div>
-                <h2>ResolveIt</h2>
+
+                <div class="form-group">
+                  <label for="category"
+                    >Category <span class="required">*</span></label
+                  >
+                  <select id="category" required>
+                    <option value="" disabled selected>Select category</option>
+                    <option value="hardware">Hardware / Equipment</option>
+                    <option value="software">Software / IT</option>
+                    <option value="facility">Facility / Maintenance</option>
+                    <option value="hr">Human Resources</option>
+                    <option value="other">Other</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label for="priority"
+                    >Priority Level <span class="required">*</span></label
+                  >
+                  <select id="priority" required>
+                    <option value="low">
+                      Low - General inquiry or minor issue
+                    </option>
+                    <option value="medium" selected>
+                      Medium - Noticeable impact on work
+                    </option>
+                    <option value="high">High - Urgent, stopping work</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label for="department">Target Department</label>
+                  <select id="department">
+                    <option value="it">IT Support</option>
+                    <option value="facilities">Facilities</option>
+                    <option value="hr">HR</option>
+                    <option value="general" selected>General Admin</option>
+                  </select>
+                </div>
+
+                <div class="form-group">
+                  <label for="location">Location / Room (if applicable)</label>
+                  <input
+                    type="text"
+                    id="location"
+                    placeholder="e.g., Room 402 or Remote"
+                  />
+                </div>
+
+                <div class="form-group span-full">
+                  <label for="description"
+                    >Detailed Description <span class="required">*</span></label
+                  >
+                  <textarea
+                    id="description"
+                    rows="5"
+                    required
+                    placeholder="Please describe the issue in detail..."
+                  ></textarea>
+                </div>
+
+                <div class="form-group span-full">
+                  <label>Attachments (Optional)</label>
+                  <div class="file-upload-zone" id="file-drop-area">
+                    <input
+                      type="file"
+                      id="attachment"
+                      accept="image/*,.pdf"
+                      hidden
+                    />
+                    <div class="upload-content">
+                      <i class="ph ph-upload-simple"></i>
+                      <p>Click to browse or drag and drop</p>
+                      <span class="text-xs text-muted"
+                        >PNG, JPG, PDF up to 5MB</span
+                      >
+                    </div>
+                    <div class="hidden file-preview" id="file-preview">
+                      <i class="ph ph-file-text"></i>
+                      <span id="file-name">filename.png</span>
+                      <button type="button" id="remove-file">
+                        <i class="ph ph-x"></i>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+
+                <div class="form-group span-full">
+                  <label for="contact"
+                    >Contact Email or Phone
+                    <span class="required">*</span></label
+                  >
+                  <input
+                    type="text"
+                    id="contact"
+                    required
+                    placeholder="How can we reach you?"
+                  />
+                </div>
+              </div>
+
+              <div class="form-actions">
+                <button
+                  type="button"
+                  class="btn btn-secondary"
+                  onclick="
+                    document.getElementById('complaint-form').reset();
+                    window.app.removeAttachment();
+                  "
+                >
+                  Reset
+                </button>
+                <button type="submit" class="btn btn-primary">
+                  <i class="ph ph-paper-plane-right"></i> Submit Complaint
+                </button>
+              </div>
+            </form>
+          </div>
+        </section>
+
+        <!-- Listings View -->
+        <section id="view-listings" class="view-section fade-in">
+          <div class="card listings-card">
+            <div class="listings-toolbar">
+              <div class="search-box">
+                <i class="ph ph-magnifying-glass"></i>
+                <input
+                  type="text"
+                  id="search-input"
+                  placeholder="Search by ID or Title..."
+                />
+              </div>
+              <div class="filter-group">
+                <select id="filter-status" class="filter-select">
+                  <option value="all">All Statuses</option>
+                  <option value="pending">Pending</option>
+                  <option value="in_progress">In Progress</option>
+                  <option value="resolved">Resolved</option>
+                  <option value="rejected">Rejected</option>
+                </select>
+                <select id="filter-priority" class="filter-select">
+                  <option value="all">All Priorities</option>
+                  <option value="high">High</option>
+                  <option value="medium">Medium</option>
+                  <option value="low">Low</option>
+                </select>
+              </div>
             </div>
 
-            <nav class="nav-menu">
-                <p class="nav-label">Menu</p>
-                <button class="nav-item active" data-view="dashboard">
-                    <i class="ph ph-squares-four"></i> Dashboard
+            <div class="table-container">
+              <table class="data-table" id="complaints-table">
+                <thead>
+                  <tr>
+                    <th>ID</th>
+                    <th>Title</th>
+                    <th>Priority</th>
+                    <th>Status</th>
+                    <th>Date</th>
+                    <th>Actions</th>
+                  </tr>
+                </thead>
+                <tbody id="listings-table-body">
+                  <!-- Dynamic content -->
+                </tbody>
+              </table>
+              <div id="listings-empty" class="hidden empty-state">
+                <i class="ph ph-magnifying-glass"></i>
+                <h3>No complaints found</h3>
+                <p>Try adjusting your search or filters.</p>
+                <button
+                  class="mt-4 btn btn-secondary"
+                  onclick="window.app.clearFilters()"
+                >
+                  Clear Filters
                 </button>
-                <button class="nav-item" data-view="submit">
-                    <i class="ph ph-plus-circle"></i> Submit Complaint
-                </button>
-                <button class="nav-item" data-view="listings">
-                    <i class="ph ph-list-dashes"></i> View Complaints
-                </button>
-                
-                <p class="nav-label mt-4">Management</p>
-                <button class="nav-item" data-view="admin">
-                    <i class="ph ph-lock-key"></i> Admin Panel
-                </button>
-            </nav>
-
-            <div class="sidebar-footer">
-                <button id="theme-toggle" class="nav-item">
-                    <i class="ph ph-moon"></i> Dark Mode
-                </button>
+              </div>
             </div>
-        </aside>
+          </div>
+        </section>
 
-        <!-- Main Content -->
-        <main class="main-content">
-            
-            <!-- Header -->
-            <header class="top-header">
-                <div class="mobile-toggle">
-                    <i class="ph ph-list"></i>
-                </div>
-                <div class="header-title">
-                    <h1 id="page-title">Dashboard</h1>
-                </div>
-                <div class="header-actions">
-                    <div class="user-profile">
-                        <img src="https://ui-avatars.com/api/?name=User&background=6366f1&color=fff" alt="User">
-                        <span>Current User</span>
-                    </div>
-                </div>
-            </header>
+        <!-- Details View -->
+        <section id="view-details" class="view-section fade-in">
+          <div class="details-header-actions">
+            <button
+              class="btn btn-secondary"
+              onclick="window.app.switchView('listings')"
+            >
+              <i class="ph ph-arrow-left"></i> Back to List
+            </button>
+          </div>
 
-            <!-- Dashboard View -->
-            <section id="view-dashboard" class="view-section active fade-in">
-                <div class="stats-grid">
-                    <div class="stat-card">
-                        <div class="stat-icon bg-indigo"><i class="ph ph-files"></i></div>
-                        <div class="stat-info">
-                            <p>Total Complaints</p>
-                            <h3 id="stat-total">0</h3>
-                        </div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="stat-icon bg-amber"><i class="ph ph-hourglass-high"></i></div>
-                        <div class="stat-info">
-                            <p>Pending</p>
-                            <h3 id="stat-pending">0</h3>
-                        </div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="stat-icon bg-blue"><i class="ph ph-arrows-clockwise"></i></div>
-                        <div class="stat-info">
-                            <p>In Progress</p>
-                            <h3 id="stat-progress">0</h3>
-                        </div>
-                    </div>
-                    <div class="stat-card">
-                        <div class="stat-icon bg-emerald"><i class="ph ph-check-circle"></i></div>
-                        <div class="stat-info">
-                            <p>Resolved</p>
-                            <h3 id="stat-resolved">0</h3>
-                        </div>
-                    </div>
+          <div class="details-grid" id="details-content">
+            <!-- Dynamic details content -->
+          </div>
+        </section>
+
+        <!-- Admin Panel View -->
+        <section id="view-admin" class="view-section fade-in">
+          <div class="card admin-card">
+            <div class="card-header">
+              <h3>Management Console</h3>
+              <p class="text-muted">Process and resolve active complaints.</p>
+            </div>
+
+            <div class="admin-grid">
+              <!-- Left col: List of active complaints -->
+              <div class="admin-list-col">
+                <div class="mb-4 search-box">
+                  <i class="ph ph-magnifying-glass"></i>
+                  <input
+                    type="text"
+                    id="admin-search"
+                    placeholder="Search active..."
+                  />
+                </div>
+                <div class="admin-complaints-list" id="admin-complaints-list">
+                  <!-- Dynamic admin list -->
+                </div>
+              </div>
+
+              <!-- Right col: Editor -->
+              <div class="admin-editor-col">
+                <div id="admin-editor-empty" class="empty-state">
+                  <i class="ph ph-cursor-click"></i>
+                  <h3>Select a complaint</h3>
+                  <p>Choose a complaint from the list to manage it.</p>
                 </div>
 
-                <div class="dashboard-content">
-                    <div class="card recent-complaints">
-                        <div class="card-header">
-                            <h3>Recent Complaints</h3>
-                            <button class="btn btn-text" onclick="window.app.switchView('listings')">View All</button>
-                        </div>
-                        <div class="table-container">
-                            <table class="data-table">
-                                <thead>
-                                    <tr>
-                                        <th>ID</th>
-                                        <th>Title</th>
-                                        <th>Category</th>
-                                        <th>Status</th>
-                                        <th>Date</th>
-                                    </tr>
-                                </thead>
-                                <tbody id="recent-table-body">
-                                    <!-- Dynamic content -->
-                                </tbody>
-                            </table>
-                        </div>
-                    </div>
+                <div id="admin-editor-form" class="hidden">
+                  <h3 id="admin-edit-title" class="mb-4">Complaint ID</h3>
+
+                  <div class="form-group">
+                    <label>Current Status</label>
+                    <select id="admin-status" class="status-select">
+                      <option value="pending">Pending</option>
+                      <option value="in_progress">In Progress</option>
+                      <option value="resolved">Resolved</option>
+                      <option value="rejected">Rejected</option>
+                    </select>
+                  </div>
+
+                  <div class="form-group">
+                    <label>Assigned Department</label>
+                    <select id="admin-department">
+                      <option value="it">IT Support</option>
+                      <option value="facilities">Facilities</option>
+                      <option value="hr">HR</option>
+                      <option value="general">General Admin</option>
+                    </select>
+                  </div>
+
+                  <div class="form-group">
+                    <label>Resolution Notes (Visible to user)</label>
+                    <textarea
+                      id="admin-notes"
+                      rows="6"
+                      placeholder="Enter troubleshooting steps or resolution details..."
+                    ></textarea>
+                  </div>
+
+                  <button
+                    class="w-full mt-4 btn btn-primary"
+                    onclick="window.app.saveAdminChanges()"
+                  >
+                    <i class="ph ph-floppy-disk"></i> Save Changes
+                  </button>
                 </div>
-            </section>
-
-            <!-- Submit View -->
-            <section id="view-submit" class="view-section fade-in">
-                <div class="card form-card">
-                    <div class="card-header">
-                        <h3>File a New Complaint</h3>
-                        <p class="text-muted">Please provide detailed information to help us resolve your issue quickly.</p>
-                    </div>
-                    <form id="complaint-form" class="modern-form">
-                        <div class="form-grid">
-                            <div class="form-group span-full">
-                                <label for="title">Complaint Title <span class="required">*</span></label>
-                                <input type="text" id="title" required placeholder="Brief summary of the issue">
-                            </div>
-                            
-                            <div class="form-group">
-                                <label for="category">Category <span class="required">*</span></label>
-                                <select id="category" required>
-                                    <option value="" disabled selected>Select category</option>
-                                    <option value="hardware">Hardware / Equipment</option>
-                                    <option value="software">Software / IT</option>
-                                    <option value="facility">Facility / Maintenance</option>
-                                    <option value="hr">Human Resources</option>
-                                    <option value="other">Other</option>
-                                </select>
-                            </div>
-
-                            <div class="form-group">
-                                <label for="priority">Priority Level <span class="required">*</span></label>
-                                <select id="priority" required>
-                                    <option value="low">Low - General inquiry or minor issue</option>
-                                    <option value="medium" selected>Medium - Noticeable impact on work</option>
-                                    <option value="high">High - Urgent, stopping work</option>
-                                </select>
-                            </div>
-
-                            <div class="form-group">
-                                <label for="department">Target Department</label>
-                                <select id="department">
-                                    <option value="it">IT Support</option>
-                                    <option value="facilities">Facilities</option>
-                                    <option value="hr">HR</option>
-                                    <option value="general" selected>General Admin</option>
-                                </select>
-                            </div>
-
-                            <div class="form-group">
-                                <label for="location">Location / Room (if applicable)</label>
-                                <input type="text" id="location" placeholder="e.g., Room 402 or Remote">
-                            </div>
-
-                            <div class="form-group span-full">
-                                <label for="description">Detailed Description <span class="required">*</span></label>
-                                <textarea id="description" rows="5" required placeholder="Please describe the issue in detail..."></textarea>
-                            </div>
-
-                            <div class="form-group span-full">
-                                <label>Attachments (Optional)</label>
-                                <div class="file-upload-zone" id="file-drop-area">
-                                    <input type="file" id="attachment" accept="image/*,.pdf" hidden>
-                                    <div class="upload-content">
-                                        <i class="ph ph-upload-simple"></i>
-                                        <p>Click to browse or drag and drop</p>
-                                        <span class="text-xs text-muted">PNG, JPG, PDF up to 5MB</span>
-                                    </div>
-                                    <div class="file-preview hidden" id="file-preview">
-                                        <i class="ph ph-file-text"></i>
-                                        <span id="file-name">filename.png</span>
-                                        <button type="button" id="remove-file"><i class="ph ph-x"></i></button>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <div class="form-group span-full">
-                                <label for="contact">Contact Email or Phone <span class="required">*</span></label>
-                                <input type="text" id="contact" required placeholder="How can we reach you?">
-                            </div>
-                        </div>
-
-                        <div class="form-actions">
-                            <button type="button" class="btn btn-secondary" onclick="document.getElementById('complaint-form').reset(); window.app.removeAttachment();">Reset</button>
-                            <button type="submit" class="btn btn-primary">
-                                <i class="ph ph-paper-plane-right"></i> Submit Complaint
-                            </button>
-                        </div>
-                    </form>
-                </div>
-            </section>
-
-            <!-- Listings View -->
-            <section id="view-listings" class="view-section fade-in">
-                <div class="card listings-card">
-                    <div class="listings-toolbar">
-                        <div class="search-box">
-                            <i class="ph ph-magnifying-glass"></i>
-                            <input type="text" id="search-input" placeholder="Search by ID or Title...">
-                        </div>
-                        <div class="filter-group">
-                            <select id="filter-status" class="filter-select">
-                                <option value="all">All Statuses</option>
-                                <option value="pending">Pending</option>
-                                <option value="in_progress">In Progress</option>
-                                <option value="resolved">Resolved</option>
-                                <option value="rejected">Rejected</option>
-                            </select>
-                            <select id="filter-priority" class="filter-select">
-                                <option value="all">All Priorities</option>
-                                <option value="high">High</option>
-                                <option value="medium">Medium</option>
-                                <option value="low">Low</option>
-                            </select>
-                        </div>
-                    </div>
-                    
-                    <div class="table-container">
-                        <table class="data-table" id="complaints-table">
-                            <thead>
-                                <tr>
-                                    <th>ID</th>
-                                    <th>Title</th>
-                                    <th>Priority</th>
-                                    <th>Status</th>
-                                    <th>Date</th>
-                                    <th>Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody id="listings-table-body">
-                                <!-- Dynamic content -->
-                            </tbody>
-                        </table>
-                        <div id="listings-empty" class="empty-state hidden">
-                            <i class="ph ph-magnifying-glass"></i>
-                            <h3>No complaints found</h3>
-                            <p>Try adjusting your search or filters.</p>
-                            <button class="btn btn-secondary mt-4" onclick="window.app.clearFilters()">Clear Filters</button>
-                        </div>
-                    </div>
-                </div>
-            </section>
-
-            <!-- Details View -->
-            <section id="view-details" class="view-section fade-in">
-                <div class="details-header-actions">
-                    <button class="btn btn-secondary" onclick="window.app.switchView('listings')">
-                        <i class="ph ph-arrow-left"></i> Back to List
-                    </button>
-                </div>
-                
-                <div class="details-grid" id="details-content">
-                    <!-- Dynamic details content -->
-                </div>
-            </section>
-
-            <!-- Admin Panel View -->
-            <section id="view-admin" class="view-section fade-in">
-                <div class="card admin-card">
-                    <div class="card-header">
-                        <h3>Management Console</h3>
-                        <p class="text-muted">Process and resolve active complaints.</p>
-                    </div>
-                    
-                    <div class="admin-grid">
-                        <!-- Left col: List of active complaints -->
-                        <div class="admin-list-col">
-                            <div class="search-box mb-4">
-                                <i class="ph ph-magnifying-glass"></i>
-                                <input type="text" id="admin-search" placeholder="Search active...">
-                            </div>
-                            <div class="admin-complaints-list" id="admin-complaints-list">
-                                <!-- Dynamic admin list -->
-                            </div>
-                        </div>
-                        
-                        <!-- Right col: Editor -->
-                        <div class="admin-editor-col">
-                            <div id="admin-editor-empty" class="empty-state">
-                                <i class="ph ph-cursor-click"></i>
-                                <h3>Select a complaint</h3>
-                                <p>Choose a complaint from the list to manage it.</p>
-                            </div>
-                            
-                            <div id="admin-editor-form" class="hidden">
-                                <h3 id="admin-edit-title" class="mb-4">Complaint ID</h3>
-                                
-                                <div class="form-group">
-                                    <label>Current Status</label>
-                                    <select id="admin-status" class="status-select">
-                                        <option value="pending">Pending</option>
-                                        <option value="in_progress">In Progress</option>
-                                        <option value="resolved">Resolved</option>
-                                        <option value="rejected">Rejected</option>
-                                    </select>
-                                </div>
-                                
-                                <div class="form-group">
-                                    <label>Assigned Department</label>
-                                    <select id="admin-department">
-                                        <option value="it">IT Support</option>
-                                        <option value="facilities">Facilities</option>
-                                        <option value="hr">HR</option>
-                                        <option value="general">General Admin</option>
-                                    </select>
-                                </div>
-
-                                <div class="form-group">
-                                    <label>Resolution Notes (Visible to user)</label>
-                                    <textarea id="admin-notes" rows="6" placeholder="Enter troubleshooting steps or resolution details..."></textarea>
-                                </div>
-                                
-                                <button class="btn btn-primary w-full mt-4" onclick="window.app.saveAdminChanges()">
-                                    <i class="ph ph-floppy-disk"></i> Save Changes
-                                </button>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </section>
-            
-        </main>
+              </div>
+            </div>
+          </div>
+        </section>
+      </main>
     </div>
 
     <!-- Toast Notification -->
-    <div id="toast" class="toast hidden">
-        <div class="toast-icon" id="toast-icon"><i class="ph ph-check-circle"></i></div>
-        <div class="toast-content">
-            <h4 id="toast-title">Success</h4>
-            <p id="toast-message">Action completed.</p>
-        </div>
-        <button class="toast-close" onclick="document.getElementById('toast').classList.add('hidden')"><i class="ph ph-x"></i></button>
+    <div id="toast" class="hidden toast">
+      <div class="toast-icon" id="toast-icon">
+        <i class="ph ph-check-circle"></i>
+      </div>
+      <div class="toast-content">
+        <h4 id="toast-title">Success</h4>
+        <p id="toast-message">Action completed.</p>
+      </div>
+      <button
+        class="toast-close"
+        onclick="document.getElementById('toast').classList.add('hidden')"
+      >
+        <i class="ph ph-x"></i>
+      </button>
     </div>
 
     <!-- Scripts -->
     <script src="script.js" type="module"></script>
-</body>
+  </body>
 </html>

--- a/public/Complaint_Management_System/script.js
+++ b/public/Complaint_Management_System/script.js
@@ -1,386 +1,412 @@
 class ComplaintApp {
-    constructor() {
-        this.items = this.loadItems();
-        this.currentView = 'dashboard';
-        this.selectedAdminComplaint = null;
-        this.init();
-    }
+  constructor() {
+    this.items = this.loadItems();
+    this.currentView = 'dashboard';
+    this.selectedAdminComplaint = null;
+    this.init();
+  }
 
-    // --- State Management ---
-    loadItems() {
-        const stored = localStorage.getItem('complaintSystemData');
-        if (stored) {
-            return JSON.parse(stored);
+  // --- State Management ---
+  loadItems() {
+    const stored = localStorage.getItem('complaintSystemData');
+    if (stored) {
+      return JSON.parse(stored);
+    }
+    return [];
+  }
+
+  saveItems() {
+    localStorage.setItem('complaintSystemData', JSON.stringify(this.items));
+    this.updateDashboardStats();
+  }
+
+  // --- Initialization ---
+  init() {
+    this.cacheDOM();
+    this.bindEvents();
+    this.initTheme();
+
+    // Initial Renders
+    this.updateDashboardStats();
+    this.renderRecentComplaints();
+  }
+
+  cacheDOM() {
+    // Navigation
+    this.navItems = document.querySelectorAll('.nav-item[data-view]');
+    this.views = document.querySelectorAll('.view-section');
+    this.mobileToggle = document.querySelector('.mobile-toggle');
+    this.sidebar = document.querySelector('.sidebar');
+    this.pageTitle = document.getElementById('page-title');
+    this.themeToggle = document.getElementById('theme-toggle');
+
+    // Dashboard
+    this.statTotal = document.getElementById('stat-total');
+    this.statPending = document.getElementById('stat-pending');
+    this.statProgress = document.getElementById('stat-progress');
+    this.statResolved = document.getElementById('stat-resolved');
+    this.recentTableBody = document.getElementById('recent-table-body');
+
+    // Forms
+    this.complaintForm = document.getElementById('complaint-form');
+    this.fileInput = document.getElementById('attachment');
+    this.fileDropArea = document.getElementById('file-drop-area');
+    this.filePreview = document.getElementById('file-preview');
+    this.fileName = document.getElementById('file-name');
+    this.removeFileBtn = document.getElementById('remove-file');
+
+    // Listings
+    this.searchInput = document.getElementById('search-input');
+    this.filterStatus = document.getElementById('filter-status');
+    this.filterPriority = document.getElementById('filter-priority');
+    this.listingsTableBody = document.getElementById('listings-table-body');
+    this.listingsEmpty = document.getElementById('listings-empty');
+    this.complaintsTable = document.getElementById('complaints-table');
+
+    // Details
+    this.detailsContent = document.getElementById('details-content');
+
+    // Admin
+    this.adminSearch = document.getElementById('admin-search');
+    this.adminComplaintsList = document.getElementById('admin-complaints-list');
+    this.adminEditorEmpty = document.getElementById('admin-editor-empty');
+    this.adminEditorForm = document.getElementById('admin-editor-form');
+
+    // Toast
+    this.toast = document.getElementById('toast');
+    this.toastTitle = document.getElementById('toast-title');
+    this.toastMessage = document.getElementById('toast-message');
+    this.toastIcon = document.getElementById('toast-icon');
+  }
+
+  bindEvents() {
+    // Navigation
+    this.navItems.forEach((item) => {
+      item.addEventListener('click', () => {
+        this.switchView(item.dataset.view);
+        if (window.innerWidth <= 768) {
+          this.sidebar.classList.remove('open');
         }
-        return [];
+      });
+    });
+
+    this.mobileToggle.addEventListener('click', () => {
+      this.sidebar.classList.toggle('open');
+    });
+
+    this.themeToggle.addEventListener('click', () => this.toggleTheme());
+
+    // File Upload
+    this.fileDropArea.addEventListener('click', (e) => {
+      if (
+        e.target !== this.removeFileBtn &&
+        !this.removeFileBtn.contains(e.target)
+      ) {
+        this.fileInput.click();
+      }
+    });
+
+    this.fileInput.addEventListener('change', (e) => this.handleFileSelect(e));
+    this.removeFileBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      this.removeAttachment();
+    });
+
+    // Form Submit
+    this.complaintForm.addEventListener('submit', (e) =>
+      this.handleComplaintSubmit(e)
+    );
+
+    // Filters
+    this.searchInput.addEventListener('input', () => this.renderListings());
+    this.filterStatus.addEventListener('change', () => this.renderListings());
+    this.filterPriority.addEventListener('change', () => this.renderListings());
+
+    // Admin Search
+    this.adminSearch.addEventListener('input', () => this.renderAdminList());
+  }
+
+  // --- Theme & UI ---
+  initTheme() {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+      document.body.setAttribute('data-theme', 'dark');
+    } else if (
+      !storedTheme &&
+      window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches
+    ) {
+      document.body.setAttribute('data-theme', 'dark');
     }
+  }
 
-    saveItems() {
-        localStorage.setItem('complaintSystemData', JSON.stringify(this.items));
-        this.updateDashboardStats();
-    }
-
-    // --- Initialization ---
-    init() {
-        this.cacheDOM();
-        this.bindEvents();
-        this.initTheme();
-        
-        // Initial Renders
-        this.updateDashboardStats();
-        this.renderRecentComplaints();
-    }
-
-    cacheDOM() {
-        // Navigation
-        this.navItems = document.querySelectorAll('.nav-item[data-view]');
-        this.views = document.querySelectorAll('.view-section');
-        this.mobileToggle = document.querySelector('.mobile-toggle');
-        this.sidebar = document.querySelector('.sidebar');
-        this.pageTitle = document.getElementById('page-title');
-        this.themeToggle = document.getElementById('theme-toggle');
-        
-        // Dashboard
-        this.statTotal = document.getElementById('stat-total');
-        this.statPending = document.getElementById('stat-pending');
-        this.statProgress = document.getElementById('stat-progress');
-        this.statResolved = document.getElementById('stat-resolved');
-        this.recentTableBody = document.getElementById('recent-table-body');
-        
-        // Forms
-        this.complaintForm = document.getElementById('complaint-form');
-        this.fileInput = document.getElementById('attachment');
-        this.fileDropArea = document.getElementById('file-drop-area');
-        this.filePreview = document.getElementById('file-preview');
-        this.fileName = document.getElementById('file-name');
-        this.removeFileBtn = document.getElementById('remove-file');
-        
-        // Listings
-        this.searchInput = document.getElementById('search-input');
-        this.filterStatus = document.getElementById('filter-status');
-        this.filterPriority = document.getElementById('filter-priority');
-        this.listingsTableBody = document.getElementById('listings-table-body');
-        this.listingsEmpty = document.getElementById('listings-empty');
-        this.complaintsTable = document.getElementById('complaints-table');
-        
-        // Details
-        this.detailsContent = document.getElementById('details-content');
-        
-        // Admin
-        this.adminSearch = document.getElementById('admin-search');
-        this.adminComplaintsList = document.getElementById('admin-complaints-list');
-        this.adminEditorEmpty = document.getElementById('admin-editor-empty');
-        this.adminEditorForm = document.getElementById('admin-editor-form');
-        
-        // Toast
-        this.toast = document.getElementById('toast');
-        this.toastTitle = document.getElementById('toast-title');
-        this.toastMessage = document.getElementById('toast-message');
-        this.toastIcon = document.getElementById('toast-icon');
-    }
-
-    bindEvents() {
-        // Navigation
-        this.navItems.forEach(item => {
-            item.addEventListener('click', () => {
-                this.switchView(item.dataset.view);
-                if(window.innerWidth <= 768) {
-                    this.sidebar.classList.remove('open');
-                }
-            });
-        });
-
-        this.mobileToggle.addEventListener('click', () => {
-            this.sidebar.classList.toggle('open');
-        });
-
-        this.themeToggle.addEventListener('click', () => this.toggleTheme());
-
-        // File Upload
-        this.fileDropArea.addEventListener('click', (e) => {
-            if(e.target !== this.removeFileBtn && !this.removeFileBtn.contains(e.target)) {
-                this.fileInput.click();
-            }
-        });
-        
-        this.fileInput.addEventListener('change', (e) => this.handleFileSelect(e));
-        this.removeFileBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            this.removeAttachment();
-        });
-
-        // Form Submit
-        this.complaintForm.addEventListener('submit', (e) => this.handleComplaintSubmit(e));
-
-        // Filters
-        this.searchInput.addEventListener('input', () => this.renderListings());
-        this.filterStatus.addEventListener('change', () => this.renderListings());
-        this.filterPriority.addEventListener('change', () => this.renderListings());
-        
-        // Admin Search
-        this.adminSearch.addEventListener('input', () => this.renderAdminList());
-    }
-
-    // --- Theme & UI ---
-    initTheme() {
-        const storedTheme = localStorage.getItem('theme');
-        if (storedTheme === 'dark') {
-            document.body.setAttribute('data-theme', 'dark');
-        } else if (!storedTheme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-            document.body.setAttribute('data-theme', 'dark');
-        }
-    }
-
-    toggleTheme() {
+  toggleTheme() {
     const current = document.body.getAttribute('data-theme');
     const btn = document.getElementById('theme-toggle');
     if (current === 'dark') {
-        document.body.removeAttribute('data-theme');
-        localStorage.setItem('theme', 'light');
-        if (btn) btn.innerHTML = '<i class="ph ph-sun"></i> Dark Mode';
+      document.body.removeAttribute('data-theme');
+      localStorage.setItem('theme', 'light');
+      if (btn) btn.innerHTML = '<i class="ph ph-sun"></i> Dark Mode';
     } else {
-        document.body.setAttribute('data-theme', 'dark');
-        localStorage.setItem('theme', 'dark');
-        if (btn) btn.innerHTML = '<i class="ph ph-moon"></i> Light Mode';
+      document.body.setAttribute('data-theme', 'dark');
+      localStorage.setItem('theme', 'dark');
+      if (btn) btn.innerHTML = '<i class="ph ph-moon"></i> Light Mode';
     }
-}
+  }
 
-    showToast(title, message, type = 'success') {
-        this.toastTitle.textContent = title;
-        this.toastMessage.textContent = message;
-        
-        if (type === 'success') {
-            this.toastIcon.innerHTML = '<i class="ph ph-check-circle"></i>';
-            this.toastIcon.style.color = 'var(--status-resolved)';
-        } else if (type === 'error') {
-            this.toastIcon.innerHTML = '<i class="ph ph-warning-circle"></i>';
-            this.toastIcon.style.color = 'var(--status-rejected)';
-        }
-        
-        this.toast.classList.remove('hidden');
-        setTimeout(() => {
-            this.toast.classList.add('hidden');
-        }, 3000);
+  showToast(title, message, type = 'success') {
+    this.toastTitle.textContent = title;
+    this.toastMessage.textContent = message;
+
+    if (type === 'success') {
+      this.toastIcon.innerHTML = '<i class="ph ph-check-circle"></i>';
+      this.toastIcon.style.color = 'var(--status-resolved)';
+    } else if (type === 'error') {
+      this.toastIcon.innerHTML = '<i class="ph ph-warning-circle"></i>';
+      this.toastIcon.style.color = 'var(--status-rejected)';
     }
 
-    // --- Routing ---
-    switchView(viewId) {
-        this.currentView = viewId;
-        
-        // Update nav UI
-        this.navItems.forEach(item => {
-            if(item.dataset.view === viewId) item.classList.add('active');
-            else item.classList.remove('active');
-        });
+    this.toast.classList.remove('hidden');
+    setTimeout(() => {
+      this.toast.classList.add('hidden');
+    }, 3000);
+  }
 
-        // Update sections
-        this.views.forEach(section => {
-            if(section.id === `view-${viewId}`) section.classList.add('active');
-            else section.classList.remove('active');
-        });
+  // --- Routing ---
+  switchView(viewId) {
+    this.currentView = viewId;
 
-        // Update Title
-        const titles = {
-            'dashboard': 'Dashboard Overview',
-            'submit': 'Submit Complaint',
-            'listings': 'Complaint Directory',
-            'details': 'Complaint Details',
-            'admin': 'Admin Panel'
-        };
-        this.pageTitle.textContent = titles[viewId] || 'Portal';
+    // Update nav UI
+    this.navItems.forEach((item) => {
+      if (item.dataset.view === viewId) item.classList.add('active');
+      else item.classList.remove('active');
+    });
 
-        // Trigger view-specific renders
-        if (viewId === 'dashboard') {
-            this.updateDashboardStats();
-            this.renderRecentComplaints();
-        } else if (viewId === 'listings') {
-            this.renderListings();
-        } else if (viewId === 'admin') {
-            this.selectedAdminComplaint = null;
-            this.renderAdminList();
-            this.renderAdminEditor();
-        }
+    // Update sections
+    this.views.forEach((section) => {
+      if (section.id === `view-${viewId}`) section.classList.add('active');
+      else section.classList.remove('active');
+    });
 
-        window.scrollTo({ top: 0, behavior: 'smooth' });
+    // Update Title
+    const titles = {
+      dashboard: 'Dashboard Overview',
+      submit: 'Submit Complaint',
+      listings: 'Complaint Directory',
+      details: 'Complaint Details',
+      admin: 'Admin Panel',
+    };
+    this.pageTitle.textContent = titles[viewId] || 'Portal';
+
+    // Trigger view-specific renders
+    if (viewId === 'dashboard') {
+      this.updateDashboardStats();
+      this.renderRecentComplaints();
+    } else if (viewId === 'listings') {
+      this.renderListings();
+    } else if (viewId === 'admin') {
+      this.selectedAdminComplaint = null;
+      this.renderAdminList();
+      this.renderAdminEditor();
     }
 
-    // --- Utilities ---
-    generateId() {
-        const prefix = "CMP-";
-        const randomStr = Math.random().toString(36).substring(2, 6).toUpperCase();
-        const dateStr = new Date().toISOString().slice(2, 10).replace(/-/g, '');
-        return `${prefix}${dateStr}-${randomStr}`;
-    }
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
 
-    getStatusConfig(status) {
-        const config = {
-            'pending': { text: 'Pending', class: 'badge-pending' },
-            'in_progress': { text: 'In Progress', class: 'badge-in_progress' },
-            'resolved': { text: 'Resolved', class: 'badge-resolved' },
-            'rejected': { text: 'Rejected', class: 'badge-rejected' }
-        };
-        return config[status] || { text: 'Unknown', class: 'badge-pending' };
-    }
+  // --- Utilities ---
+  generateId() {
+    const prefix = 'CMP-';
+    const randomStr = Math.random().toString(36).substring(2, 6).toUpperCase();
+    const dateStr = new Date().toISOString().slice(2, 10).replace(/-/g, '');
+    return `${prefix}${dateStr}-${randomStr}`;
+  }
 
-    getPriorityConfig(priority) {
-        const config = {
-            'low': { text: 'Low', class: 'badge-pending' },
-            'medium': { text: 'Medium', class: 'badge-in_progress' },
-            'high': { text: 'High', class: 'badge-rejected' }
-        };
-        return config[priority] || { text: 'Normal', class: 'badge-pending' };
-    }
+  getStatusConfig(status) {
+    const config = {
+      pending: { text: 'Pending', class: 'badge-pending' },
+      in_progress: { text: 'In Progress', class: 'badge-in_progress' },
+      resolved: { text: 'Resolved', class: 'badge-resolved' },
+      rejected: { text: 'Rejected', class: 'badge-rejected' },
+    };
+    return config[status] || { text: 'Unknown', class: 'badge-pending' };
+  }
 
-    // --- File Handling ---
-    handleFileSelect(e) {
-        const file = e.target.files[0];
-        if (file) {
-            // Check size (5MB)
-            if (file.size > 5 * 1024 * 1024) {
-                this.showToast('File Too Large', 'Maximum file size is 5MB', 'error');
-                this.fileInput.value = '';
-                return;
-            }
-            this.fileName.textContent = file.name;
-            document.querySelector('.upload-content').style.display = 'none';
-            this.filePreview.classList.remove('hidden');
-            this.filePreview.style.display = 'flex';
-        }
-    }
+  getPriorityConfig(priority) {
+    const config = {
+      low: { text: 'Low', class: 'badge-pending' },
+      medium: { text: 'Medium', class: 'badge-in_progress' },
+      high: { text: 'High', class: 'badge-rejected' },
+    };
+    return config[priority] || { text: 'Normal', class: 'badge-pending' };
+  }
 
-    removeAttachment() {
+  // --- File Handling ---
+  handleFileSelect(e) {
+    const file = e.target.files[0];
+    if (file) {
+      // Check size (5MB)
+      if (file.size > 5 * 1024 * 1024) {
+        this.showToast('File Too Large', 'Maximum file size is 5MB', 'error');
         this.fileInput.value = '';
-        this.fileName.textContent = '';
-        document.querySelector('.upload-content').style.display = 'flex';
-        this.filePreview.classList.add('hidden');
-        this.filePreview.style.display = 'none';
+        return;
+      }
+      this.fileName.textContent = file.name;
+      document.querySelector('.upload-content').style.display = 'none';
+      this.filePreview.classList.remove('hidden');
+      this.filePreview.style.display = 'flex';
+    }
+  }
+
+  removeAttachment() {
+    this.fileInput.value = '';
+    this.fileName.textContent = '';
+    document.querySelector('.upload-content').style.display = 'flex';
+    this.filePreview.classList.add('hidden');
+    this.filePreview.style.display = 'none';
+  }
+
+  // --- Submitting ---
+  handleComplaintSubmit(e) {
+    e.preventDefault();
+
+    const file = this.fileInput.files[0];
+    let fileDataUrl = '';
+
+    // If a file is attached, read it as Data URL to store in localStorage safely
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        fileDataUrl = event.target.result;
+        this.finalizeSubmission(fileDataUrl);
+      };
+      reader.readAsDataURL(file);
+    } else {
+      this.finalizeSubmission('');
+    }
+  }
+
+  finalizeSubmission(attachmentData) {
+    const newComplaint = {
+      id: this.generateId(),
+      title: document.getElementById('title').value,
+      category: document.getElementById('category').value,
+      priority: document.getElementById('priority').value,
+      department: document.getElementById('department').value,
+      location: document.getElementById('location').value,
+      description: document.getElementById('description').value,
+      contact: document.getElementById('contact').value,
+      attachment: attachmentData,
+      status: 'pending',
+      resolutionNotes: '',
+      createdAt: new Date().toISOString(),
+      timeline: [
+        {
+          status: 'pending',
+          date: new Date().toISOString(),
+          note: 'Complaint submitted by user.',
+        },
+      ],
+    };
+
+    this.items.unshift(newComplaint);
+    this.saveItems();
+
+    this.complaintForm.reset();
+    this.removeAttachment();
+
+    this.showToast(
+      'Complaint Submitted',
+      `Your Complaint ID is ${newComplaint.id}`
+    );
+    setTimeout(() => {
+      this.viewComplaintDetails(newComplaint.id);
+    }, 1500);
+  }
+
+  // --- Dashboard Rendering ---
+  updateDashboardStats() {
+    const total = this.items.length;
+    const pending = this.items.filter((i) => i.status === 'pending').length;
+    const progress = this.items.filter(
+      (i) => i.status === 'in_progress'
+    ).length;
+    const resolved = this.items.filter((i) => i.status === 'resolved').length;
+
+    this.statTotal.textContent = total;
+    this.statPending.textContent = pending;
+    this.statProgress.textContent = progress;
+    this.statResolved.textContent = resolved;
+  }
+
+  renderRecentComplaints() {
+    this.recentTableBody.innerHTML = '';
+    const recentItems = this.items.slice(0, 5);
+
+    if (recentItems.length === 0) {
+      this.recentTableBody.innerHTML = `<tr><td colspan="5" style="text-align: center; color: var(--text-muted); padding: 2rem;">No complaints found.</td></tr>`;
+      return;
     }
 
-    // --- Submitting ---
-    handleComplaintSubmit(e) {
-        e.preventDefault();
-        
-        const file = this.fileInput.files[0];
-        let fileDataUrl = '';
+    recentItems.forEach((item) => {
+      const tr = document.createElement('tr');
+      const statusCfg = this.getStatusConfig(item.status);
+      const date = new Date(item.createdAt).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      });
 
-        // If a file is attached, read it as Data URL to store in localStorage safely
-        if (file) {
-            const reader = new FileReader();
-            reader.onload = (event) => {
-                fileDataUrl = event.target.result;
-                this.finalizeSubmission(fileDataUrl);
-            };
-            reader.readAsDataURL(file);
-        } else {
-            this.finalizeSubmission('');
-        }
-    }
-
-    finalizeSubmission(attachmentData) {
-        const newComplaint = {
-            id: this.generateId(),
-            title: document.getElementById('title').value,
-            category: document.getElementById('category').value,
-            priority: document.getElementById('priority').value,
-            department: document.getElementById('department').value,
-            location: document.getElementById('location').value,
-            description: document.getElementById('description').value,
-            contact: document.getElementById('contact').value,
-            attachment: attachmentData,
-            status: 'pending',
-            createdAt: new Date().toISOString(),
-            timeline: [
-                {
-                    status: 'pending',
-                    date: new Date().toISOString(),
-                    note: 'Complaint submitted by user.'
-                }
-            ]
-        };
-
-        this.items.unshift(newComplaint);
-        this.saveItems();
-        
-        this.complaintForm.reset();
-        this.removeAttachment();
-        
-        this.showToast('Complaint Submitted', `Your Complaint ID is ${newComplaint.id}`);
-        setTimeout(() => {
-            this.viewComplaintDetails(newComplaint.id);
-        }, 1500);
-    }
-
-    // --- Dashboard Rendering ---
-    updateDashboardStats() {
-        const total = this.items.length;
-        const pending = this.items.filter(i => i.status === 'pending').length;
-        const progress = this.items.filter(i => i.status === 'in_progress').length;
-        const resolved = this.items.filter(i => i.status === 'resolved').length;
-
-        this.statTotal.textContent = total;
-        this.statPending.textContent = pending;
-        this.statProgress.textContent = progress;
-        this.statResolved.textContent = resolved;
-    }
-
-    renderRecentComplaints() {
-        this.recentTableBody.innerHTML = '';
-        const recentItems = this.items.slice(0, 5);
-
-        if (recentItems.length === 0) {
-            this.recentTableBody.innerHTML = `<tr><td colspan="5" style="text-align: center; color: var(--text-muted); padding: 2rem;">No complaints found.</td></tr>`;
-            return;
-        }
-
-        recentItems.forEach(item => {
-            const tr = document.createElement('tr');
-            const statusCfg = this.getStatusConfig(item.status);
-            const date = new Date(item.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-
-            tr.innerHTML = `
+      tr.innerHTML = `
                 <td style="font-family: monospace; font-weight: 500;">${item.id}</td>
                 <td style="font-weight: 500;">${item.title}</td>
                 <td style="text-transform: capitalize;">${item.category}</td>
                 <td><span class="badge ${statusCfg.class}">${statusCfg.text}</span></td>
                 <td>${date}</td>
             `;
-            tr.style.cursor = 'pointer';
-            tr.onclick = () => this.viewComplaintDetails(item.id);
-            this.recentTableBody.appendChild(tr);
-        });
+      tr.style.cursor = 'pointer';
+      tr.onclick = () => this.viewComplaintDetails(item.id);
+      this.recentTableBody.appendChild(tr);
+    });
+  }
+
+  // --- Listings Rendering ---
+  renderListings() {
+    const query = this.searchInput.value.toLowerCase();
+    const statusFilter = this.filterStatus.value;
+    const priorityFilter = this.filterPriority.value;
+
+    const filtered = this.items.filter((item) => {
+      const matchesSearch =
+        item.title.toLowerCase().includes(query) ||
+        item.id.toLowerCase().includes(query);
+      const matchesStatus =
+        statusFilter === 'all' || item.status === statusFilter;
+      const matchesPriority =
+        priorityFilter === 'all' || item.priority === priorityFilter;
+      return matchesSearch && matchesStatus && matchesPriority;
+    });
+
+    this.listingsTableBody.innerHTML = '';
+
+    if (filtered.length === 0) {
+      this.complaintsTable.classList.add('hidden');
+      this.listingsEmpty.classList.remove('hidden');
+      return;
     }
 
-    // --- Listings Rendering ---
-    renderListings() {
-        const query = this.searchInput.value.toLowerCase();
-        const statusFilter = this.filterStatus.value;
-        const priorityFilter = this.filterPriority.value;
+    this.complaintsTable.classList.remove('hidden');
+    this.listingsEmpty.classList.add('hidden');
 
-        const filtered = this.items.filter(item => {
-            const matchesSearch = item.title.toLowerCase().includes(query) || item.id.toLowerCase().includes(query);
-            const matchesStatus = statusFilter === 'all' || item.status === statusFilter;
-            const matchesPriority = priorityFilter === 'all' || item.priority === priorityFilter;
-            return matchesSearch && matchesStatus && matchesPriority;
-        });
+    filtered.forEach((item) => {
+      const tr = document.createElement('tr');
+      const statusCfg = this.getStatusConfig(item.status);
+      const priorityCfg = this.getPriorityConfig(item.priority);
+      const date = new Date(item.createdAt).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      });
 
-        this.listingsTableBody.innerHTML = '';
-
-        if (filtered.length === 0) {
-            this.complaintsTable.classList.add('hidden');
-            this.listingsEmpty.classList.remove('hidden');
-            return;
-        }
-
-        this.complaintsTable.classList.remove('hidden');
-        this.listingsEmpty.classList.add('hidden');
-
-        filtered.forEach(item => {
-            const tr = document.createElement('tr');
-            const statusCfg = this.getStatusConfig(item.status);
-            const priorityCfg = this.getPriorityConfig(item.priority);
-            const date = new Date(item.createdAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-
-            tr.innerHTML = `
+      tr.innerHTML = `
                 <td style="font-family: monospace; font-weight: 500;">${item.id}</td>
                 <td style="font-weight: 500; max-width: 250px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">${item.title}</td>
                 <td><span class="badge ${priorityCfg.class}">${priorityCfg.text}</span></td>
@@ -392,57 +418,63 @@ class ComplaintApp {
                     </button>
                 </td>
             `;
-            tr.style.cursor = 'pointer';
-            tr.onclick = () => this.viewComplaintDetails(item.id);
-            this.listingsTableBody.appendChild(tr);
-        });
-    }
+      tr.style.cursor = 'pointer';
+      tr.onclick = () => this.viewComplaintDetails(item.id);
+      this.listingsTableBody.appendChild(tr);
+    });
+  }
 
-    clearFilters() {
-        this.searchInput.value = '';
-        this.filterStatus.value = 'all';
-        this.filterPriority.value = 'all';
-        this.renderListings();
-    }
+  clearFilters() {
+    this.searchInput.value = '';
+    this.filterStatus.value = 'all';
+    this.filterPriority.value = 'all';
+    this.renderListings();
+  }
 
-    // --- Details Rendering ---
-    viewComplaintDetails(id) {
-        const item = this.items.find(i => i.id === id);
-        if (!item) return;
+  // --- Details Rendering ---
+  viewComplaintDetails(id) {
+    const item = this.items.find((i) => i.id === id);
+    if (!item) return;
 
-        this.switchView('details');
-        
-        const statusCfg = this.getStatusConfig(item.status);
-        const priorityCfg = this.getPriorityConfig(item.priority);
-        const date = new Date(item.createdAt).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' });
+    this.switchView('details');
 
-        let attachmentHTML = '';
-        if (item.attachment) {
-            // Check if it's likely an image by data URL prefix
-            if (item.attachment.startsWith('data:image')) {
-                attachmentHTML = `
+    const statusCfg = this.getStatusConfig(item.status);
+    const priorityCfg = this.getPriorityConfig(item.priority);
+    const date = new Date(item.createdAt).toLocaleString('en-US', {
+      dateStyle: 'medium',
+      timeStyle: 'short',
+    });
+
+    let attachmentHTML = '';
+    if (item.attachment) {
+      // Check if it's likely an image by data URL prefix
+      if (item.attachment.startsWith('data:image')) {
+        attachmentHTML = `
                     <div class="mt-4">
                         <h4>Attachment</h4>
                         <img src="${item.attachment}" class="attachment-img" alt="Attachment">
                     </div>
                 `;
-            } else {
-                attachmentHTML = `
+      } else {
+        attachmentHTML = `
                     <div class="mt-4">
                         <h4>Attachment</h4>
                         <a href="${item.attachment}" download="attachment" class="btn btn-secondary mt-2"><i class="ph ph-download-simple"></i> Download File</a>
                     </div>
                 `;
-            }
-        }
+      }
+    }
 
-        let timelineHTML = '';
-        item.timeline.forEach((event, idx) => {
-            const eventDate = new Date(event.date).toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' });
-            const sCfg = this.getStatusConfig(event.status);
-            const isLast = idx === item.timeline.length - 1;
-            
-            timelineHTML += `
+    let timelineHTML = '';
+    item.timeline.forEach((event, idx) => {
+      const eventDate = new Date(event.date).toLocaleString('en-US', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+      });
+      const sCfg = this.getStatusConfig(event.status);
+      const isLast = idx === item.timeline.length - 1;
+
+      timelineHTML += `
                 <div class="timeline-item">
                     <div class="timeline-dot ${isLast ? 'active' : ''}"></div>
                     <div class="timeline-content">
@@ -452,9 +484,9 @@ class ComplaintApp {
                     </div>
                 </div>
             `;
-        });
+    });
 
-        this.detailsContent.innerHTML = `
+    this.detailsContent.innerHTML = `
             <div class="details-main">
                 <div class="card details-info-card">
                     <div class="details-title-row">
@@ -510,104 +542,127 @@ class ComplaintApp {
                 </div>
             </div>
         `;
+  }
+
+  // --- Admin Rendering ---
+  renderAdminList() {
+    const query = this.adminSearch.value.toLowerCase();
+    // Only show pending or in_progress in the admin quick list, or all if searching
+    let filtered = this.items;
+    if (query) {
+      filtered = this.items.filter(
+        (item) =>
+          item.title.toLowerCase().includes(query) ||
+          item.id.toLowerCase().includes(query)
+      );
+    } else {
+      filtered = this.items.filter(
+        (item) => item.status === 'pending' || item.status === 'in_progress'
+      );
     }
 
-    // --- Admin Rendering ---
-    renderAdminList() {
-        const query = this.adminSearch.value.toLowerCase();
-        // Only show pending or in_progress in the admin quick list, or all if searching
-        let filtered = this.items;
-        if (query) {
-            filtered = this.items.filter(item => 
-                item.title.toLowerCase().includes(query) || 
-                item.id.toLowerCase().includes(query)
-            );
-        } else {
-            filtered = this.items.filter(item => item.status === 'pending' || item.status === 'in_progress');
-        }
+    this.adminComplaintsList.innerHTML = '';
 
-        this.adminComplaintsList.innerHTML = '';
-        
-        if(filtered.length === 0) {
-            this.adminComplaintsList.innerHTML = `<p class="text-muted" style="padding: 1rem; text-align: center;">No active complaints found.</p>`;
-            return;
-        }
+    if (filtered.length === 0) {
+      this.adminComplaintsList.innerHTML = `<p class="text-muted" style="padding: 1rem; text-align: center;">No active complaints found.</p>`;
+      return;
+    }
 
-        filtered.forEach(item => {
-            const div = document.createElement('div');
-            const isSelected = this.selectedAdminComplaint && this.selectedAdminComplaint.id === item.id;
-            const statusCfg = this.getStatusConfig(item.status);
-            
-            div.className = `admin-list-item ${isSelected ? 'selected' : ''}`;
-            div.innerHTML = `
+    filtered.forEach((item) => {
+      const div = document.createElement('div');
+      const isSelected =
+        this.selectedAdminComplaint &&
+        this.selectedAdminComplaint.id === item.id;
+      const statusCfg = this.getStatusConfig(item.status);
+
+      div.className = `admin-list-item ${isSelected ? 'selected' : ''}`;
+      div.innerHTML = `
                 <div class="admin-list-item-header">
                     <h4>${item.id}</h4>
                     <span class="badge ${statusCfg.class}" style="font-size: 0.6rem; padding: 0.1rem 0.4rem;">${statusCfg.text}</span>
                 </div>
                 <p class="text-muted" style="font-size: 0.75rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">${item.title}</p>
             `;
-            div.onclick = () => this.selectAdminComplaint(item.id);
-            this.adminComplaintsList.appendChild(div);
-        });
+      div.onclick = () => this.selectAdminComplaint(item.id);
+      this.adminComplaintsList.appendChild(div);
+    });
+  }
+
+  selectAdminComplaint(id) {
+    this.selectedAdminComplaint = this.items.find((i) => i.id === id);
+    this.renderAdminList(); // update selected visual
+    this.renderAdminEditor();
+  }
+
+  renderAdminEditor() {
+    if (!this.selectedAdminComplaint) {
+      this.adminEditorEmpty.classList.remove('hidden');
+      this.adminEditorForm.classList.add('hidden');
+      return;
     }
 
-    selectAdminComplaint(id) {
-        this.selectedAdminComplaint = this.items.find(i => i.id === id);
-        this.renderAdminList(); // update selected visual
-        this.renderAdminEditor();
+    this.adminEditorEmpty.classList.add('hidden');
+    this.adminEditorForm.classList.remove('hidden');
+
+    document.getElementById('admin-edit-title').textContent =
+      `Manage: ${this.selectedAdminComplaint.id}`;
+    document.getElementById('admin-status').value =
+      this.selectedAdminComplaint.status;
+    document.getElementById('admin-department').value =
+      this.selectedAdminComplaint.department;
+    document.getElementById('admin-notes').value =
+      this.selectedAdminComplaint.resolutionNotes || '';
+  }
+
+  saveAdminChanges() {
+    if (!this.selectedAdminComplaint) return;
+
+    const newStatus = document.getElementById('admin-status').value;
+    const newDept = document.getElementById('admin-department').value;
+    const notes = document.getElementById('admin-notes').value;
+    const trimmedNotes = notes.trim();
+    let changed = false;
+
+    if (this.selectedAdminComplaint.department !== newDept) {
+      this.selectedAdminComplaint.department = newDept;
+      changed = true;
     }
 
-    renderAdminEditor() {
-        if (!this.selectedAdminComplaint) {
-            this.adminEditorEmpty.classList.remove('hidden');
-            this.adminEditorForm.classList.add('hidden');
-            return;
-        }
-
-        this.adminEditorEmpty.classList.add('hidden');
-        this.adminEditorForm.classList.remove('hidden');
-
-        document.getElementById('admin-edit-title').textContent = `Manage: ${this.selectedAdminComplaint.id}`;
-        document.getElementById('admin-status').value = this.selectedAdminComplaint.status;
-        document.getElementById('admin-department').value = this.selectedAdminComplaint.department;
-        document.getElementById('admin-notes').value = '';
+    if (this.selectedAdminComplaint.resolutionNotes !== trimmedNotes) {
+      this.selectedAdminComplaint.resolutionNotes = trimmedNotes;
+      changed = true;
     }
 
-    saveAdminChanges() {
-        if (!this.selectedAdminComplaint) return;
+    if (
+      this.selectedAdminComplaint.status !== newStatus ||
+      trimmedNotes !== ''
+    ) {
+      this.selectedAdminComplaint.status = newStatus;
 
-        const newStatus = document.getElementById('admin-status').value;
-        const newDept = document.getElementById('admin-department').value;
-        const notes = document.getElementById('admin-notes').value;
-
-        let changed = false;
-
-        if (this.selectedAdminComplaint.department !== newDept) {
-            this.selectedAdminComplaint.department = newDept;
-            changed = true;
-        }
-
-        if (this.selectedAdminComplaint.status !== newStatus || notes.trim() !== '') {
-            this.selectedAdminComplaint.status = newStatus;
-            
-            this.selectedAdminComplaint.timeline.push({
-                status: newStatus,
-                date: new Date().toISOString(),
-                note: notes.trim() !== '' ? notes : `Status updated to ${this.getStatusConfig(newStatus).text} by Admin.`
-            });
-            changed = true;
-        }
-
-        if (changed) {
-            this.saveItems();
-            this.showToast('Changes Saved', `Complaint ${this.selectedAdminComplaint.id} has been updated.`);
-            this.renderAdminList();
-            this.renderAdminEditor(); // clear notes
-        }
+      this.selectedAdminComplaint.timeline.push({
+        status: newStatus,
+        date: new Date().toISOString(),
+        note:
+          trimmedNotes !== ''
+            ? trimmedNotes
+            : `Status updated to ${this.getStatusConfig(newStatus).text} by Admin.`,
+      });
+      changed = true;
     }
+
+    if (changed) {
+      this.saveItems();
+      this.showToast(
+        'Changes Saved',
+        `Complaint ${this.selectedAdminComplaint.id} has been updated.`
+      );
+      this.renderAdminList();
+      this.renderAdminEditor();
+    }
+  }
 }
 
 // Initialize Application
 document.addEventListener('DOMContentLoaded', () => {
-    window.app = new ComplaintApp();
+  window.app = new ComplaintApp();
 });

--- a/public/Complaint_Management_System/style.css
+++ b/public/Complaint_Management_System/style.css
@@ -1,990 +1,1031 @@
 :root {
-    /* Light Theme (Vercel/Stripe inspired) */
-    --bg-color: #fafafa;
-    --text-primary: #171717;
-    --text-secondary: #666666;
-    --text-muted: #a3a3a3;
-    
-    /* Surfaces */
-    --surface-base: #ffffff;
-    --surface-elevated: rgba(255, 255, 255, 0.8);
-    --border-color: #eaeaea;
-    --border-light: rgba(0, 0, 0, 0.05);
-    
-    /* Brand Colors */
-    --primary: #000000;
-    --primary-hover: #333333;
-    --primary-foreground: #ffffff;
-    
-    /* Status Colors */
-    --status-pending: #f59e0b;
-    --status-progress: #3b82f6;
-    --status-resolved: #10b981;
-    --status-rejected: #ef4444;
-    
-    /* Effects */
-    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
-    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -2px rgba(0, 0, 0, 0.02);
-    --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.04);
-    
-    --radius-sm: 6px;
-    --radius-md: 10px;
-    --radius-lg: 16px;
-    
-    --transition: all 0.2s ease;
+  /* Light Theme (Vercel/Stripe inspired) */
+  --bg-color: #fafafa;
+  --text-primary: #171717;
+  --text-secondary: #666666;
+  --text-muted: #a3a3a3;
+
+  /* Surfaces */
+  --surface-base: #ffffff;
+  --surface-elevated: rgba(255, 255, 255, 0.8);
+  --border-color: #eaeaea;
+  --border-light: rgba(0, 0, 0, 0.05);
+
+  /* Brand Colors */
+  --primary: #000000;
+  --primary-hover: #333333;
+  --primary-foreground: #ffffff;
+
+  /* Status Colors */
+  --status-pending: #f59e0b;
+  --status-progress: #3b82f6;
+  --status-resolved: #10b981;
+  --status-rejected: #ef4444;
+
+  /* Effects */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.05), 0 2px 4px -1px rgba(0, 0, 0, 0.03);
+  --shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.05), 0 4px 6px -2px rgba(0, 0, 0, 0.02);
+  --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.04);
+
+  --radius-sm: 6px;
+  --radius-md: 10px;
+  --radius-lg: 16px;
+
+  --transition: all 0.2s ease;
 }
 
-[data-theme="dark"] {
-    /* Dark Theme (Linear/Cursor inspired) */
-    --bg-color: #000000;
-    --text-primary: #ededed;
-    --text-secondary: #a1a1aa;
-    --text-muted: #52525b;
-    
-    /* Surfaces */
-    --surface-base: #0a0a0a;
-    --surface-elevated: rgba(20, 20, 20, 0.7);
-    --border-color: #27272a;
-    --border-light: rgba(255, 255, 255, 0.05);
-    
-    /* Brand Colors */
-    --primary: #ffffff;
-    --primary-hover: #e5e5e5;
-    --primary-foreground: #000000;
-    
-    /* Effects */
-    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.5);
-    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.5), 0 2px 4px -1px rgba(0, 0, 0, 0.3);
-    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -2px rgba(0, 0, 0, 0.3);
-    --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.4);
+[data-theme='dark'] {
+  /* Dark Theme (Linear/Cursor inspired) */
+  --bg-color: #000000;
+  --text-primary: #ededed;
+  --text-secondary: #a1a1aa;
+  --text-muted: #52525b;
+
+  /* Surfaces */
+  --surface-base: #0a0a0a;
+  --surface-elevated: rgba(20, 20, 20, 0.7);
+  --border-color: #27272a;
+  --border-light: rgba(255, 255, 255, 0.05);
+
+  /* Brand Colors */
+  --primary: #ffffff;
+  --primary-hover: #e5e5e5;
+  --primary-foreground: #000000;
+
+  /* Effects */
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.5);
+  --shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.5), 0 2px 4px -1px rgba(0, 0, 0, 0.3);
+  --shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.5), 0 4px 6px -2px rgba(0, 0, 0, 0.3);
+  --glass-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.4);
 }
 
 /* Base Styles */
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 body {
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-    background-color: var(--bg-color);
-    color: var(--text-primary);
-    line-height: 1.5;
-    overflow-x: hidden;
-    transition: background-color 0.3s ease, color 0.3s ease;
+  font-family:
+    'Inter',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
+  background-color: var(--bg-color);
+  color: var(--text-primary);
+  line-height: 1.5;
+  overflow-x: hidden;
+  transition:
+    background-color 0.3s ease,
+    color 0.3s ease;
 }
 
 /* Background Effects */
 .bg-effects {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    z-index: -1;
-    overflow: hidden;
-    pointer-events: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: -1;
+  overflow: hidden;
+  pointer-events: none;
 }
 
 .glow {
-    position: absolute;
-    border-radius: 50%;
-    filter: blur(100px);
-    opacity: 0.15;
-    animation: float 20s ease-in-out infinite;
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(100px);
+  opacity: 0.15;
+  animation: float 20s ease-in-out infinite;
 }
 
 .glow-1 {
-    top: -10%;
-    left: -10%;
-    width: 600px;
-    height: 600px;
-    background: #6366f1;
+  top: -10%;
+  left: -10%;
+  width: 600px;
+  height: 600px;
+  background: #6366f1;
 }
 
 .glow-2 {
-    bottom: -10%;
-    right: -10%;
-    width: 500px;
-    height: 500px;
-    background: #10b981;
-    animation-delay: -10s;
+  bottom: -10%;
+  right: -10%;
+  width: 500px;
+  height: 500px;
+  background: #10b981;
+  animation-delay: -10s;
 }
 
 @keyframes float {
-    0%, 100% { transform: translate(0, 0); }
-    33% { transform: translate(30px, -50px); }
-    66% { transform: translate(-20px, 40px); }
+  0%,
+  100% {
+    transform: translate(0, 0);
+  }
+  33% {
+    transform: translate(30px, -50px);
+  }
+  66% {
+    transform: translate(-20px, 40px);
+  }
 }
 
 /* Layout */
 .app-container {
-    display: flex;
-    min-height: 100vh;
+  display: flex;
+  min-height: 100vh;
 }
 
 /* Sidebar */
 .sidebar {
-    width: 260px;
-    background: var(--surface-base);
-    border-right: 1px solid var(--border-color);
-    display: flex;
-    flex-direction: column;
-    padding: 1.5rem 1rem;
-    position: fixed;
-    height: 100vh;
-    z-index: 40;
-    transition: var(--transition);
+  width: 260px;
+  background: var(--surface-base);
+  border-right: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  padding: 1.5rem 1rem;
+  position: fixed;
+  height: 100vh;
+  z-index: 40;
+  transition: var(--transition);
 }
 
 .brand {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0 0.5rem 2rem 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0 0.5rem 2rem 0.5rem;
 }
 
 .brand-icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 32px;
-    height: 32px;
-    background: var(--primary);
-    color: var(--primary-foreground);
-    border-radius: var(--radius-sm);
-    font-size: 1.2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  background: var(--primary);
+  color: var(--primary-foreground);
+  border-radius: var(--radius-sm);
+  font-size: 1.2rem;
 }
 
 .brand h2 {
-    font-size: 1.25rem;
-    font-weight: 600;
-    letter-spacing: -0.02em;
+  font-size: 1.25rem;
+  font-weight: 600;
+  letter-spacing: -0.02em;
 }
 
 .nav-menu {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .nav-label {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--text-muted);
-    margin: 1rem 0 0.5rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin: 1rem 0 0.5rem 0.5rem;
 }
 
 .nav-item {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.5rem 0.75rem;
-    border: none;
-    background: transparent;
-    color: var(--text-secondary);
-    font-family: inherit;
-    font-size: 0.875rem;
-    font-weight: 500;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: var(--transition);
-    text-align: left;
-    width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: var(--transition);
+  text-align: left;
+  width: 100%;
 }
 
 .nav-item i {
-    font-size: 1.25rem;
+  font-size: 1.25rem;
 }
 
 .nav-item:hover {
-    background: var(--border-light);
-    color: var(--text-primary);
+  background: var(--border-light);
+  color: var(--text-primary);
 }
 
 .nav-item.active {
-    background: var(--border-light);
-    color: var(--text-primary);
-    font-weight: 600;
+  background: var(--border-light);
+  color: var(--text-primary);
+  font-weight: 600;
 }
 
 .sidebar-footer {
-    padding-top: 1rem;
-    border-top: 1px solid var(--border-color);
+  padding-top: 1rem;
+  border-top: 1px solid var(--border-color);
 }
 
 /* Main Content Area */
 .main-content {
-    flex: 1;
-    margin-left: 260px;
-    display: flex;
-    flex-direction: column;
-    min-height: 100vh;
+  flex: 1;
+  margin-left: 260px;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
 .top-header {
-    height: 64px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 2rem;
-    border-bottom: 1px solid var(--border-color);
-    background: var(--surface-elevated);
-    backdrop-filter: blur(12px);
-    -webkit-backdrop-filter: blur(12px);
-    position: sticky;
-    top: 0;
-    z-index: 30;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 2rem;
+  border-bottom: 1px solid var(--border-color);
+  background: var(--surface-elevated);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  position: sticky;
+  top: 0;
+  z-index: 30;
 }
 
 .header-title h1 {
-    font-size: 1.125rem;
-    font-weight: 600;
+  font-size: 1.125rem;
+  font-weight: 600;
 }
 
 .user-profile {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-secondary);
 }
 
 .user-profile img {
-    width: 32px;
-    height: 32px;
-    border-radius: 50%;
-    border: 1px solid var(--border-color);
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  border: 1px solid var(--border-color);
 }
 
 .mobile-toggle {
-    display: none;
-    cursor: pointer;
-    font-size: 1.5rem;
+  display: none;
+  cursor: pointer;
+  font-size: 1.5rem;
 }
 
 /* Views */
 .view-section {
-    display: none;
-    padding: 2rem;
-    flex: 1;
-    max-width: 1200px;
-    margin: 0 auto;
-    width: 100%;
+  display: none;
+  padding: 2rem;
+  flex: 1;
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
 }
 
 .view-section.active {
-    display: block;
+  display: block;
 }
 
 .fade-in {
-    animation: fadeIn 0.3s ease-out forwards;
+  animation: fadeIn 0.3s ease-out forwards;
 }
 
 @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* Utilities */
-.text-muted { color: var(--text-muted); }
-.mt-4 { margin-top: 1rem; }
-.mb-4 { margin-bottom: 1rem; }
-.w-full { width: 100%; }
+.text-muted {
+  color: var(--text-muted);
+}
+.mt-4 {
+  margin-top: 1rem;
+}
+.mb-4 {
+  margin-bottom: 1rem;
+}
+.w-full {
+  width: 100%;
+}
 
 /* Buttons */
 .btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 0.5rem 1rem;
-    font-family: inherit;
-    font-size: 0.875rem;
-    font-weight: 500;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    transition: var(--transition);
-    border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  font-family: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: var(--transition);
+  border: 1px solid transparent;
 }
 
 .btn-primary {
-    background: var(--primary);
-    color: var(--primary-foreground);
-    box-shadow: var(--shadow-sm);
+  background: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: var(--shadow-sm);
 }
 
 .btn-primary:hover {
-    background: var(--primary-hover);
+  background: var(--primary-hover);
 }
 
 .btn-secondary {
-    background: transparent;
-    color: var(--text-primary);
-    border-color: var(--border-color);
+  background: transparent;
+  color: var(--text-primary);
+  border-color: var(--border-color);
 }
 
 .btn-secondary:hover {
-    background: var(--border-light);
+  background: var(--border-light);
 }
 
 .btn-text {
-    background: transparent;
-    color: var(--text-secondary);
-    padding: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  padding: 0;
 }
 
 .btn-text:hover {
-    color: var(--text-primary);
+  color: var(--text-primary);
 }
 
 /* Cards */
 .card {
-    background: var(--surface-base);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-sm);
-    overflow: hidden;
+  background: var(--surface-base);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
 }
 
 .card-header {
-    padding: 1.5rem;
-    border-bottom: 1px solid var(--border-color);
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
+  padding: 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
 }
 
 .card-header h3 {
-    font-size: 1.125rem;
-    font-weight: 600;
+  font-size: 1.125rem;
+  font-weight: 600;
 }
 
 /* Stats Grid */
 .stats-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
 }
 
 .stat-card {
-    background: var(--surface-base);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
-    padding: 1.5rem;
-    display: flex;
-    align-items: center;
-    gap: 1.25rem;
-    box-shadow: var(--shadow-sm);
-    transition: var(--transition);
+  background: var(--surface-base);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  box-shadow: var(--shadow-sm);
+  transition: var(--transition);
 }
 
 .stat-card:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
 }
 
 .stat-icon {
-    width: 48px;
-    height: 48px;
-    border-radius: var(--radius-sm);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.5rem;
-    color: white;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  color: white;
 }
 
-.bg-indigo { background: #6366f1; }
-.bg-amber { background: #f59e0b; }
-.bg-blue { background: #3b82f6; }
-.bg-emerald { background: #10b981; }
+.bg-indigo {
+  background: #6366f1;
+}
+.bg-amber {
+  background: #f59e0b;
+}
+.bg-blue {
+  background: #3b82f6;
+}
+.bg-emerald {
+  background: #10b981;
+}
 
 .stat-info p {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-    font-weight: 500;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  font-weight: 500;
 }
 
 .stat-info h3 {
-    font-size: 1.5rem;
-    font-weight: 700;
-    margin-top: 0.25rem;
-    color: var(--text-primary);
+  font-size: 1.5rem;
+  font-weight: 700;
+  margin-top: 0.25rem;
+  color: var(--text-primary);
 }
 
 /* Tables */
 .table-container {
-    overflow-x: auto;
+  overflow-x: auto;
 }
 
 .data-table {
-    width: 100%;
-    border-collapse: collapse;
-    text-align: left;
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
 }
 
 .data-table th {
-    font-size: 0.75rem;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--text-muted);
-    padding: 1rem 1.5rem;
-    border-bottom: 1px solid var(--border-color);
-    background: rgba(0, 0, 0, 0.02);
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+  background: rgba(0, 0, 0, 0.02);
 }
 
-[data-theme="dark"] .data-table th {
-    background: rgba(255, 255, 255, 0.02);
+[data-theme='dark'] .data-table th {
+  background: rgba(255, 255, 255, 0.02);
 }
 
 .data-table td {
-    padding: 1rem 1.5rem;
-    border-bottom: 1px solid var(--border-color);
-    font-size: 0.875rem;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+  font-size: 0.875rem;
 }
 
 .data-table tbody tr:hover {
-    background: var(--border-light);
+  background: var(--border-light);
 }
 
 .data-table tbody tr:last-child td {
-    border-bottom: none;
+  border-bottom: none;
 }
 
 /* Status Badges */
 .badge {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.25rem 0.6rem;
-    border-radius: 9999px;
-    font-size: 0.75rem;
-    font-weight: 500;
-    text-transform: uppercase;
-    letter-spacing: 0.02em;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.6rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
 }
 
 .badge-pending {
-    background: rgba(245, 158, 11, 0.1);
-    color: var(--status-pending);
-    border: 1px solid rgba(245, 158, 11, 0.2);
+  background: rgba(245, 158, 11, 0.1);
+  color: var(--status-pending);
+  border: 1px solid rgba(245, 158, 11, 0.2);
 }
 
 .badge-in_progress {
-    background: rgba(59, 130, 246, 0.1);
-    color: var(--status-progress);
-    border: 1px solid rgba(59, 130, 246, 0.2);
+  background: rgba(59, 130, 246, 0.1);
+  color: var(--status-progress);
+  border: 1px solid rgba(59, 130, 246, 0.2);
 }
 
 .badge-resolved {
-    background: rgba(16, 185, 129, 0.1);
-    color: var(--status-resolved);
-    border: 1px solid rgba(16, 185, 129, 0.2);
+  background: rgba(16, 185, 129, 0.1);
+  color: var(--status-resolved);
+  border: 1px solid rgba(16, 185, 129, 0.2);
 }
 
 .badge-rejected {
-    background: rgba(239, 68, 68, 0.1);
-    color: var(--status-rejected);
-    border: 1px solid rgba(239, 68, 68, 0.2);
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--status-rejected);
+  border: 1px solid rgba(239, 68, 68, 0.2);
 }
 
 /* Forms */
 .form-card {
-    max-width: 800px;
-    margin: 0 auto;
+  max-width: 800px;
+  margin: 0 auto;
 }
 
 .modern-form {
-    padding: 2rem;
+  padding: 2rem;
 }
 
 .form-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1.5rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
 }
 
 .span-full {
-    grid-column: 1 / -1;
+  grid-column: 1 / -1;
 }
 
 .form-group {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
 
 .form-group label {
-    font-size: 0.875rem;
-    font-weight: 500;
-    color: var(--text-primary);
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-primary);
 }
 
 .required {
-    color: var(--status-rejected);
+  color: var(--status-rejected);
 }
 
-.form-group input[type="text"],
+.form-group input[type='text'],
 .form-group select,
 .form-group textarea {
-    width: 100%;
-    padding: 0.75rem;
-    background: transparent;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-sm);
-    color: var(--text-primary);
-    font-family: inherit;
-    font-size: 0.875rem;
-    transition: var(--transition);
+  width: 100%;
+  padding: 0.75rem;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 0.875rem;
+  transition: var(--transition);
 }
 
 .form-group input:focus,
 .form-group select:focus,
 .form-group textarea:focus {
-    outline: none;
-    border-color: var(--text-secondary);
-    box-shadow: 0 0 0 1px var(--text-secondary);
+  outline: none;
+  border-color: var(--text-secondary);
+  box-shadow: 0 0 0 1px var(--text-secondary);
 }
 
 /* File Upload Zone */
 .file-upload-zone {
-    border: 2px dashed var(--border-color);
-    border-radius: var(--radius-md);
-    padding: 2rem;
-    text-align: center;
-    cursor: pointer;
-    transition: var(--transition);
+  border: 2px dashed var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  text-align: center;
+  cursor: pointer;
+  transition: var(--transition);
 }
 
 .file-upload-zone:hover {
-    border-color: var(--text-secondary);
-    background: var(--border-light);
+  border-color: var(--text-secondary);
+  background: var(--border-light);
 }
 
 .upload-content {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 0.5rem;
-    color: var(--text-secondary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--text-secondary);
 }
 
 .upload-content i {
-    font-size: 2rem;
-    color: var(--text-muted);
+  font-size: 2rem;
+  color: var(--text-muted);
 }
 
 .file-preview {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 1rem;
-    background: var(--border-light);
-    padding: 1rem;
-    border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  background: var(--border-light);
+  padding: 1rem;
+  border-radius: var(--radius-sm);
 }
 
 .file-preview.hidden {
-    display: none;
+  display: none;
 }
 
 .form-actions {
-    margin-top: 2rem;
-    padding-top: 1.5rem;
-    border-top: 1px solid var(--border-color);
-    display: flex;
-    justify-content: flex-end;
-    gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--border-color);
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
 }
 
 /* Listings Toolbar */
 .listings-toolbar {
-    padding: 1rem 1.5rem;
-    border-bottom: 1px solid var(--border-color);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1rem;
-    flex-wrap: wrap;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--border-color);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .search-box {
-    position: relative;
-    flex: 1;
-    max-width: 300px;
+  position: relative;
+  flex: 1;
+  max-width: 300px;
 }
 
 .search-box i {
-    position: absolute;
-    left: 1rem;
-    top: 50%;
-    transform: translateY(-50%);
-    color: var(--text-muted);
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-muted);
 }
 
 .search-box input {
-    width: 100%;
-    padding: 0.5rem 1rem 0.5rem 2.5rem;
-    background: var(--border-light);
-    border: 1px solid transparent;
-    border-radius: var(--radius-sm);
-    color: var(--text-primary);
-    font-size: 0.875rem;
+  width: 100%;
+  padding: 0.5rem 1rem 0.5rem 2.5rem;
+  background: var(--border-light);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.875rem;
 }
 
 .search-box input:focus {
-    outline: none;
-    border-color: var(--border-color);
+  outline: none;
+  border-color: var(--border-color);
 }
 
 .filter-group {
-    display: flex;
-    gap: 0.5rem;
+  display: flex;
+  gap: 0.5rem;
 }
 
 .filter-select {
-    padding: 0.5rem 2rem 0.5rem 1rem;
-    background: var(--border-light);
-    border: 1px solid transparent;
-    border-radius: var(--radius-sm);
-    color: var(--text-primary);
-    font-size: 0.875rem;
-    appearance: none;
-    cursor: pointer;
+  padding: 0.5rem 2rem 0.5rem 1rem;
+  background: var(--border-light);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  appearance: none;
+  cursor: pointer;
 }
 
 .filter-select:focus {
-    outline: none;
-    border-color: var(--border-color);
+  outline: none;
+  border-color: var(--border-color);
 }
 
 /* Empty State */
 .empty-state {
-    padding: 4rem 2rem;
-    text-align: center;
-    color: var(--text-secondary);
+  padding: 4rem 2rem;
+  text-align: center;
+  color: var(--text-secondary);
 }
 
 .empty-state.hidden {
-    display: none;
+  display: none;
 }
 
 .empty-state i {
-    font-size: 3rem;
-    color: var(--text-muted);
-    margin-bottom: 1rem;
+  font-size: 3rem;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
 }
 
 .empty-state h3 {
-    color: var(--text-primary);
-    font-size: 1.125rem;
-    margin-bottom: 0.5rem;
+  color: var(--text-primary);
+  font-size: 1.125rem;
+  margin-bottom: 0.5rem;
 }
 
 /* Details View */
 .details-header-actions {
-    margin-bottom: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
 .details-grid {
-    display: grid;
-    grid-template-columns: 2fr 1fr;
-    gap: 1.5rem;
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: 1.5rem;
 }
 
 .details-main {
-    display: flex;
-    flex-direction: column;
-    gap: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .details-info-card {
-    padding: 2rem;
+  padding: 2rem;
 }
 
 .details-title-row {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    margin-bottom: 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1.5rem;
 }
 
 .details-title-row h2 {
-    font-size: 1.5rem;
-    font-weight: 600;
+  font-size: 1.5rem;
+  font-weight: 600;
 }
 
 .details-meta {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1.5rem;
-    margin-bottom: 2rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 2rem;
 }
 
 .meta-block p {
-    font-size: 0.75rem;
-    text-transform: uppercase;
-    color: var(--text-muted);
-    font-weight: 600;
-    margin-bottom: 0.25rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  font-weight: 600;
+  margin-bottom: 0.25rem;
 }
 
 .meta-block span {
-    font-size: 0.875rem;
-    font-weight: 500;
+  font-size: 0.875rem;
+  font-weight: 500;
 }
 
 .details-desc h4 {
-    font-size: 1rem;
-    margin-bottom: 0.5rem;
+  font-size: 1rem;
+  margin-bottom: 0.5rem;
 }
 
 .details-desc p {
-    color: var(--text-secondary);
-    white-space: pre-wrap;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
 }
 
 .attachment-img {
-    max-width: 100%;
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--border-color);
-    margin-top: 1rem;
+  max-width: 100%;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+  margin-top: 1rem;
 }
 
 /* Timeline */
 .timeline-card {
-    padding: 1.5rem;
+  padding: 1.5rem;
 }
 
 .timeline {
-    position: relative;
-    padding-left: 1.5rem;
+  position: relative;
+  padding-left: 1.5rem;
 }
 
 .timeline::before {
-    content: '';
-    position: absolute;
-    left: 6px;
-    top: 0;
-    bottom: 0;
-    width: 2px;
-    background: var(--border-color);
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--border-color);
 }
 
 .timeline-item {
-    position: relative;
-    margin-bottom: 1.5rem;
+  position: relative;
+  margin-bottom: 1.5rem;
 }
 
 .timeline-item:last-child {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .timeline-dot {
-    position: absolute;
-    left: -1.5rem;
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    background: var(--surface-base);
-    border: 2px solid var(--border-color);
-    margin-left: -1px;
+  position: absolute;
+  left: -1.5rem;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--surface-base);
+  border: 2px solid var(--border-color);
+  margin-left: -1px;
 }
 
 .timeline-dot.active {
-    border-color: var(--primary);
-    background: var(--primary);
+  border-color: var(--primary);
+  background: var(--primary);
 }
 
 .timeline-content h5 {
-    font-size: 0.875rem;
-    font-weight: 600;
+  font-size: 0.875rem;
+  font-weight: 600;
 }
 
 .timeline-content span {
-    font-size: 0.75rem;
-    color: var(--text-muted);
+  font-size: 0.75rem;
+  color: var(--text-muted);
 }
 
 .timeline-content p {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-    margin-top: 0.25rem;
-    background: var(--border-light);
-    padding: 0.5rem;
-    border-radius: var(--radius-sm);
-    border-left: 2px solid var(--text-muted);
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin-top: 0.25rem;
+  background: var(--border-light);
+  padding: 0.5rem;
+  border-radius: var(--radius-sm);
+  border-left: 2px solid var(--text-muted);
 }
 
 /* Admin Grid */
 .admin-grid {
-    display: grid;
-    grid-template-columns: 300px 1fr;
-    min-height: 500px;
-    border-top: 1px solid var(--border-color);
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  min-height: 500px;
+  border-top: 1px solid var(--border-color);
 }
 
 .admin-list-col {
-    border-right: 1px solid var(--border-color);
-    padding: 1rem;
-    background: rgba(0,0,0,0.01);
+  border-right: 1px solid var(--border-color);
+  padding: 1rem;
+  background: rgba(0, 0, 0, 0.01);
 }
 
-[data-theme="dark"] .admin-list-col {
-    background: rgba(255,255,255,0.01);
+[data-theme='dark'] .admin-list-col {
+  background: rgba(255, 255, 255, 0.01);
 }
 /* Dark mode dropdown fix */
-[data-theme="dark"] select,
-[data-theme="dark"] select option {
-    background-color: #1e1e2e !important;
-    color: #ffffff !important;
+[data-theme='dark'] select,
+[data-theme='dark'] select option {
+  background-color: #1e1e2e !important;
+  color: #ffffff !important;
 }
 
 .admin-complaints-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    max-height: 500px;
-    overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 500px;
+  overflow-y: auto;
 }
 
 .admin-list-item {
-    padding: 0.75rem;
-    border-radius: var(--radius-sm);
-    cursor: pointer;
-    border: 1px solid transparent;
-    transition: var(--transition);
+  padding: 0.75rem;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: var(--transition);
 }
 
 .admin-list-item:hover {
-    background: var(--surface-base);
-    border-color: var(--border-color);
+  background: var(--surface-base);
+  border-color: var(--border-color);
 }
 
 .admin-list-item.selected {
-    background: var(--surface-base);
-    border-color: var(--primary);
-    box-shadow: var(--shadow-sm);
+  background: var(--surface-base);
+  border-color: var(--primary);
+  box-shadow: var(--shadow-sm);
 }
 
 .admin-list-item-header {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 0.25rem;
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
 }
 
 .admin-list-item h4 {
-    font-size: 0.875rem;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 150px;
+  font-size: 0.875rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 150px;
 }
 
 .admin-editor-col {
-    padding: 2rem;
+  padding: 2rem;
 }
 
 /* Toast */
 .toast {
-    position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    background: var(--surface-elevated);
-    backdrop-filter: blur(12px);
-    border: 1px solid var(--border-color);
-    box-shadow: var(--shadow-lg);
-    border-radius: var(--radius-md);
-    padding: 1rem 1.5rem;
-    display: flex;
-    align-items: flex-start;
-    gap: 1rem;
-    z-index: 100;
-    transition: var(--transition);
-    transform: translateY(0);
-    opacity: 1;
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background: var(--surface-elevated);
+  backdrop-filter: blur(12px);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-lg);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.5rem;
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  z-index: 100;
+  transition: var(--transition);
+  transform: translateY(0);
+  opacity: 1;
 }
 
 .toast.hidden {
-    transform: translateY(20px);
-    opacity: 0;
-    pointer-events: none;
+  transform: translateY(20px);
+  opacity: 0;
+  pointer-events: none;
 }
 
 .toast-icon {
-    font-size: 1.5rem;
-    color: var(--status-resolved);
+  font-size: 1.5rem;
+  color: var(--status-resolved);
 }
 
 .toast-content h4 {
-    font-size: 0.875rem;
-    font-weight: 600;
-    margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
 }
 
 .toast-content p {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
+  font-size: 0.875rem;
+  color: var(--text-secondary);
 }
 
 .toast-close {
-    background: transparent;
-    border: none;
-    color: var(--text-muted);
-    cursor: pointer;
-    margin-left: 1rem;
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  margin-left: 1rem;
 }
 
 /* Responsive */
 @media (max-width: 1024px) {
-    .details-grid {
-        grid-template-columns: 1fr;
-    }
-    .admin-grid {
-        grid-template-columns: 1fr;
-    }
-    .admin-list-col {
-        border-right: none;
-        border-bottom: 1px solid var(--border-color);
-    }
+  .details-grid {
+    grid-template-columns: 1fr;
+  }
+  .admin-grid {
+    grid-template-columns: 1fr;
+  }
+  .admin-list-col {
+    border-right: none;
+    border-bottom: 1px solid var(--border-color);
+  }
 }
 
 @media (max-width: 768px) {
-    .sidebar {
-        transform: translateX(-100%);
-    }
-    
-    .sidebar.open {
-        transform: translateX(0);
-        box-shadow: var(--shadow-lg);
-    }
-    
-    .main-content {
-        margin-left: 0;
-    }
-    
-    .mobile-toggle {
-        display: block;
-    }
-    
-    .form-grid {
-        grid-template-columns: 1fr;
-    }
-    
-    .listings-toolbar {
-        flex-direction: column;
-        align-items: stretch;
-    }
-    
-    .search-box {
-        max-width: 100%;
-    }
+  .sidebar {
+    transform: translateX(-100%);
+  }
+
+  .sidebar.open {
+    transform: translateX(0);
+    box-shadow: var(--shadow-lg);
+  }
+
+  .main-content {
+    margin-left: 0;
+  }
+
+  .mobile-toggle {
+    display: block;
+  }
+
+  .form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .listings-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .search-box {
+    max-width: 100%;
+  }
 }


### PR DESCRIPTION
## Pull Request Description

### Related Issue

Closes #9003

### Summary

This PR fixes an issue where Resolution Notes entered by administrators were not preserved when reopening a complaint in the Admin Panel.

Previously, resolution notes were only stored in timeline entries and the Resolution Notes field was reset whenever the complaint was reopened. This prevented administrators from reviewing or continuing previous resolution work.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

- Added persistent storage for complaint resolution notes.
- Saved resolution notes directly within the complaint object.
- Loaded previously saved resolution notes when reopening a complaint.
- Allowed administrators to continue editing existing notes.
- Kept timeline history functionality unchanged.
- Prevented resolution notes from being cleared after saving changes.

## Testing

### Manual Testing

- [x] Opened a complaint in the Admin Panel.
- [x] Entered resolution notes and saved changes.
- [x] Opened another complaint.
- [x] Reopened the original complaint.
- [x] Verified previously saved notes were displayed.
- [x] Updated existing notes and saved again.
- [x] Confirmed notes persisted after page refresh.
- [x] Verified timeline entries continued to record status updates correctly.

## Result

Resolution Notes now persist across complaint reopen actions, allowing administrators to review, update, and maintain complete resolution details without losing previously entered information.