### PR TITLE
fix: correct broken absolute image paths in Flipkart-clone

### DIFF
--- a/public/Flipkart-clone/index.html
+++ b/public/Flipkart-clone/index.html
@@ -13,15 +13,15 @@
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
     />
-    <link rel="stylesheet" href="/public/Flipkart-clone/nav.css" />
-    <link rel="stylesheet" href="/public/Flipkart-clone/style.css" />
+    <link rel="stylesheet" href="nav.css" />
+    <link rel="stylesheet" href="style.css" />
   </head>
   <body>
     <!-- ─── NAVBAR ─── -->
     <nav class="navbar">
       <div class="nav-left">
-        <a href="/public/Flipkart-clone/index.html" class="logo-section">
-          <img src="/public/Flipkart-clone/logo.png" alt="Flipkart logo" />
+        <a href="index.html" class="logo-section">
+          <img src="logo.png" alt="Flipkart logo" />
           <div>
             <h2>Flipkart</h2>
             <span>Explore <em>Plus</em> ✦</span>
@@ -139,11 +139,11 @@
     <!-- ─── HERO SLIDER ─── -->
     <div class="hero-section">
       <div class="section-track">
-        <div class="section-item"><img src="/public/Flipkart-clone/hero1.png" alt="Offer 1" /></div>
-        <div class="section-item"><img src="/public/Flipkart-clone/hero2.png" alt="Offer 2" /></div>
-        <div class="section-item"><img src="/public/Flipkart-clone/hero3.png" alt="Offer 3" /></div>
-        <div class="section-item"><img src="/public/Flipkart-clone/hero4.png" alt="Offer 4" /></div>
-        <div class="section-item"><img src="/public/Flipkart-clone/hero5.png" alt="Offer 5" /></div>
+        <div class="section-item"><img src="hero1.png" alt="Offer 1" /></div>
+        <div class="section-item"><img src="hero2.png" alt="Offer 2" /></div>
+        <div class="section-item"><img src="hero3.png" alt="Offer 3" /></div>
+        <div class="section-item"><img src="hero4.png" alt="Offer 4" /></div>
+        <div class="section-item"><img src="hero5.png" alt="Offer 5" /></div>
       </div>
 
       <button
@@ -170,7 +170,7 @@
       </div>
     </div>
 
-    <script src="/public/Flipkart-clone/script.js"></script>
+    <script src="script.js"></script>
 
     <!-- ─── BRANDS IN SPOTLIGHT ─── -->
     <section class="brands-section">
@@ -178,7 +178,7 @@
       <div class="brands-grid">
         <div class="brand-card">
           <div class="image-container">
-            <img src="/public/Flipkart-clone/image1.png" alt="Bata" />
+            <img src="image1.png" alt="Bata" />
             <span class="ad-badge">AD</span>
           </div>
           <div class="card-details">
@@ -189,7 +189,7 @@
 
         <div class="brand-card">
           <div class="image-container">
-            <img src="/public/Flipkart-clone/image2.png" alt="Kamiliant" />
+            <img src="image2.png" alt="Kamiliant" />
             <span class="ad-badge">AD</span>
           </div>
           <div class="card-details">
@@ -200,7 +200,7 @@
 
         <div class="brand-card">
           <div class="image-container">
-            <img src="/public/Flipkart-clone/image3.png" alt="Abros" />
+            <img src="image3.png" alt="Abros" />
             <span class="ad-badge">AD</span>
           </div>
           <div class="card-details">
@@ -211,7 +211,7 @@
 
         <div class="brand-card">
           <div class="image-container">
-            <img src="/public/Flipkart-clone/image4.png" alt="Fire-Boltt" />
+            <img src="image4.png" alt="Fire-Boltt" />
             <span class="ad-badge">AD</span>
           </div>
           <div class="card-details"></div>
@@ -219,7 +219,7 @@
 
         <div class="brand-card">
           <div class="image-container">
-            <img src="/public/Flipkart-clone/image5.png" alt="boAt Smartwatch" />
+            <img src="image5.png" alt="boAt Smartwatch" />
             <span class="ad-badge">AD</span>
           </div>
           <div class="card-details"></div>
@@ -227,7 +227,7 @@
 
         <div class="brand-card">
           <div class="image-container">
-            <img src="/public/Flipkart-clone/image6.png" alt="boAt Airdopes" />
+            <img src="image6.png" alt="boAt Airdopes" />
             <span class="ad-badge">AD</span>
           </div>
           <div class="card-details"></div>
@@ -243,7 +243,7 @@
         aria-label="Get Ready For The Hottest Sale"
       >
         <img
-          src="/public/Flipkart-clone/grwm.png"
+          src="grwm.png"
           alt="GRWM Sale - Starts 29th May. Get Ready For The Hottest Sale"
           class="banner-image"
         />


### PR DESCRIPTION
Fixes #9171

## Description
All 17 image references in public/Flipkart-clone/index.html used
a broken absolute path (/public/Flipkart-clone/filename.png)
instead of a relative path, even though the image files exist
directly in the same folder. This caused the logo, all 5 hero
banner images, all 6 product images, and grwm.png to fail to
load site-wide.

## Fix
Replaced all /public/Flipkart-clone/ path prefixes with relative
paths so images resolve correctly relative to index.html.

## Testing
- Served the site locally with http-server
- Opened public/Flipkart-clone/index.html directly
- Confirmed logo, hero banner, and all product images now load correctly
- No more 404s in Network tab for image requests

## Checklist
- [x] Tested locally
- [x] No new console errors
- [x] Follows existing code style