### PR TITLE
fix: implement missing getRecommendations function to prevent ReferenceError

### DIFF
--- a/index.js
+++ b/index.js
@@ -1534,6 +1534,19 @@ function renderRecommendationsForProject(project) {
     return;
   }
 
+function getRecommendations(project, allProjects) {
+  if (!project || !allProjects) return [];
+  return allProjects
+    .filter(function (p) {
+      if (p.id === project.id) return false;
+      const shared = (p.techStack || []).filter(function (t) {
+        return (project.techStack || []).includes(t);
+      });
+      return shared.length > 0 || p.category === project.category;
+    })
+    .slice(0, 6);
+}
+
   const recommendations = getRecommendations(project, PROJECTS);
   if (!recommendations.length) {
     const noRecommendations = document.createElement("p");


### PR DESCRIPTION
Fixes #9157

## Description
index.js called getRecommendations(project, PROJECTS) on line 1537,
but this function was never defined anywhere in the codebase. This
caused an uncaught ReferenceError every time a user clicked on any
project card, breaking the "Related Projects" recommendations panel
site-wide.

## Fix
Implemented getRecommendations(project, allProjects) which filters
the project list to find related projects based on shared tech
stack overlap or matching category, returning up to 6 recommendations.

## Testing
- Served the site locally with http-server
- Clicked multiple project cards
- Confirmed no console errors after the fix
- Confirmed recommendations panel now renders related projects instead of crashing

## Checklist
- [x] Tested locally
- [x] No new console errors
- [x] Follows existing code style