### PR TITLE
fix: correct case-sensitive link and remove dead Searchbars link in Custom-Scroll-Bar

### DIFF
--- a/public/Custom-Scroll-Bar/index.html
+++ b/public/Custom-Scroll-Bar/index.html
@@ -24,7 +24,7 @@
 
   <ul class="nav-links">
     <li><a href="index.html">Home</a></li>
-    <li><a href="Scrollbars.html">Scrollbars</a></li>
+    <li><a href="scrollbars.html">Scrollbars</a></li>
     <li><a href="#footer-container">About</a></li>
   </ul>
 
@@ -121,7 +121,6 @@
 
         <ul>
           <li><a href="index.html">Home</a></li>
-          <li><a href="Searchbars.html">Searchbars</a></li>
           <li><a href="#footer-container">Contact</a></li>
         </ul>
       </div>
@@ -150,3 +149,4 @@
 
 </body>
 </html>
+


### PR DESCRIPTION
Fixes #9174

## Description
The "Scrollbars" nav link pointed to "Scrollbars.html" (capital S)
while the actual file on disk is "scrollbars.html" (lowercase),
which works locally on case-insensitive filesystems but 404s on
case-sensitive hosting like Vercel/Linux. Additionally, the
"Searchbars" footer link pointed to "Searchbars.html", which does
not exist anywhere in the project.

## Fix
- Corrected the "Scrollbars" link to use the proper lowercase filename
- Removed the dead "Searchbars" link entirely since no corresponding page exists

## Testing
- Verified scrollbars.html exists on disk and is now correctly linked
- Verified the broken Searchbars list item is fully removed
- No remaining references to the broken paths

## Checklist
- [x] Tested locally
- [x] No new console errors
- [x] Follows existing code style