### PR TITLE
Fix: stop cursor trail particles from spawning after changing cursor: custom option to cursor: default

### DIFF
--- a/cursor.js
+++ b/cursor.js
@@ -34,6 +34,7 @@
   let mouseX = 0, mouseY = 0;
   let outerX = 0, outerY = 0;
   let lastParticle = 0;
+  let activeParticles = []; // tracks { el, rafId } for every in-flight trail particle
 
   const isMobile = window.matchMedia("(pointer: coarse)").matches;
 
@@ -80,6 +81,11 @@
     if (!CURSOR_STYLES.find(s => s.id === id)) id = DEFAULT_STYLE;
     activeStyle = id;
     saveStyle(id);
+
+    // Tear down any leftover trail/particle effects from the previous style
+    // before applying the new one (this is what fixes #8732 — particles no
+    // longer linger on screen after switching to Default or any other style).
+    clearActiveParticles();
 
     ensureCursorElements();
 
@@ -193,7 +199,7 @@
 
   /* ── Spawn trail particles ── */
   function spawnParticle(x, y) {
-    if (activeStyle === "default" || activeStyle === "minimal") return;
+    if (!isEnabled || activeStyle === "default" || activeStyle === "minimal") return;
 
     const el = document.createElement("div");
     let color = "#93c5fd", txt = "", sz = 5;
@@ -249,6 +255,16 @@
     let px = x, py = y, frame = 0;
     const maxFrames = dur / 16;
 
+    // Register this particle so a style switch can cancel + remove it immediately
+    const particle = { el, rafId: null };
+    activeParticles.push(particle);
+
+    function removeParticle() {
+      const idx = activeParticles.indexOf(particle);
+      if (idx !== -1) activeParticles.splice(idx, 1);
+      el.remove();
+    }
+
     function animateParticle() {
       frame++;
       px += vx;
@@ -256,17 +272,29 @@
       el.style.left = px + "px";
       el.style.top = py + "px";
       el.style.opacity = String(0.9 * (1 - frame / maxFrames));
-      if (frame < maxFrames) requestAnimationFrame(animateParticle);
-      else el.remove();
+      if (frame < maxFrames) {
+        particle.rafId = requestAnimationFrame(animateParticle);
+      } else {
+        removeParticle();
+      }
     }
-    requestAnimationFrame(animateParticle);
+    particle.rafId = requestAnimationFrame(animateParticle);
+  }
+
+  /* ── Cleanup: cancel every in-flight trail animation & strip its DOM node ── */
+  function clearActiveParticles() {
+    activeParticles.forEach((p) => {
+      if (p.rafId !== null) cancelAnimationFrame(p.rafId);
+      p.el.remove();
+    });
+    activeParticles.length = 0;
   }
 
   /* ── Animation loop ── */
   function startLoop() {
     function tick() {
       requestAnimationFrame(tick);
-      if (activeStyle === "default" || !outerEl) return;
+      if (!isEnabled || activeStyle === "default" || !outerEl) return;
 
       outerX += (mouseX - outerX) * 0.15;
       outerY += (mouseY - outerY) * 0.15;
@@ -446,6 +474,7 @@
     isEnabled = false;
     saveEnabled(false);
     document.body.style.cursor = "auto";
+    clearActiveParticles();
     if (outerEl) {
       outerEl.classList.remove("is-visible");
       outerEl.style.display = "none";


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8732 

### Summary
Fixes a bug where custom cursor trail/particle effects kept spawning after switching from a custom cursor style back to the default cursor via the "Cursor: Custom / Cursor: default" navbar toggle. The particle-spawning function only checked which "style" was active, not whether the cursor system had been `disabled`, so new particles kept appearing on every mouse move even after logging the cursor off.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added an `isEnabled` check to `spawnParticle()` and the cursor ring follow-loop in `cursor.js`, so disabling the custom cursor  system now actually stops new trail particles from being created (previously it only checked the selected style, not the on/off state).
- Added an `activeParticles` registry that tracks each spawned particle's DOM node and `requestAnimationFrame` id, plus a `clearActiveParticles()` cleanup function that cancels in-flight animations and removes the nodes immediately. This is called whenever the cursor style changes or the system is disabled, instead of letting old particles linger and fade out on their own.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [ ] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**
- [x] Tested and verified in **Brave Browser**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
