### PR TITLE
fix: maintain sidebar active state when sections change programmatically

### DIFF
--- a/public/Mood Tracker/index.html
+++ b/public/Mood Tracker/index.html
@@ -1,311 +1,240 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta
-    name="viewport"
-    content="width=device-width, initial-scale=1.0"
-  />
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Mood OS</title>
+    <title>Mood OS</title>
 
-  <link
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-    rel="stylesheet"
-  />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+    />
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 
-  <link
-    rel="preconnect"
-    href="https://fonts.googleapis.com"
-  />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
 
-  <link
-    rel="preconnect"
-    href="https://fonts.gstatic.com"
-    crossorigin
-  />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 
-  <link
-    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
-    rel="stylesheet"
-  />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"
+      rel="stylesheet"
+    />
 
-  <link
-    rel="stylesheet"
-    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
-  />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css"
+    />
 
-  <link rel="stylesheet" href="styles.css" />
-</head>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
 
-<body class="dark">
+  <body class="dark">
+    <div class="bg-blur blur-1"></div>
+    <div class="bg-blur blur-2"></div>
+    <div class="bg-blur blur-3"></div>
 
-  <div class="bg-blur blur-1"></div>
-  <div class="bg-blur blur-2"></div>
-  <div class="bg-blur blur-3"></div>
+    <div class="mobile-overlay" id="mobileOverlay"></div>
 
-  <div class="mobile-overlay" id="mobileOverlay"></div>
+    <div class="app">
+      <!-- ================= SIDEBAR ================= -->
+      <aside class="sidebar" id="sidebar">
+        <div class="brand">
+          <div class="logo">🧠</div>
 
-  <div class="app">
-
-    <!-- ================= SIDEBAR ================= -->
-    <aside class="sidebar" id="sidebar">
-
-      <div class="brand">
-        <div class="logo">
-          🧠
-        </div>
-
-        <div>
-          <h2>Mood OS</h2>
-          <span>Track your emotions</span>
-        </div>
-      </div>
-
-      <!-- TIME -->
-      <div class="time-box">
-        <p id="currentDate"></p>
-        <h3 id="currentTime"></h3>
-      </div>
-
-      <!-- NAVIGATION -->
-      <nav class="nav-links">
-
-        <button onclick="switchSection('mood')">
-          <i class="fa-solid fa-cloud-sun"></i>
-          Mood Tracker
-        </button>
-
-        <button onclick="switchSection('analysis')">
-          <i class="fa-solid fa-chart-line"></i>
-          Analysis
-        </button>
-
-        <button onclick="switchSection('journal')">
-          <i class="fa-solid fa-book"></i>
-          Journal
-        </button>
-
-        <button onclick="switchSection('insights')">
-          <i class="fa-solid fa-brain"></i>
-          Insights
-        </button>
-
-        <button onclick="switchSection('trends')">
-          <i class="fa-solid fa-chart-column"></i>
-          Trends
-        </button>
-
-      </nav>
-
-      <!-- FILTER -->
-      <div class="sidebar-card">
-
-        <h5>Filter Timeline</h5>
-
-        <select
-          id="filterRange"
-          onchange="applyFilter()"
-        >
-          <option value="day">Today</option>
-          <option value="week">This Week</option>
-          <option value="month">This Month</option>
-        </select>
-
-      </div>
-
-      <!-- ACTIONS -->
-      <div class="sidebar-actions">
-
-        <button onclick="toggleTheme()">
-          🌙 Toggle Theme
-        </button>
-
-        <button onclick="exportData()">
-          📦 Export Data
-        </button>
-
-      </div>
-
-    </aside>
-
-    <!-- ================= MAIN ================= -->
-    <main class="main">
-
-      <!-- MOBILE HEADER -->
-      <div class="mobile-header">
-
-        <button
-          class="menu-btn"
-          onclick="toggleSidebar()"
-        >
-          ☰
-        </button>
-
-        <h2>Mood OS</h2>
-
-      </div>
-
-      <!-- STATS -->
-      <div class="stats-grid">
-
-        <div class="stat-card">
-          <span>🔥 Streak</span>
-          <h3 id="streakText">0</h3>
-        </div>
-
-        <div class="stat-card">
-          <span>⚡ Energy Avg</span>
-          <h3 id="avgEnergy">-</h3>
-        </div>
-
-        <div class="stat-card">
-          <span>😵 Stress Avg</span>
-          <h3 id="avgStress">-</h3>
-        </div>
-
-        <div class="stat-card">
-          <span>😊 Mood Score</span>
-          <h3 id="avgMood">-</h3>
-        </div>
-
-      </div>
-
-      <!-- ================= MOOD TRACKER ================= -->
-      <section id="mood" class="section active">
-
-        <div class="section-header">
-          <h1>Mood Tracker</h1>
-          <p>Track how your day feels.</p>
-        </div>
-
-        <div class="card">
-
-          <div class="mood-selector">
-
-            <button class="mood-btn">😊</button>
-            <button class="mood-btn">😌</button>
-            <button class="mood-btn">😐</button>
-            <button class="mood-btn">😔</button>
-            <button class="mood-btn">😡</button>
-
+          <div>
+            <h2>Mood OS</h2>
+            <span>Track your emotions</span>
           </div>
+        </div>
 
-          <input
-            id="moodInput"
-            placeholder="Describe your mood..."
-          />
+        <!-- TIME -->
+        <div class="time-box">
+          <p id="currentDate"></p>
+          <h3 id="currentTime"></h3>
+        </div>
 
-          <div class="grid-2">
-
-            <select id="energyLevel">
-              <option value="1">Energy Low</option>
-              <option value="3">Energy Medium</option>
-              <option value="5">Energy High</option>
-            </select>
-
-            <select id="stressLevel">
-              <option value="1">Stress Low</option>
-              <option value="3">Stress Medium</option>
-              <option value="5">Stress High</option>
-            </select>
-
-          </div>
-
-          <textarea
-            id="journalText"
-            placeholder="Write about your day..."
-          ></textarea>
-
-          <input
-            id="highlight"
-            placeholder="Best moment of your day ✨"
-          />
-
-          <div
-            id="liveMoodPreview"
-            class="preview-box"
-          >
-            Mood preview appears here...
-          </div>
-
-          <button onclick="addEntry()">
-            Save Entry
+        <!-- NAVIGATION -->
+        <nav class="nav-links">
+          <button onclick="switchSection('mood', this)">
+            <i class="fa-solid fa-cloud-sun"></i>
+            Mood Tracker
           </button>
 
+          <button onclick="switchSection('analysis', this)">
+            <i class="fa-solid fa-chart-line"></i>
+            Analysis
+          </button>
+
+          <button onclick="switchSection('journal', this)">
+            <i class="fa-solid fa-book"></i>
+            Journal
+          </button>
+
+          <button onclick="switchSection('insights', this)">
+            <i class="fa-solid fa-brain"></i>
+            Insights
+          </button>
+
+          <button onclick="switchSection('trends', this)">
+            <i class="fa-solid fa-chart-column"></i>
+            Trends
+          </button>
+        </nav>
+
+        <!-- FILTER -->
+        <div class="sidebar-card">
+          <h5>Filter Timeline</h5>
+
+          <select id="filterRange" onchange="applyFilter()">
+            <option value="day">Today</option>
+            <option value="week">This Week</option>
+            <option value="month">This Month</option>
+          </select>
         </div>
 
-      </section>
+        <!-- ACTIONS -->
+        <div class="sidebar-actions">
+          <button onclick="toggleTheme()">🌙 Toggle Theme</button>
 
-      <!-- ANALYSIS -->
-      <section id="analysis" class="section">
+          <button onclick="exportData()">📦 Export Data</button>
+        </div>
+      </aside>
 
-        <div class="section-header">
-          <h1>Analysis Dashboard</h1>
-          <p>Your emotional patterns.</p>
+      <!-- ================= MAIN ================= -->
+      <main class="main">
+        <!-- MOBILE HEADER -->
+        <div class="mobile-header">
+          <button class="menu-btn" onclick="toggleSidebar()">☰</button>
+
+          <h2>Mood OS</h2>
         </div>
 
-        <div class="card">
-          <canvas id="chart"></canvas>
+        <!-- STATS -->
+        <div class="stats-grid">
+          <div class="stat-card">
+            <span>🔥 Streak</span>
+            <h3 id="streakText">0</h3>
+          </div>
+
+          <div class="stat-card">
+            <span>⚡ Energy Avg</span>
+            <h3 id="avgEnergy">-</h3>
+          </div>
+
+          <div class="stat-card">
+            <span>😵 Stress Avg</span>
+            <h3 id="avgStress">-</h3>
+          </div>
+
+          <div class="stat-card">
+            <span>😊 Mood Score</span>
+            <h3 id="avgMood">-</h3>
+          </div>
         </div>
 
-      </section>
+        <!-- ================= MOOD TRACKER ================= -->
+        <section id="mood" class="section active">
+          <div class="section-header">
+            <h1>Mood Tracker</h1>
+            <p>Track how your day feels.</p>
+          </div>
 
-      <!-- JOURNAL -->
-      <section id="journal" class="section">
+          <div class="card">
+            <div class="mood-selector">
+              <button class="mood-btn">😊</button>
+              <button class="mood-btn">😌</button>
+              <button class="mood-btn">😐</button>
+              <button class="mood-btn">😔</button>
+              <button class="mood-btn">😡</button>
+            </div>
 
-        <div class="section-header">
-          <h1>Journal Timeline</h1>
-          <p>Your latest entries.</p>
-        </div>
+            <input id="moodInput" placeholder="Describe your mood..." />
 
-        <input
-          id="searchJournal"
-          placeholder="Search entries..."
-          oninput="filterJournal()"
-        />
+            <div class="grid-2">
+              <select id="energyLevel">
+                <option value="1">Energy Low</option>
+                <option value="3">Energy Medium</option>
+                <option value="5">Energy High</option>
+              </select>
 
-        <ul id="entriesList"></ul>
+              <select id="stressLevel">
+                <option value="1">Stress Low</option>
+                <option value="3">Stress Medium</option>
+                <option value="5">Stress High</option>
+              </select>
+            </div>
 
-      </section>
+            <textarea
+              id="journalText"
+              placeholder="Write about your day..."
+            ></textarea>
 
-      <!-- INSIGHTS -->
-      <section id="insights" class="section">
+            <input id="highlight" placeholder="Best moment of your day ✨" />
 
-        <div class="section-header">
-          <h1>AI Insights</h1>
-          <p>Generated from your emotions.</p>
-        </div>
+            <div id="liveMoodPreview" class="preview-box">
+              Mood preview appears here...
+            </div>
 
-        <div class="card">
-          <p id="insightBox">
-            Insights will appear here...
-          </p>
-        </div>
+            <button onclick="addEntry()">Save Entry</button>
+          </div>
+        </section>
 
-      </section>
+        <!-- ANALYSIS -->
+        <section id="analysis" class="section">
+          <div class="section-header">
+            <h1>Analysis Dashboard</h1>
+            <p>Your emotional patterns.</p>
+          </div>
 
-      <!-- TRENDS -->
-      <section id="trends" class="section">
+          <div class="card">
+            <canvas id="chart"></canvas>
+          </div>
+        </section>
 
-        <div class="section-header">
-          <h1>Emotional Trends</h1>
-          <p>See your emotional activity.</p>
-        </div>
+        <!-- JOURNAL -->
+        <section id="journal" class="section">
+          <div class="section-header">
+            <h1>Journal Timeline</h1>
+            <p>Your latest entries.</p>
+          </div>
 
-        <div class="card">
-          <div id="heatmap"></div>
-        </div>
+          <input
+            id="searchJournal"
+            placeholder="Search entries..."
+            oninput="filterJournal()"
+          />
 
-      </section>
+          <ul id="entriesList"></ul>
+        </section>
 
-    </main>
+        <!-- INSIGHTS -->
+        <section id="insights" class="section">
+          <div class="section-header">
+            <h1>AI Insights</h1>
+            <p>Generated from your emotions.</p>
+          </div>
 
-  </div>
+          <div class="card">
+            <p id="insightBox">Insights will appear here...</p>
+          </div>
+        </section>
 
-  <script src="script.js"></script>
+        <!-- TRENDS -->
+        <section id="trends" class="section">
+          <div class="section-header">
+            <h1>Emotional Trends</h1>
+            <p>See your emotional activity.</p>
+          </div>
 
-</body>
+          <div class="card">
+            <div id="heatmap"></div>
+          </div>
+        </section>
+      </main>
+    </div>
+
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/public/Mood Tracker/script.js
+++ b/public/Mood Tracker/script.js
@@ -1,8 +1,8 @@
-let entries = JSON.parse(localStorage.getItem("moodEntries")) || [];
+let entries = JSON.parse(localStorage.getItem('moodEntries')) || [];
 
 let state = {
-  filter: "day",
-  section: "mood",
+  filter: 'day',
+  section: 'mood',
 };
 
 let chart;
@@ -14,7 +14,7 @@ window.onload = () => {
 
   setInterval(updateTime, 1000);
 
-  switchSection("mood");
+  switchSection('mood');
   updateAll();
 
   setupMoodButtons();
@@ -26,100 +26,99 @@ window.onload = () => {
 function updateTime() {
   const now = new Date();
 
-  document.getElementById("currentDate").innerText =
-    now.toDateString();
+  document.getElementById('currentDate').innerText = now.toDateString();
 
-  document.getElementById("currentTime").innerText =
-    now.toLocaleTimeString();
+  document.getElementById('currentTime').innerText = now.toLocaleTimeString();
 }
 
 // ================= THEME =================
 function toggleTheme() {
   const body = document.body;
 
-  if (body.classList.contains("dark")) {
-    body.classList.remove("dark");
-    body.classList.add("light");
+  if (body.classList.contains('dark')) {
+    body.classList.remove('dark');
+    body.classList.add('light');
 
-    localStorage.setItem("theme", "light");
+    localStorage.setItem('theme', 'light');
   } else {
-    body.classList.remove("light");
-    body.classList.add("dark");
+    body.classList.remove('light');
+    body.classList.add('dark');
 
-    localStorage.setItem("theme", "dark");
+    localStorage.setItem('theme', 'dark');
   }
 }
 
 function loadTheme() {
-  const savedTheme = localStorage.getItem("theme") || "dark";
+  const savedTheme = localStorage.getItem('theme') || 'dark';
 
-  document.body.classList.remove("dark", "light");
+  document.body.classList.remove('dark', 'light');
   document.body.classList.add(savedTheme);
 }
 
 // ================= MOBILE SIDEBAR =================
 function toggleSidebar() {
-  const sidebar = document.getElementById("sidebar");
-  const overlay = document.getElementById("mobileOverlay");
+  const sidebar = document.getElementById('sidebar');
+  const overlay = document.getElementById('mobileOverlay');
 
-  sidebar.classList.toggle("show");
-  overlay.classList.toggle("show");
+  sidebar.classList.toggle('show');
+  overlay.classList.toggle('show');
 }
 
 function setupMobileOverlay() {
-  const overlay = document.getElementById("mobileOverlay");
+  const overlay = document.getElementById('mobileOverlay');
 
-  overlay.addEventListener("click", () => {
-    document.getElementById("sidebar").classList.remove("show");
-    overlay.classList.remove("show");
+  overlay.addEventListener('click', () => {
+    document.getElementById('sidebar').classList.remove('show');
+    overlay.classList.remove('show');
   });
 }
 
 // ================= SECTION SWITCH =================
-function switchSection(id) {
+function switchSection(id, button = null) {
   state.section = id;
 
-  document.querySelectorAll(".section").forEach((section) => {
-    section.classList.remove("active");
+  document.querySelectorAll('.section').forEach((section) => {
+    section.classList.remove('active');
   });
 
-  document.getElementById(id).classList.add("active");
+  document.getElementById(id).classList.add('active');
 
-  // active nav button
-  document.querySelectorAll(".nav-links button").forEach((btn) => {
-    btn.classList.remove("active-btn");
+  // Update navigation highlight
+  document.querySelectorAll('.nav-links button').forEach((btn) => {
+    btn.classList.remove('active');
   });
 
-  event?.target?.closest("button")?.classList.add("active-btn");
+  if (button) {
+    button.classList.add('active');
+  } else {
+    const matchingButton = document.querySelector(
+      `.nav-links button[onclick*="${id}"]`
+    );
 
-  // close mobile sidebar
-  document.getElementById("sidebar").classList.remove("show");
-  document.getElementById("mobileOverlay").classList.remove("show");
+    matchingButton?.classList.add('active');
+  }
+
+  document.getElementById('sidebar').classList.remove('show');
+  document.getElementById('mobileOverlay').classList.remove('show');
 }
 
 // ================= ADD ENTRY =================
 function addEntry() {
-  const mood = document.getElementById("moodInput").value.trim();
+  const mood = document.getElementById('moodInput').value.trim();
 
-  const journal =
-    document.getElementById("journalText").value.trim();
+  const journal = document.getElementById('journalText').value.trim();
 
-  const highlight =
-    document.getElementById("highlight").value.trim();
+  const highlight = document.getElementById('highlight').value.trim();
 
   if (!mood && !journal) {
-    alert("Please enter your mood or journal.");
+    alert('Please enter your mood or journal.');
     return;
   }
 
   const entry = {
-    mood: mood || "Neutral",
-    energy: Number(
-      document.getElementById("energyLevel").value
-    ),
-    stress: Number(
-      document.getElementById("stressLevel").value
-    ),
+    mood: mood || 'Neutral',
+    energy: Number(document.getElementById('energyLevel').value),
+    stress: Number(document.getElementById('stressLevel').value),
     journal,
     highlight,
     ts: Date.now(),
@@ -127,36 +126,30 @@ function addEntry() {
 
   entries.push(entry);
 
-  localStorage.setItem(
-    "moodEntries",
-    JSON.stringify(entries)
-  );
+  localStorage.setItem('moodEntries', JSON.stringify(entries));
 
   clearInputs();
   updateAll();
 
-  document.getElementById(
-    "liveMoodPreview"
-  ).innerText = "✅ Mood entry saved successfully!";
+  document.getElementById('liveMoodPreview').innerText =
+    '✅ Mood entry saved successfully!';
 }
 
 // ================= CLEAR INPUTS =================
 function clearInputs() {
-  document.getElementById("moodInput").value = "";
+  document.getElementById('moodInput').value = '';
 
-  document.getElementById("journalText").value = "";
+  document.getElementById('journalText').value = '';
 
-  document.getElementById("highlight").value = "";
+  document.getElementById('highlight').value = '';
 
-  document.getElementById(
-    "liveMoodPreview"
-  ).innerText = "Mood preview appears here...";
+  document.getElementById('liveMoodPreview').innerText =
+    'Mood preview appears here...';
 }
 
 // ================= FILTER =================
 function applyFilter() {
-  state.filter =
-    document.getElementById("filterRange").value;
+  state.filter = document.getElementById('filterRange').value;
 
   updateAll();
 }
@@ -167,14 +160,11 @@ function getFilteredEntries() {
   return entries.filter((entry) => {
     const diff = now - entry.ts;
 
-    if (state.filter === "day")
-      return diff < 86400000;
+    if (state.filter === 'day') return diff < 86400000;
 
-    if (state.filter === "week")
-      return diff < 604800000;
+    if (state.filter === 'week') return diff < 604800000;
 
-    if (state.filter === "month")
-      return diff < 2592000000;
+    if (state.filter === 'month') return diff < 2592000000;
 
     return true;
   });
@@ -194,51 +184,34 @@ function updateAll() {
 // ================= STATS =================
 function updateStats(data) {
   if (data.length === 0) {
-    document.getElementById("avgEnergy").innerText =
-      "-";
+    document.getElementById('avgEnergy').innerText = '-';
 
-    document.getElementById("avgStress").innerText =
-      "-";
+    document.getElementById('avgStress').innerText = '-';
 
-    document.getElementById("avgMood").innerText =
-      "-";
+    document.getElementById('avgMood').innerText = '-';
 
-    document.getElementById("streakText").innerText =
-      "0";
+    document.getElementById('streakText').innerText = '0';
 
     return;
   }
 
-  const avgEnergy = avg(
-    data.map((d) => d.energy)
-  ).toFixed(1);
+  const avgEnergy = avg(data.map((d) => d.energy)).toFixed(1);
 
-  const avgStress = avg(
-    data.map((d) => d.stress)
-  ).toFixed(1);
+  const avgStress = avg(data.map((d) => d.stress)).toFixed(1);
 
-  const moodScore = (
-    avgEnergy * 2 -
-    avgStress
-  ).toFixed(1);
+  const moodScore = (avgEnergy * 2 - avgStress).toFixed(1);
 
-  document.getElementById("avgEnergy").innerText =
-    avgEnergy;
+  document.getElementById('avgEnergy').innerText = avgEnergy;
 
-  document.getElementById("avgStress").innerText =
-    avgStress;
+  document.getElementById('avgStress').innerText = avgStress;
 
-  document.getElementById("avgMood").innerText =
-    moodScore;
+  document.getElementById('avgMood').innerText = moodScore;
 
-  document.getElementById("streakText").innerText =
-    calculateStreak();
+  document.getElementById('streakText').innerText = calculateStreak();
 }
 
 function avg(arr) {
-  return (
-    arr.reduce((a, b) => a + b, 0) / arr.length
-  );
+  return arr.reduce((a, b) => a + b, 0) / arr.length;
 }
 
 // ================= STREAK =================
@@ -247,17 +220,10 @@ function calculateStreak() {
 
   let streak = 1;
 
-  const sorted = [...entries].sort(
-    (a, b) => a.ts - b.ts
-  );
+  const sorted = [...entries].sort((a, b) => a.ts - b.ts);
 
-  for (
-    let i = sorted.length - 1;
-    i > 0;
-    i--
-  ) {
-    const diff =
-      sorted[i].ts - sorted[i - 1].ts;
+  for (let i = sorted.length - 1; i > 0; i--) {
+    const diff = sorted[i].ts - sorted[i - 1].ts;
 
     if (diff <= 172800000) {
       streak++;
@@ -271,14 +237,12 @@ function calculateStreak() {
 
 // ================= JOURNAL =================
 function updateJournal(data) {
-  const list =
-    document.getElementById("entriesList");
+  const list = document.getElementById('entriesList');
 
-  list.innerHTML = "";
+  list.innerHTML = '';
 
   if (data.length === 0) {
-    list.innerHTML =
-      "<li>No entries found.</li>";
+    list.innerHTML = '<li>No entries found.</li>';
 
     return;
   }
@@ -287,12 +251,10 @@ function updateJournal(data) {
     .slice()
     .reverse()
     .forEach((entry) => {
-      const li = document.createElement("li");
+      const li = document.createElement('li');
 
       li.innerHTML = `
-        <strong>${new Date(
-          entry.ts
-        ).toLocaleString()}</strong>
+        <strong>${new Date(entry.ts).toLocaleString()}</strong>
         <br><br>
 
         <b>Mood:</b> ${entry.mood}
@@ -306,11 +268,11 @@ function updateJournal(data) {
 
         <b>Journal:</b>
         <br>
-        ${entry.journal || "No journal"}
+        ${entry.journal || 'No journal'}
 
         <br><br>
 
-        ✨ ${entry.highlight || "No highlight"}
+        ✨ ${entry.highlight || 'No highlight'}
       `;
 
       list.appendChild(li);
@@ -319,21 +281,13 @@ function updateJournal(data) {
 
 // ================= SEARCH JOURNAL =================
 function filterJournal() {
-  const query = document
-    .getElementById("searchJournal")
-    .value.toLowerCase();
+  const query = document.getElementById('searchJournal').value.toLowerCase();
 
   const filtered = getFilteredEntries().filter(
     (entry) =>
-      entry.mood
-        .toLowerCase()
-        .includes(query) ||
-      entry.journal
-        .toLowerCase()
-        .includes(query) ||
-      entry.highlight
-        .toLowerCase()
-        .includes(query)
+      entry.mood.toLowerCase().includes(query) ||
+      entry.journal.toLowerCase().includes(query) ||
+      entry.highlight.toLowerCase().includes(query)
   );
 
   updateJournal(filtered);
@@ -341,44 +295,34 @@ function filterJournal() {
 
 // ================= INSIGHTS =================
 function updateInsights(data) {
-  const box =
-    document.getElementById("insightBox");
+  const box = document.getElementById('insightBox');
 
   if (data.length < 2) {
-    box.innerText =
-      "Not enough data yet for insights.";
+    box.innerText = 'Not enough data yet for insights.';
 
     return;
   }
 
-  const avgEnergy = avg(
-    data.map((d) => d.energy)
-  );
+  const avgEnergy = avg(data.map((d) => d.energy));
 
-  const avgStress = avg(
-    data.map((d) => d.stress)
-  );
+  const avgStress = avg(data.map((d) => d.stress));
 
-  let message = "";
+  let message = '';
 
   if (avgStress >= 4) {
-    message +=
-      "⚠️ Your stress levels are high lately. Try relaxing.\n\n";
+    message += '⚠️ Your stress levels are high lately. Try relaxing.\n\n';
   }
 
   if (avgEnergy <= 2) {
-    message +=
-      "⚡ Your energy seems low. Sleep and hydration may help.\n\n";
+    message += '⚡ Your energy seems low. Sleep and hydration may help.\n\n';
   }
 
   if (avgEnergy >= 4 && avgStress <= 2) {
-    message +=
-      "🌟 Excellent emotional balance detected.\n\n";
+    message += '🌟 Excellent emotional balance detected.\n\n';
   }
 
-  if (message === "") {
-    message =
-      "😊 Your mood trends look stable and balanced.";
+  if (message === '') {
+    message = '😊 Your mood trends look stable and balanced.';
   }
 
   box.innerText = message;
@@ -386,49 +330,42 @@ function updateInsights(data) {
 
 // ================= CHART =================
 function updateChart(data) {
-  const canvas =
-    document.getElementById("chart");
+  const canvas = document.getElementById('chart');
 
   if (!canvas) return;
 
-  const ctx = canvas.getContext("2d");
+  const ctx = canvas.getContext('2d');
 
-  const labels = data.map((entry) =>
-    new Date(entry.ts).toLocaleDateString()
-  );
+  const labels = data.map((entry) => new Date(entry.ts).toLocaleDateString());
 
-  const energyData = data.map(
-    (entry) => entry.energy
-  );
+  const energyData = data.map((entry) => entry.energy);
 
-  const stressData = data.map(
-    (entry) => entry.stress
-  );
+  const stressData = data.map((entry) => entry.stress);
 
   if (chart) {
     chart.destroy();
   }
 
   chart = new Chart(ctx, {
-    type: "line",
+    type: 'line',
 
     data: {
       labels,
 
       datasets: [
         {
-          label: "Energy",
+          label: 'Energy',
           data: energyData,
-          borderColor: "#06b6d4",
-          backgroundColor: "transparent",
+          borderColor: '#06b6d4',
+          backgroundColor: 'transparent',
           tension: 0.4,
         },
 
         {
-          label: "Stress",
+          label: 'Stress',
           data: stressData,
-          borderColor: "#8b5cf6",
-          backgroundColor: "transparent",
+          borderColor: '#8b5cf6',
+          backgroundColor: 'transparent',
           tension: 0.4,
         },
       ],
@@ -440,10 +377,7 @@ function updateChart(data) {
       plugins: {
         legend: {
           labels: {
-            color:
-              getComputedStyle(
-                document.body
-              ).getPropertyValue("--text"),
+            color: getComputedStyle(document.body).getPropertyValue('--text'),
           },
         },
       },
@@ -451,19 +385,13 @@ function updateChart(data) {
       scales: {
         x: {
           ticks: {
-            color:
-              getComputedStyle(
-                document.body
-              ).getPropertyValue("--text"),
+            color: getComputedStyle(document.body).getPropertyValue('--text'),
           },
         },
 
         y: {
           ticks: {
-            color:
-              getComputedStyle(
-                document.body
-              ).getPropertyValue("--text"),
+            color: getComputedStyle(document.body).getPropertyValue('--text'),
           },
 
           beginAtZero: true,
@@ -476,31 +404,21 @@ function updateChart(data) {
 
 // ================= HEATMAP =================
 function updateHeatmap(data) {
-  const heatmap =
-    document.getElementById("heatmap");
+  const heatmap = document.getElementById('heatmap');
 
-  heatmap.innerHTML = "";
+  heatmap.innerHTML = '';
 
   if (data.length === 0) return;
 
   data.forEach((entry) => {
-    const cell =
-      document.createElement("div");
+    const cell = document.createElement('div');
 
-    cell.classList.add("heatmap-cell");
+    cell.classList.add('heatmap-cell');
 
-    const level =
-      Math.min(
-        5,
-        Math.max(
-          1,
-          Math.round(
-            (entry.energy +
-              (6 - entry.stress)) /
-              2
-          )
-        )
-      );
+    const level = Math.min(
+      5,
+      Math.max(1, Math.round((entry.energy + (6 - entry.stress)) / 2))
+    );
 
     cell.classList.add(`level-${level}`);
 
@@ -516,63 +434,44 @@ Stress: ${entry.stress}
 
 // ================= LIVE PREVIEW =================
 function setupLivePreview() {
-  const moodInput =
-    document.getElementById("moodInput");
+  const moodInput = document.getElementById('moodInput');
 
-  const preview =
-    document.getElementById(
-      "liveMoodPreview"
-    );
+  const preview = document.getElementById('liveMoodPreview');
 
-  moodInput.addEventListener(
-    "input",
-    (e) => {
-      const text =
-        e.target.value.toLowerCase();
+  moodInput.addEventListener('input', (e) => {
+    const text = e.target.value.toLowerCase();
 
-      if (
-        text.includes("happy") ||
-        text.includes("great") ||
-        text.includes("excited")
-      ) {
-        preview.innerText =
-          "😊 Positive mood detected!";
-      } else if (
-        text.includes("sad") ||
-        text.includes("angry") ||
-        text.includes("upset")
-      ) {
-        preview.innerText =
-          "⚠️ Negative emotional state detected.";
-      } else if (
-        text.includes("tired") ||
-        text.includes("exhausted")
-      ) {
-        preview.innerText =
-          "😴 You may need some rest.";
-      } else {
-        preview.innerText =
-          "🧠 Analyzing your emotional state...";
-      }
+    if (
+      text.includes('happy') ||
+      text.includes('great') ||
+      text.includes('excited')
+    ) {
+      preview.innerText = '😊 Positive mood detected!';
+    } else if (
+      text.includes('sad') ||
+      text.includes('angry') ||
+      text.includes('upset')
+    ) {
+      preview.innerText = '⚠️ Negative emotional state detected.';
+    } else if (text.includes('tired') || text.includes('exhausted')) {
+      preview.innerText = '😴 You may need some rest.';
+    } else {
+      preview.innerText = '🧠 Analyzing your emotional state...';
     }
-  );
+  });
 }
 
 // ================= MOOD BUTTONS =================
 function setupMoodButtons() {
-  const moodButtons =
-    document.querySelectorAll(".mood-btn");
+  const moodButtons = document.querySelectorAll('.mood-btn');
 
-  const moodInput =
-    document.getElementById("moodInput");
+  const moodInput = document.getElementById('moodInput');
 
   moodButtons.forEach((btn) => {
-    btn.addEventListener("click", () => {
-      moodButtons.forEach((b) =>
-        b.classList.remove("selected")
-      );
+    btn.addEventListener('click', () => {
+      moodButtons.forEach((b) => b.classList.remove('selected'));
 
-      btn.classList.add("selected");
+      btn.classList.add('selected');
 
       moodInput.value = btn.innerText;
     });
@@ -582,24 +481,19 @@ function setupMoodButtons() {
 // ================= EXPORT DATA =================
 function exportData() {
   if (entries.length === 0) {
-    alert("No data available to export.");
+    alert('No data available to export.');
     return;
   }
 
-  const blob = new Blob(
-    [JSON.stringify(entries, null, 2)],
-    {
-      type: "application/json",
-    }
-  );
+  const blob = new Blob([JSON.stringify(entries, null, 2)], {
+    type: 'application/json',
+  });
 
-  const link =
-    document.createElement("a");
+  const link = document.createElement('a');
 
-  link.href =
-    URL.createObjectURL(blob);
+  link.href = URL.createObjectURL(blob);
 
-  link.download = "mood-data.json";
+  link.download = 'mood-data.json';
 
   document.body.appendChild(link);
 

--- a/public/Mood Tracker/styles.css
+++ b/public/Mood Tracker/styles.css
@@ -21,14 +21,14 @@
 
 body.light {
   --bg: #f4f7fb;
-  --card: rgba(255,255,255,0.9);
-  --border: rgba(0,0,0,0.08);
+  --card: rgba(255, 255, 255, 0.9);
+  --border: rgba(0, 0, 0, 0.08);
   --text: #111827;
   --text-secondary: #6b7280;
 }
 
 body {
-  font-family: "Inter", sans-serif;
+  font-family: 'Inter', sans-serif;
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
@@ -86,7 +86,7 @@ body {
 
 .sidebar {
   width: 300px;
-  background: rgba(255,255,255,0.04);
+  background: rgba(255, 255, 255, 0.04);
   backdrop-filter: blur(18px);
   border-right: 1px solid var(--border);
   padding: 24px;
@@ -106,11 +106,7 @@ body {
 .logo {
   width: 60px;
   height: 60px;
-  background: linear-gradient(
-    135deg,
-    var(--primary),
-    #4f46e5
-  );
+  background: linear-gradient(135deg, var(--primary), #4f46e5);
   border-radius: 18px;
   display: grid;
   place-items: center;
@@ -162,11 +158,11 @@ body {
   border-radius: 12px;
   text-align: left;
   cursor: pointer;
-  transition: .3s;
+  transition: 0.3s;
 }
 
 .nav-links button:hover {
-  background: rgba(124,58,237,.15);
+  background: rgba(124, 58, 237, 0.15);
 }
 
 .nav-links i {
@@ -224,7 +220,7 @@ body {
 
 .stats-grid {
   display: grid;
-  grid-template-columns: repeat(4,1fr);
+  grid-template-columns: repeat(4, 1fr);
   gap: 20px;
   margin-bottom: 30px;
 }
@@ -290,7 +286,7 @@ input,
 textarea,
 select {
   width: 100%;
-  background: rgba(255,255,255,.06);
+  background: rgba(255, 255, 255, 0.06);
   border: 1px solid var(--border);
   color: var(--text);
   border-radius: 12px;
@@ -310,11 +306,7 @@ button {
 .card button {
   width: 100%;
   margin-top: 15px;
-  background: linear-gradient(
-    135deg,
-    var(--primary),
-    var(--primary-light)
-  );
+  background: linear-gradient(135deg, var(--primary), var(--primary-light));
   border: none;
   color: white;
   padding: 14px;
@@ -339,9 +331,9 @@ button {
   border-radius: 18px;
   border: none;
   font-size: 1.7rem;
-  background: rgba(255,255,255,.08);
+  background: rgba(255, 255, 255, 0.08);
   cursor: pointer;
-  transition: .3s;
+  transition: 0.3s;
 }
 
 .mood-btn:hover {
@@ -354,7 +346,7 @@ button {
 
 .grid-2 {
   display: grid;
-  grid-template-columns: repeat(2,1fr);
+  grid-template-columns: repeat(2, 1fr);
   gap: 15px;
 }
 
@@ -366,7 +358,7 @@ button {
   margin-top: 15px;
   padding: 15px;
   border-radius: 12px;
-  background: rgba(124,58,237,.1);
+  background: rgba(124, 58, 237, 0.1);
   border: 1px dashed var(--primary);
 }
 
@@ -414,11 +406,11 @@ button {
 .mobile-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0,0,0,.5);
+  background: rgba(0, 0, 0, 0.5);
   z-index: 998;
   opacity: 0;
   visibility: hidden;
-  transition: .3s;
+  transition: 0.3s;
 }
 
 .mobile-overlay.show {
@@ -431,21 +423,19 @@ button {
 ========================= */
 
 @media (max-width: 1024px) {
-
   .stats-grid {
-    grid-template-columns: repeat(2,1fr);
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
 @media (max-width: 768px) {
-
   .sidebar {
     position: fixed;
     left: -100%;
     top: 0;
     width: 280px;
     z-index: 999;
-    transition: .35s;
+    transition: 0.35s;
   }
 
   .sidebar.show {
@@ -487,7 +477,6 @@ button {
 }
 
 @media (max-width: 480px) {
-
   .section-header h1 {
     font-size: 1.5rem;
   }
@@ -503,10 +492,6 @@ button {
 }
 
 .nav-links button.active {
-  background: linear-gradient(
-    135deg,
-    var(--primary),
-    var(--primary-light)
-  );
+  background: linear-gradient(135deg, var(--primary), var(--primary-light));
   color: white;
 }


### PR DESCRIPTION
## Pull Request Description

### Closes

Closes #9098

### Summary

Fixes an issue where sidebar navigation highlighting disappeared when sections were changed programmatically.

The previous implementation relied on the global `event` object, which only exists during click events. As a result, navigation highlighting failed during page initialization and any future programmatic navigation.

### Changes Made

- Removed dependency on global `event`.
- Updated navigation buttons to pass a button reference.
- Added fallback logic to locate and activate the correct navigation button when no click event exists.
- Standardized highlighting using the existing `.active` CSS class.

### Root Cause

`switchSection()` attempted to apply the active state using:

```js
event?.target?.closest('button')?.classList.add('active-btn');
```

When invoked outside a click handler, `event` is undefined and no navigation item receives an active state.

### Solution

The active navigation item is now determined directly from the section identifier or the clicked button reference, ensuring consistent behavior regardless of how navigation occurs.

### Tested

- Initial page load
- Sidebar button clicks
- `switchSection('analysis')` from DevTools
- Mobile navigation
- Repeated section switching

### Result

The correct navigation item remains highlighted for all navigation paths.