### PR TITLE
Feature : Show CAPTCHA Success message as a toast notification instead of inline text

### DIFF
--- a/public/captcha/captcha.css
+++ b/public/captcha/captcha.css
@@ -997,6 +997,211 @@ body.light-theme label {
 }
 
 /* ==========================
+   TOAST NOTIFICATIONS
+   ========================== */
+#toast-container {
+    position: fixed;
+    bottom: 28px;
+    right: 28px;
+    z-index: 99999;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    pointer-events: none;
+}
+
+.toast {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    min-width: 300px;
+    max-width: 400px;
+    padding: 16px 20px;
+    border-radius: 18px;
+    background: rgba(15, 23, 42, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.10);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    box-shadow:
+        0 8px 32px rgba(0, 0, 0, 0.45),
+        0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+    pointer-events: all;
+    cursor: default;
+    /* Slide in from right */
+    animation: toastSlideIn 0.38s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+    will-change: transform, opacity;
+    overflow: hidden;
+    position: relative;
+}
+
+.toast.toast-exit {
+    animation: toastSlideOut 0.32s ease-in forwards;
+}
+
+.toast-icon {
+    flex-shrink: 0;
+    width: 40px;
+    height: 40px;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+}
+
+.toast-success .toast-icon {
+    background: rgba(34, 197, 94, 0.18);
+    color: #4ade80;
+}
+
+.toast-error .toast-icon {
+    background: rgba(239, 68, 68, 0.18);
+    color: #fb7185;
+}
+
+.toast-warning .toast-icon {
+    background: rgba(245, 158, 11, 0.18);
+    color: #fbbf24;
+}
+
+.toast-body {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+}
+
+.toast-title {
+    font-weight: 700;
+    font-size: 0.95rem;
+    line-height: 1.3;
+}
+
+.toast-success .toast-title { color: #4ade80; }
+.toast-error   .toast-title { color: #fb7185; }
+.toast-warning .toast-title { color: #fbbf24; }
+
+.toast-message {
+    font-size: 0.85rem;
+    color: rgba(255, 255, 255, 0.65);
+    line-height: 1.5;
+}
+
+.toast-close {
+    flex-shrink: 0;
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.35);
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 4px;
+    border-radius: 6px;
+    transition: color 0.2s ease, background 0.2s ease;
+    align-self: flex-start;
+}
+
+.toast-close:hover {
+    color: rgba(255, 255, 255, 0.8);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+/* Progress bar that auto-drains */
+.toast-progress {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    height: 3px;
+    border-radius: 0 0 18px 18px;
+    animation: toastProgress linear forwards;
+}
+
+.toast-success .toast-progress { background: #22c55e; }
+.toast-error   .toast-progress { background: #ef4444; }
+.toast-warning .toast-progress { background: #f59e0b; }
+
+@keyframes toastSlideIn {
+    from {
+        opacity: 0;
+        transform: translateX(60px) scale(0.95);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+    }
+}
+
+@keyframes toastSlideOut {
+    from {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+        max-height: 120px;
+        margin-bottom: 0;
+    }
+    to {
+        opacity: 0;
+        transform: translateX(60px) scale(0.92);
+        max-height: 0;
+        margin-bottom: -12px;
+        padding-top: 0;
+        padding-bottom: 0;
+    }
+}
+
+@keyframes toastProgress {
+    from { width: 100%; }
+    to   { width: 0%; }
+}
+
+/* ── Light theme overrides for toast ─────────────────── */
+body.light-theme .toast {
+    background: rgba(255, 255, 255, 0.88);
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    box-shadow:
+        0 8px 32px rgba(0, 0, 0, 0.12),
+        0 0 0 1px rgba(255, 255, 255, 0.6) inset;
+}
+
+body.light-theme .toast-message {
+    color: rgba(30, 41, 59, 0.75);
+}
+
+body.light-theme .toast-close {
+    color: rgba(30, 41, 59, 0.4);
+}
+
+body.light-theme .toast-close:hover {
+    color: rgba(30, 41, 59, 0.8);
+    background: rgba(0, 0, 0, 0.06);
+}
+
+body.light-theme .toast-success .toast-icon {
+    background: rgba(34, 197, 94, 0.15);
+}
+
+body.light-theme .toast-error .toast-icon {
+    background: rgba(239, 68, 68, 0.15);
+}
+
+body.light-theme .toast-warning .toast-icon {
+    background: rgba(245, 158, 11, 0.15);
+}
+
+/* Mobile responsive toast */
+@media (max-width: 480px) {
+    #toast-container {
+        bottom: 16px;
+        right: 12px;
+        left: 12px;
+    }
+
+    .toast {
+        min-width: unset;
+        max-width: 100%;
+    }
+}
+
+/* ==========================
    MOBILE RESPONSIVE
    ========================== */
 @media (max-width: 768px) {

--- a/public/captcha/captcha.js
+++ b/public/captcha/captcha.js
@@ -1,6 +1,7 @@
 let selectedImageAnswer = "";
 
-const resultMessage = document.getElementById("resultMessage");
+// Removed: resultMessage is replaced by toast notifications
+// const resultMessage = document.getElementById("resultMessage");
 
 const captchaContainer = document.getElementById("captchaContainer");
 const textInput = document.getElementById("captchaInput");
@@ -227,8 +228,6 @@ const generateCaptcha = () => {
 
     textCaptchaField.classList.remove('hidden');
 
-    resultMessage.textContent = '';
-    resultMessage.className = 'result';
     selectedImageAnswer = '';
 
     // Normalize type string case to prevent logic matching bugs
@@ -316,6 +315,61 @@ const generateCaptcha = () => {
     }
 };
 
+// ==========================
+// TOAST NOTIFICATION SYSTEM
+// ==========================
+
+/**
+ * Shows a toast notification outside the form.
+ * @param {'success'|'error'|'warning'} type
+ * @param {string} title
+ * @param {string} message
+ * @param {number} duration  Auto-dismiss delay in ms (default 4000)
+ */
+function showToast(type, title, message, duration = 4000) {
+    const container = document.getElementById('toast-container');
+    if (!container) return;
+
+    const icons = {
+        success: '✓',
+        error:   '✕',
+        warning: '⚠'
+    };
+
+    const toast = document.createElement('div');
+    toast.className = `toast toast-${type}`;
+    toast.setAttribute('role', 'alert');
+    toast.innerHTML = `
+        <div class="toast-icon">${icons[type] ?? '!'}</div>
+        <div class="toast-body">
+            <span class="toast-title">${title}</span>
+            <span class="toast-message">${message}</span>
+        </div>
+        <button class="toast-close" aria-label="Dismiss notification">&times;</button>
+        <div class="toast-progress" style="animation-duration: ${duration}ms;"></div>
+    `;
+
+    // Close on button click
+    toast.querySelector('.toast-close').addEventListener('click', () => dismissToast(toast));
+
+    container.appendChild(toast);
+
+    // Auto-dismiss
+    const timer = setTimeout(() => dismissToast(toast), duration);
+
+    // Cancel auto-dismiss if user hovers (pause experience)
+    toast.addEventListener('mouseenter', () => clearTimeout(timer));
+    toast.addEventListener('mouseleave', () =>
+        setTimeout(() => dismissToast(toast), 800)
+    );
+}
+
+function dismissToast(toast) {
+    if (!toast || toast.classList.contains('toast-exit')) return;
+    toast.classList.add('toast-exit');
+    toast.addEventListener('animationend', () => toast.remove(), { once: true });
+}
+
 const lockoutUser = () => {
     lockoutEndTime = Date.now() + 60 * 1000;
     updateLockoutUI();
@@ -326,12 +380,15 @@ const updateLockoutUI = () => {
     if (now < lockoutEndTime) {
         const remaining = Math.ceil((lockoutEndTime - now) / 1000);
         submitButton.disabled = true;
-        resultMessage.textContent = `Too many attempts. Wait ${remaining} seconds.`;
-        resultMessage.style.color = 'red';
+        showToast(
+            'warning',
+            'Too Many Attempts',
+            `Please wait ${remaining} second${remaining !== 1 ? 's' : ''} before trying again.`,
+            Math.min(remaining * 1000, 5000)
+        );
         setTimeout(updateLockoutUI, 1000);
     } else {
         submitButton.disabled = false;
-        resultMessage.textContent = '';
         attempts = 0;
         generateCaptcha();
     }
@@ -350,14 +407,15 @@ const verifyCaptcha = () => {
   const isCorrect = userInput === currentCaptcha.toString().toLowerCase();
   
   if (isCorrect) {
-      resultMessage.textContent = "Very Good! You passed the Test.";
-      resultMessage.classList.add('success');
-      resultMessage.classList.remove('error');
+      showToast(
+          'success',
+          'Captcha Passed!',
+          'Well done! You verified you are human. A new challenge is loading…',
+          3500
+      );
       attempts = 0;
       setTimeout(() => {
           textInput.value = "";
-          resultMessage.textContent = "";
-          resultMessage.className = 'result';
           generateCaptcha();
       }, 1500);
   } else {
@@ -365,9 +423,12 @@ const verifyCaptcha = () => {
       if (attempts >= maxAttempts) {
           lockoutUser();
       } else {
-          resultMessage.textContent = `Sorry, your input is incorrect. Please try again. (Attempt ${attempts}/${maxAttempts})`;
-          resultMessage.classList.add('error');
-          resultMessage.classList.remove('success');
+          showToast(
+              'error',
+              'Incorrect Answer',
+              `That's not right. Attempt ${attempts} of ${maxAttempts} — give it another go!`,
+              4000
+          );
       }
   }
 };

--- a/public/captcha/generate.html
+++ b/public/captcha/generate.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Document</title>
+    <title>Generate Captcha – Captcha</title>
     <link rel="stylesheet" href="captcha.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
@@ -82,7 +82,7 @@
             <button class="submit" type="button">Submit CAPTCHA</button>
         </div>
 
-        <p id="resultMessage" class="result" aria-live="assertive"></p>
+
 
     </div>
     </div>
@@ -90,6 +90,9 @@
     </div>
 
 
+
+    <!-- Toast Notification Container -->
+    <div id="toast-container" aria-live="assertive" aria-atomic="true"></div>
 
     <footer class="footer">
 


### PR DESCRIPTION
## 📝 Pull Request Description
### Related Issue
Closes #9092 

### Summary
Provide a short, reviewer-friendly summary of what changed and why.

- Replaced the inline form result message on the Generate Captcha page with a toast notification system that appears outside the form, matching the page's existing dark/light theme. Toasts auto-dismiss, show a draining progress bar, and support success, error, and warning states for pass, fail, and lockout scenarios respectively.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [X] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
Detailed description of change 1 [generate.html]
- 

1. The inline paragraph element (with id='resultMessage') that used to display verification results inside the form was removed.
2. In its place, a <div id="toast-container"> was added outside the form, positioned between the closing container div and the footer. 
3. The page title was also updated from the generic "Document" to "Generate Captcha – Captcha".

Detailed description of change 2 [captcha.css]
-

1. A complete toast notification styling block was added.
2. It defines a fixed-position container anchored to the bottom-right of the viewport.
3. Three toast variants were styled : success (green), error (red), and warning (amber), each with a matching icon background, title color, and progress bar color. 
4. Toasts use a spring-based slide-in animation from the right and a slide-out exit animation.
5. A thin draining progress bar sits at the bottom of each toast, animating over the auto-dismiss duration.
6. Light theme overrides were added using the existing body.light-theme selector to ensure the toasts blend with both dark and light backgrounds. 
7. A mobile responsive block ensures toasts go full-width on small screens.

Detailed description of change 3 [captcha.js]
-

1. The const resultMessage declaration was commented out since the DOM element no longer exists. 
2. Two new functions were introduced : showToast(type, title, message, duration) which dynamically creates and appends a toast to the container, and dismissToast(toast) which triggers the exit animation and removes the element on completion.
3. All three places where resultMessage was previously mutated were replaced with showToast() calls : success on a correct answer, error with an attempt counter on a wrong answer, and warning with a live countdown during lockout.
4. Two leftover resultMessage references inside generateCaptcha() that were not caught in the initial migration were also removed; these were causing a JavaScript crash on every captcha generation, which is what made the captcha area disappear entirely.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [X] Tested and verified in **Google Chrome**
- [X] Tested and verified in **Mozilla Firefox**
- [X] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [X] Keyboard navigation and focus outlines checked
- [X] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
*Please attach screenshots or screen recordings showing before vs after behavior if this PR includes visual changes.*

|Before|
|------|

<img width="3420" height="1904" alt="Feature Update successful challenge submission notification" src="https://github.com/user-attachments/assets/66445412-e94f-4ed7-8be0-35081b0ab984" />

|After|
|-----|

<img width="3420" height="1904" alt="yess 2026-06-20 at 11 15 15 PM" src="https://github.com/user-attachments/assets/4f4b966e-65c3-4659-a0da-021f9f9b5c1d" />

<img width="3420" height="1904" alt="yess 2026-06-20 at 11 13 09 PM" src="https://github.com/user-attachments/assets/dead83f0-4d22-4aa1-aa39-5b6531f48f19" />

---

## 🤝 Contributor Checklist
- [X] My code follows the code style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation / README files accordingly.
- [X] My changes generate no new warnings or console errors.
- [X] There are no unrelated changes or formatter noise in this PR.
