### PR TITLE
fix: enable manual dismissal of toast notifications

### DIFF
--- a/public/Lost_And_Found_Portal/index.html
+++ b/public/Lost_And_Found_Portal/index.html
@@ -1,312 +1,479 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Lost & Found Portal</title>
     <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
     <!-- Icons -->
     <script src="https://unpkg.com/@phosphor-icons/web"></script>
     <!-- Custom Styles -->
-    <link rel="stylesheet" href="style.css">
-</head>
-<body>
-
-    <a href="../../" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 16px;border-radius:8px;background:#1e293b;color:#3b82f6;border:1px solid #3b82f6;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;transition:all 0.2s ease;" onmouseover="this.style.background='#3b82f6';this.style.color='#fff'" onmouseout="this.style.background='#1e293b';this.style.color='#3b82f6'">← Back to Home</a>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <a
+      href="../../"
+      class="project-back-button"
+      style="
+        position: fixed;
+        left: 18px;
+        top: 18px;
+        padding: 8px 16px;
+        border-radius: 8px;
+        background: #1e293b;
+        color: #3b82f6;
+        border: 1px solid #3b82f6;
+        text-decoration: none;
+        z-index: 9999;
+        font-weight: 700;
+        font-family: Inter, system-ui, sans-serif;
+        transition: all 0.2s ease;
+      "
+      onmouseover="
+        this.style.background = '#3b82f6';
+        this.style.color = '#fff';
+      "
+      onmouseout="
+        this.style.background = '#1e293b';
+        this.style.color = '#3b82f6';
+      "
+      >← Back to Home</a
+    >
 
     <div class="background-elements">
-        <div class="blob blob-1"></div>
-        <div class="blob blob-2"></div>
-        <div class="blob blob-3"></div>
+      <div class="blob blob-1"></div>
+      <div class="blob blob-2"></div>
+      <div class="blob blob-3"></div>
     </div>
 
     <nav class="navbar glass">
-        <div class="nav-brand">
-            <i class="ph-fill ph-magnifying-glass"></i>
-            <span>Lost & Found</span>
-        </div>
-        <div class="nav-links">
-            <button class="nav-btn active" data-view="home">Home</button>
-            <button class="nav-btn" data-view="browse">Browse Listings</button>
-            <button class="nav-btn btn-primary" data-view="report-lost">Report Lost</button>
-            <button class="nav-btn btn-secondary" data-view="report-found">Report Found</button>
-            <button id="theme-toggle" class="icon-btn" aria-label="Toggle Dark Mode">
-                <i class="ph ph-moon"></i>
-            </button>
-        </div>
-        <div class="mobile-menu-btn">
-            <i class="ph ph-list"></i>
-        </div>
+      <div class="nav-brand">
+        <i class="ph-fill ph-magnifying-glass"></i>
+        <span>Lost & Found</span>
+      </div>
+      <div class="nav-links">
+        <button class="nav-btn active" data-view="home">Home</button>
+        <button class="nav-btn" data-view="browse">Browse Listings</button>
+        <button class="nav-btn btn-primary" data-view="report-lost">
+          Report Lost
+        </button>
+        <button class="nav-btn btn-secondary" data-view="report-found">
+          Report Found
+        </button>
+        <button
+          id="theme-toggle"
+          class="icon-btn"
+          aria-label="Toggle Dark Mode"
+        >
+          <i class="ph ph-moon"></i>
+        </button>
+      </div>
+      <div class="mobile-menu-btn">
+        <i class="ph ph-list"></i>
+      </div>
     </nav>
 
     <!-- Mobile Navigation Menu -->
-    <div class="mobile-menu glass hidden">
-        <button class="nav-btn active" data-view="home">Home</button>
-        <button class="nav-btn" data-view="browse">Browse Listings</button>
-        <button class="nav-btn btn-primary" data-view="report-lost">Report Lost</button>
-        <button class="nav-btn btn-secondary" data-view="report-found">Report Found</button>
+    <div class="hidden mobile-menu glass">
+      <button class="nav-btn active" data-view="home">Home</button>
+      <button class="nav-btn" data-view="browse">Browse Listings</button>
+      <button class="nav-btn btn-primary" data-view="report-lost">
+        Report Lost
+      </button>
+      <button class="nav-btn btn-secondary" data-view="report-found">
+        Report Found
+      </button>
     </div>
 
     <main class="main-content">
-        <!-- Home View -->
-        <section id="view-home" class="view-section active fade-in">
-            <div class="hero">
-                <div class="hero-content">
-                    <h1>Find what you've <span class="text-gradient">Lost</span>. <br>Return what you've <span class="text-gradient">Found</span>.</h1>
-                    <p>A community-driven platform to reunite people with their belongings. Report lost items or help someone by reporting what you've found.</p>
-                    <div class="hero-actions">
-                        <button class="btn btn-primary btn-lg" onclick="window.app.switchView('report-lost')">I Lost Something</button>
-                        <button class="btn btn-secondary btn-lg" onclick="window.app.switchView('report-found')">I Found Something</button>
-                    </div>
-                </div>
+      <!-- Home View -->
+      <section id="view-home" class="view-section active fade-in">
+        <div class="hero">
+          <div class="hero-content">
+            <h1>
+              Find what you've <span class="text-gradient">Lost</span>.
+              <br />Return what you've <span class="text-gradient">Found</span>.
+            </h1>
+            <p>
+              A community-driven platform to reunite people with their
+              belongings. Report lost items or help someone by reporting what
+              you've found.
+            </p>
+            <div class="hero-actions">
+              <button
+                class="btn btn-primary btn-lg"
+                onclick="window.app.switchView('report-lost')"
+              >
+                I Lost Something
+              </button>
+              <button
+                class="btn btn-secondary btn-lg"
+                onclick="window.app.switchView('report-found')"
+              >
+                I Found Something
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="stats-container">
+          <div class="stat-card glass hover-effect">
+            <div class="stat-icon lost-icon" aria-hidden="true">
+              <i class="ph ph-warning-circle"></i>
+            </div>
+            <div class="stat-info">
+              <h3>Reported Lost</h3>
+              <p id="stat-lost" class="stat-number">124</p>
+            </div>
+          </div>
+          <div class="stat-card glass hover-effect">
+            <div class="stat-icon found-icon" aria-hidden="true">
+              <i class="ph ph-check-circle"></i>
+            </div>
+            <div class="stat-info">
+              <h3>Reported Found</h3>
+              <p id="stat-found" class="stat-number">89</p>
+            </div>
+          </div>
+          <div class="stat-card glass hover-effect">
+            <div class="stat-icon reunited-icon" aria-hidden="true">
+              <i class="ph ph-handshake"></i>
+            </div>
+            <div class="stat-info">
+              <h3>Items Reunited</h3>
+              <p id="stat-reunited" class="stat-number">0</p>
+            </div>
+          </div>
+          <div class="stat-card glass hover-effect">
+            <div class="stat-icon never-found-icon" aria-hidden="true">
+              <i class="ph ph-x-circle"></i>
+            </div>
+            <div class="stat-info">
+              <h3>Never Found</h3>
+              <p id="stat-never-found" class="stat-number">0</p>
+            </div>
+          </div>
+        </div>
+
+        <div class="recent-listings">
+          <div class="section-header">
+            <h2>Recent Listings</h2>
+            <button
+              class="btn btn-text"
+              onclick="window.app.switchView('browse')"
+            >
+              View All <i class="ph ph-arrow-right"></i>
+            </button>
+          </div>
+          <div class="listings-grid" id="home-recent-listings">
+            <!-- Populated by JS -->
+          </div>
+        </div>
+      </section>
+
+      <!-- Browse View -->
+      <section id="view-browse" class="hidden view-section fade-in">
+        <div class="page-header">
+          <h2>Browse Listings</h2>
+          <p>Search through reported lost and found items in your area.</p>
+        </div>
+
+        <div class="filters-container glass">
+          <div class="search-bar">
+            <i class="ph ph-magnifying-glass"></i>
+            <input
+              type="text"
+              id="search-input"
+              placeholder="Search items by name or description..."
+            />
+          </div>
+          <div class="filter-controls">
+            <select id="type-filter" class="custom-select">
+              <option value="all">All Items</option>
+              <option value="lost">Lost Items</option>
+              <option value="found">Found Items</option>
+            </select>
+            <select id="category-filter" class="custom-select">
+              <option value="all">All Categories</option>
+              <option value="electronics">Electronics</option>
+              <option value="wallet">Wallet/Purse</option>
+              <option value="keys">Keys</option>
+              <option value="pets">Pets</option>
+              <option value="clothing">Clothing</option>
+              <option value="other">Other</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="listings-grid" id="browse-listings">
+          <!-- Populated by JS -->
+        </div>
+
+        <div id="empty-state" class="hidden empty-state">
+          <i class="ph ph-magnifying-glass"></i>
+          <h3>No items found</h3>
+          <p>
+            Try adjusting your search or filters to find what you're looking
+            for.
+          </p>
+          <button class="btn btn-secondary" onclick="window.app.resetFilters()">
+            Clear Filters
+          </button>
+        </div>
+      </section>
+
+      <!-- Report Lost View -->
+      <section id="view-report-lost" class="hidden view-section fade-in">
+        <div class="form-container glass">
+          <div class="text-center form-header">
+            <div class="form-icon lost-bg">
+              <i class="ph ph-warning-circle"></i>
+            </div>
+            <h2>Report a Lost Item</h2>
+            <p>
+              Provide details about the item you lost so the community can help
+              you find it.
+            </p>
+          </div>
+
+          <form id="report-lost-form" class="report-form">
+            <div class="form-group">
+              <label for="lost-item-name">Item Name</label>
+              <input
+                type="text"
+                id="lost-item-name"
+                required
+                placeholder="e.g. Black Leather Wallet"
+              />
             </div>
 
-            <div class="stats-container">
-                <div class="stat-card glass hover-effect">
-                    <div class="stat-icon lost-icon" aria-hidden="true"><i class="ph ph-warning-circle"></i></div>
-                    <div class="stat-info">
-                        <h3>Reported Lost</h3>
-                        <p id="stat-lost" class="stat-number">124</p>
-                    </div>
-                </div>
-                <div class="stat-card glass hover-effect">
-                    <div class="stat-icon found-icon" aria-hidden="true"><i class="ph ph-check-circle"></i></div>
-                    <div class="stat-info">
-                        <h3>Reported Found</h3>
-                        <p id="stat-found" class="stat-number">89</p>
-                    </div>
-                </div>
-                <div class="stat-card glass hover-effect">
-                    <div class="stat-icon reunited-icon" aria-hidden="true"><i class="ph ph-handshake"></i></div>
-                    <div class="stat-info">
-                        <h3>Items Reunited</h3>
-                        <p id="stat-reunited" class="stat-number">0</p>
-                    </div>
-                </div>
-                <div class="stat-card glass hover-effect">
-                    <div class="stat-icon never-found-icon" aria-hidden="true"><i class="ph ph-x-circle"></i></div>
-                    <div class="stat-info">
-                        <h3>Never Found</h3>
-                        <p id="stat-never-found" class="stat-number">0</p>
-                    </div>
-                </div>
+            <div class="form-row">
+              <div class="form-group">
+                <label for="lost-category">Category</label>
+                <select id="lost-category" required>
+                  <option value="" disabled selected>Select Category</option>
+                  <option value="electronics">Electronics</option>
+                  <option value="wallet">Wallet/Purse</option>
+                  <option value="keys">Keys</option>
+                  <option value="pets">Pets</option>
+                  <option value="clothing">Clothing</option>
+                  <option value="other">Other</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label for="lost-date">Date Lost</label>
+                <input type="date" id="lost-date" required />
+              </div>
             </div>
 
-            <div class="recent-listings">
-                <div class="section-header">
-                    <h2>Recent Listings</h2>
-                    <button class="btn btn-text" onclick="window.app.switchView('browse')">View All <i class="ph ph-arrow-right"></i></button>
-                </div>
-                <div class="listings-grid" id="home-recent-listings">
-                    <!-- Populated by JS -->
-                </div>
-            </div>
-        </section>
-
-        <!-- Browse View -->
-        <section id="view-browse" class="view-section hidden fade-in">
-            <div class="page-header">
-                <h2>Browse Listings</h2>
-                <p>Search through reported lost and found items in your area.</p>
+            <div class="form-group">
+              <label for="lost-location">Location Lost</label>
+              <input
+                type="text"
+                id="lost-location"
+                required
+                placeholder="e.g. Central Park, near the fountain"
+              />
             </div>
 
-            <div class="filters-container glass">
-                <div class="search-bar">
-                    <i class="ph ph-magnifying-glass"></i>
-                    <input type="text" id="search-input" placeholder="Search items by name or description...">
-                </div>
-                <div class="filter-controls">
-                    <select id="type-filter" class="custom-select">
-                        <option value="all">All Items</option>
-                        <option value="lost">Lost Items</option>
-                        <option value="found">Found Items</option>
-                    </select>
-                    <select id="category-filter" class="custom-select">
-                        <option value="all">All Categories</option>
-                        <option value="electronics">Electronics</option>
-                        <option value="wallet">Wallet/Purse</option>
-                        <option value="keys">Keys</option>
-                        <option value="pets">Pets</option>
-                        <option value="clothing">Clothing</option>
-                        <option value="other">Other</option>
-                    </select>
-                </div>
+            <div class="form-group">
+              <label for="lost-description">Description</label>
+              <textarea
+                id="lost-description"
+                rows="4"
+                required
+                placeholder="Provide distinguishing features, colors, brands, etc."
+              ></textarea>
             </div>
 
-            <div class="listings-grid" id="browse-listings">
-                <!-- Populated by JS -->
+            <div class="form-group">
+              <label for="lost-contact"
+                >Contact Information (Phone or Email)</label
+              >
+              <input
+                type="text"
+                id="lost-contact"
+                required
+                placeholder="How can someone reach you?"
+              />
             </div>
-            
-            <div id="empty-state" class="empty-state hidden">
-                <i class="ph ph-magnifying-glass"></i>
-                <h3>No items found</h3>
-                <p>Try adjusting your search or filters to find what you're looking for.</p>
-                <button class="btn btn-secondary" onclick="window.app.resetFilters()">Clear Filters</button>
+
+            <div class="form-group file-upload">
+              <label for="lost-image">Reference Image (Optional)</label>
+              <div class="file-drop-area" id="lost-drop-area">
+                <i class="ph ph-upload-simple"></i>
+                <span class="file-msg"
+                  >Click or drag and drop an image here</span
+                >
+                <input
+                  type="file"
+                  id="lost-image"
+                  accept="image/*"
+                  class="file-input"
+                />
+              </div>
+              <div
+                id="lost-image-preview"
+                class="hidden image-preview-container"
+              >
+                <img id="lost-preview-img" src="" alt="Preview" />
+                <button type="button" class="remove-image-btn">
+                  <i class="ph ph-x"></i>
+                </button>
+              </div>
             </div>
-        </section>
 
-        <!-- Report Lost View -->
-        <section id="view-report-lost" class="view-section hidden fade-in">
-            <div class="form-container glass">
-                <div class="form-header text-center">
-                    <div class="form-icon lost-bg"><i class="ph ph-warning-circle"></i></div>
-                    <h2>Report a Lost Item</h2>
-                    <p>Provide details about the item you lost so the community can help you find it.</p>
-                </div>
-                
-                <form id="report-lost-form" class="report-form">
-                    <div class="form-group">
-                        <label for="lost-item-name">Item Name</label>
-                        <input type="text" id="lost-item-name" required placeholder="e.g. Black Leather Wallet">
-                    </div>
-                    
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label for="lost-category">Category</label>
-                            <select id="lost-category" required>
-                                <option value="" disabled selected>Select Category</option>
-                                <option value="electronics">Electronics</option>
-                                <option value="wallet">Wallet/Purse</option>
-                                <option value="keys">Keys</option>
-                                <option value="pets">Pets</option>
-                                <option value="clothing">Clothing</option>
-                                <option value="other">Other</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="lost-date">Date Lost</label>
-                            <input type="date" id="lost-date" required>
-                        </div>
-                    </div>
+            <button type="submit" class="btn btn-primary btn-full btn-lg">
+              Submit Report
+            </button>
+          </form>
+        </div>
+      </section>
 
-                    <div class="form-group">
-                        <label for="lost-location">Location Lost</label>
-                        <input type="text" id="lost-location" required placeholder="e.g. Central Park, near the fountain">
-                    </div>
-
-                    <div class="form-group">
-                        <label for="lost-description">Description</label>
-                        <textarea id="lost-description" rows="4" required placeholder="Provide distinguishing features, colors, brands, etc."></textarea>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="lost-contact">Contact Information (Phone or Email)</label>
-                        <input type="text" id="lost-contact" required placeholder="How can someone reach you?">
-                    </div>
-
-                    <div class="form-group file-upload">
-                        <label for="lost-image">Reference Image (Optional)</label>
-                        <div class="file-drop-area" id="lost-drop-area">
-                            <i class="ph ph-upload-simple"></i>
-                            <span class="file-msg">Click or drag and drop an image here</span>
-                            <input type="file" id="lost-image" accept="image/*" class="file-input">
-                        </div>
-                        <div id="lost-image-preview" class="image-preview-container hidden">
-                            <img id="lost-preview-img" src="" alt="Preview">
-                            <button type="button" class="remove-image-btn"><i class="ph ph-x"></i></button>
-                        </div>
-                    </div>
-
-                    <button type="submit" class="btn btn-primary btn-full btn-lg">Submit Report</button>
-                </form>
+      <!-- Report Found View -->
+      <section id="view-report-found" class="hidden view-section fade-in">
+        <div class="form-container glass">
+          <div class="text-center form-header">
+            <div class="form-icon found-bg">
+              <i class="ph ph-check-circle"></i>
             </div>
-        </section>
+            <h2>Report a Found Item</h2>
+            <p>
+              Found something? List it here to help reunite it with its owner.
+            </p>
+          </div>
 
-        <!-- Report Found View -->
-        <section id="view-report-found" class="view-section hidden fade-in">
-            <div class="form-container glass">
-                <div class="form-header text-center">
-                    <div class="form-icon found-bg"><i class="ph ph-check-circle"></i></div>
-                    <h2>Report a Found Item</h2>
-                    <p>Found something? List it here to help reunite it with its owner.</p>
-                </div>
-                
-                <form id="report-found-form" class="report-form">
-                    <div class="form-group">
-                        <label for="found-item-name">Item Name</label>
-                        <input type="text" id="found-item-name" required placeholder="e.g. Set of Keys with Honda logo">
-                    </div>
-                    
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label for="found-category">Category</label>
-                            <select id="found-category" required>
-                                <option value="" disabled selected>Select Category</option>
-                                <option value="electronics">Electronics</option>
-                                <option value="wallet">Wallet/Purse</option>
-                                <option value="keys">Keys</option>
-                                <option value="pets">Pets</option>
-                                <option value="clothing">Clothing</option>
-                                <option value="other">Other</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="found-date">Date Found</label>
-                            <input type="date" id="found-date" required>
-                        </div>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="found-location">Location Found</label>
-                        <input type="text" id="found-location" required placeholder="e.g. Downtown Coffee Shop">
-                    </div>
-
-                    <div class="form-group">
-                        <label for="found-description">Description</label>
-                        <textarea id="found-description" rows="4" required placeholder="Provide details, but keep some hidden to verify the true owner."></textarea>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="found-contact">Contact Information (Phone or Email)</label>
-                        <input type="text" id="found-contact" required placeholder="How can the owner reach you?">
-                    </div>
-
-                    <div class="form-group file-upload">
-                        <label for="found-image">Item Image</label>
-                        <div class="file-drop-area" id="found-drop-area">
-                            <i class="ph ph-upload-simple"></i>
-                            <span class="file-msg">Click or drag and drop an image here</span>
-                            <input type="file" id="found-image" accept="image/*" class="file-input">
-                        </div>
-                        <div id="found-image-preview" class="image-preview-container hidden">
-                            <img id="found-preview-img" src="" alt="Preview">
-                            <button type="button" class="remove-image-btn"><i class="ph ph-x"></i></button>
-                        </div>
-                    </div>
-
-                    <button type="submit" class="btn btn-secondary btn-full btn-lg">Submit Report</button>
-                </form>
+          <form id="report-found-form" class="report-form">
+            <div class="form-group">
+              <label for="found-item-name">Item Name</label>
+              <input
+                type="text"
+                id="found-item-name"
+                required
+                placeholder="e.g. Set of Keys with Honda logo"
+              />
             </div>
-        </section>
 
-        <!-- Item Details View -->
-        <section id="view-details" class="view-section hidden fade-in">
-            <button class="btn btn-text back-btn" onclick="window.app.switchView('browse')"><i class="ph ph-arrow-left"></i> Back to Browse</button>
-            <div class="details-container glass" id="item-details-content">
-                <!-- Populated by JS -->
+            <div class="form-row">
+              <div class="form-group">
+                <label for="found-category">Category</label>
+                <select id="found-category" required>
+                  <option value="" disabled selected>Select Category</option>
+                  <option value="electronics">Electronics</option>
+                  <option value="wallet">Wallet/Purse</option>
+                  <option value="keys">Keys</option>
+                  <option value="pets">Pets</option>
+                  <option value="clothing">Clothing</option>
+                  <option value="other">Other</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label for="found-date">Date Found</label>
+                <input type="date" id="found-date" required />
+              </div>
             </div>
-        </section>
 
+            <div class="form-group">
+              <label for="found-location">Location Found</label>
+              <input
+                type="text"
+                id="found-location"
+                required
+                placeholder="e.g. Downtown Coffee Shop"
+              />
+            </div>
+
+            <div class="form-group">
+              <label for="found-description">Description</label>
+              <textarea
+                id="found-description"
+                rows="4"
+                required
+                placeholder="Provide details, but keep some hidden to verify the true owner."
+              ></textarea>
+            </div>
+
+            <div class="form-group">
+              <label for="found-contact"
+                >Contact Information (Phone or Email)</label
+              >
+              <input
+                type="text"
+                id="found-contact"
+                required
+                placeholder="How can the owner reach you?"
+              />
+            </div>
+
+            <div class="form-group file-upload">
+              <label for="found-image">Item Image</label>
+              <div class="file-drop-area" id="found-drop-area">
+                <i class="ph ph-upload-simple"></i>
+                <span class="file-msg"
+                  >Click or drag and drop an image here</span
+                >
+                <input
+                  type="file"
+                  id="found-image"
+                  accept="image/*"
+                  class="file-input"
+                />
+              </div>
+              <div
+                id="found-image-preview"
+                class="hidden image-preview-container"
+              >
+                <img id="found-preview-img" src="" alt="Preview" />
+                <button type="button" class="remove-image-btn">
+                  <i class="ph ph-x"></i>
+                </button>
+              </div>
+            </div>
+
+            <button type="submit" class="btn btn-secondary btn-full btn-lg">
+              Submit Report
+            </button>
+          </form>
+        </div>
+      </section>
+
+      <!-- Item Details View -->
+      <section id="view-details" class="hidden view-section fade-in">
+        <button
+          class="btn btn-text back-btn"
+          onclick="window.app.switchView('browse')"
+        >
+          <i class="ph ph-arrow-left"></i> Back to Browse
+        </button>
+        <div class="details-container glass" id="item-details-content">
+          <!-- Populated by JS -->
+        </div>
+      </section>
     </main>
 
     <footer class="footer">
-        <p>&copy; 2026 Lost & Found Portal. Built for 100 Days 100 Web Projects.</p>
+      <p>
+        &copy; 2026 Lost & Found Portal. Built for 100 Days 100 Web Projects.
+      </p>
     </footer>
 
     <!-- Toast Notification -->
-    <div id="toast" class="toast hidden glass">
-        <div class="toast-icon"><i class="ph ph-check-circle"></i></div>
-        <div class="toast-content">
-            <h4 id="toast-title">Success</h4>
-            <p id="toast-message">Item reported successfully.</p>
-        </div>
-        <button class="toast-close"><i class="ph ph-x"></i></button>
+    <div id="toast" class="hidden toast glass">
+      <div class="toast-icon"><i class="ph ph-check-circle"></i></div>
+      <div class="toast-content">
+        <h4 id="toast-title">Success</h4>
+        <p id="toast-message">Item reported successfully.</p>
+      </div>
+      <button class="toast-close"><i class="ph ph-x"></i></button>
     </div>
 
     <!-- Scripts -->
     <script src="script.js"></script>
-</body>
+  </body>
 </html>

--- a/public/Lost_And_Found_Portal/script.js
+++ b/public/Lost_And_Found_Portal/script.js
@@ -4,348 +4,405 @@
  */
 
 class LostAndFoundApp {
-    constructor() {
-        this.items = this.loadItems();
-        this.currentView = 'home';
-        this.init();
+  constructor() {
+    this.items = this.loadItems();
+    this.currentView = 'home';
+    this.init();
+  }
+
+  // Initial Data
+  getInitialData() {
+    return [];
+  }
+
+  hideToast() {
+    if (!this.toast || this.toast.classList.contains('hidden')) return;
+
+    this.toast.classList.add('fade-out');
+
+    setTimeout(() => {
+      this.toast.classList.add('hidden');
+      this.toast.classList.remove('fade-out');
+    }, 300);
+  }
+  loadItems() {
+    const stored = localStorage.getItem('lostAndFoundApp_v2_Items');
+    if (stored) {
+      return JSON.parse(stored);
+    }
+    const initial = this.getInitialData();
+    localStorage.setItem('lostAndFoundApp_v2_Items', JSON.stringify(initial));
+    return initial;
+  }
+
+  saveItems() {
+    localStorage.setItem(
+      'lostAndFoundApp_v2_Items',
+      JSON.stringify(this.items)
+    );
+    this.updateStats();
+    if (this.currentView === 'home') {
+      this.renderRecentListings();
+    } else if (this.currentView === 'browse') {
+      this.renderBrowseListings();
+    }
+  }
+
+  init() {
+    this.cacheDOM();
+    this.bindEvents();
+    this.initTheme();
+    this.updateStats();
+    this.renderRecentListings();
+
+    // Setup file upload previews
+    this.setupImageUpload('lost');
+    this.setupImageUpload('found');
+
+    // FIX: Set max date to today for lost and found date fields
+    this.setMaxDates();
+  }
+
+  // FIX: New method to restrict future dates
+  setMaxDates() {
+    const today = new Date().toISOString().split('T')[0];
+    const lostDate = document.getElementById('lost-date');
+    const foundDate = document.getElementById('found-date');
+    if (lostDate) lostDate.setAttribute('max', today);
+    if (foundDate) foundDate.setAttribute('max', today);
+  }
+
+  cacheDOM() {
+    this.navBtns = document.querySelectorAll('.nav-btn');
+    this.mobileMenuBtn = document.querySelector('.mobile-menu-btn');
+    this.mobileMenu = document.querySelector('.mobile-menu');
+    this.themeToggle = document.getElementById('theme-toggle');
+    this.views = document.querySelectorAll('.view-section');
+    // Toast
+    this.toast = document.getElementById('toast');
+    this.toastCloseBtn = document.querySelector('.toast-close');
+    // Forms
+    this.reportLostForm = document.getElementById('report-lost-form');
+    this.reportFoundForm = document.getElementById('report-found-form');
+
+    // Search & Filters
+    this.searchInput = document.getElementById('search-input');
+    this.typeFilter = document.getElementById('type-filter');
+    this.categoryFilter = document.getElementById('category-filter');
+
+    // Grids
+    this.homeRecentGrid = document.getElementById('home-recent-listings');
+    this.browseGrid = document.getElementById('browse-listings');
+    this.emptyState = document.getElementById('empty-state');
+    this.detailsContent = document.getElementById('item-details-content');
+
+    // Toast
+    this.toast = document.getElementById('toast');
+  }
+
+  bindEvents() {
+    // Navigation
+    this.navBtns.forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        const view = e.target.getAttribute('data-view');
+        if (view) this.switchView(view);
+        this.mobileMenu.classList.add('hidden');
+      });
+    });
+
+    // Toast close button
+    if (this.toastCloseBtn) {
+      this.toastCloseBtn.addEventListener('click', () => {
+        this.hideToast();
+      });
     }
 
-    // Initial Data
-    getInitialData() {
-        return [];
+    // Mobile Menu
+    this.mobileMenuBtn.addEventListener('click', () => {
+      this.mobileMenu.classList.toggle('hidden');
+    });
+
+    // Theme Toggle
+    this.themeToggle.addEventListener('click', () => this.toggleTheme());
+
+    // Forms
+    if (this.reportLostForm) {
+      this.reportLostForm.addEventListener('submit', (e) =>
+        this.handleReportSubmit(e, 'lost')
+      );
+    }
+    if (this.reportFoundForm) {
+      this.reportFoundForm.addEventListener('submit', (e) =>
+        this.handleReportSubmit(e, 'found')
+      );
     }
 
-    loadItems() {
-        const stored = localStorage.getItem('lostAndFoundApp_v2_Items');
-        if (stored) {
-            return JSON.parse(stored);
-        }
-        const initial = this.getInitialData();
-        localStorage.setItem('lostAndFoundApp_v2_Items', JSON.stringify(initial));
-        return initial;
+    // Filters
+    if (this.searchInput) {
+      this.searchInput.addEventListener('input', () =>
+        this.renderBrowseListings()
+      );
+    }
+    if (this.typeFilter) {
+      this.typeFilter.addEventListener('change', () =>
+        this.renderBrowseListings()
+      );
+    }
+    if (this.categoryFilter) {
+      this.categoryFilter.addEventListener('change', () =>
+        this.renderBrowseListings()
+      );
+    }
+  }
+
+  initTheme() {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'dark') {
+      document.body.setAttribute('data-theme', 'dark');
+      this.themeToggle.innerHTML = '<i class="ph ph-sun"></i>';
+    }
+  }
+
+  toggleTheme() {
+    const isDark = document.body.getAttribute('data-theme') === 'dark';
+    if (isDark) {
+      document.body.removeAttribute('data-theme');
+      localStorage.setItem('theme', 'light');
+      this.themeToggle.innerHTML = '<i class="ph ph-moon"></i>';
+    } else {
+      document.body.setAttribute('data-theme', 'dark');
+      localStorage.setItem('theme', 'dark');
+      this.themeToggle.innerHTML = '<i class="ph ph-sun"></i>';
+    }
+  }
+
+  switchView(viewId) {
+    this.views.forEach((view) => {
+      view.classList.add('hidden');
+      view.classList.remove('active');
+    });
+
+    const targetView = document.getElementById(`view-${viewId}`);
+    if (targetView) {
+      targetView.classList.remove('hidden');
+      void targetView.offsetWidth;
+      targetView.classList.add('active');
     }
 
-    saveItems() {
-        localStorage.setItem('lostAndFoundApp_v2_Items', JSON.stringify(this.items));
-        this.updateStats();
-        if (this.currentView === 'home') {
-            this.renderRecentListings();
-        } else if (this.currentView === 'browse') {
-            this.renderBrowseListings();
-        }
+    this.navBtns.forEach((btn) => {
+      if (btn.getAttribute('data-view') === viewId) {
+        btn.classList.add('active');
+      } else {
+        btn.classList.remove('active');
+      }
+    });
+
+    this.currentView = viewId;
+
+    if (viewId === 'home') {
+      this.updateStats();
+      this.renderRecentListings();
+    } else if (viewId === 'browse') {
+      this.renderBrowseListings();
     }
 
-    init() {
-        this.cacheDOM();
-        this.bindEvents();
-        this.initTheme();
-        this.updateStats();
-        this.renderRecentListings();
-        
-        // Setup file upload previews
-        this.setupImageUpload('lost');
-        this.setupImageUpload('found');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
 
-        // FIX: Set max date to today for lost and found date fields
-        this.setMaxDates();
+  updateStats() {
+    // Total historical reports
+    const lostCount = this.items.filter((item) => item.type === 'lost').length;
+    const foundCount = this.items.filter(
+      (item) => item.type === 'found'
+    ).length;
+
+    // Calculate all items successfully resolved (both lost items recovered & found items returned)
+    const reunitedCount = this.items.filter(
+      (item) =>
+        item.reunionStatus === 'reunited' ||
+        item.status === 'reunited' ||
+        item.reunited === true
+    ).length;
+
+    // Never found: Lost items that have NOT been successfully reunited
+    const neverFoundCount = this.items.filter(
+      (item) =>
+        item.type === 'lost' &&
+        item.reunionStatus !== 'reunited' &&
+        item.status !== 'reunited' &&
+        item.reunited !== true
+    ).length;
+
+    const statLost = document.getElementById('stat-lost');
+    const statFound = document.getElementById('stat-found');
+    const statReunited = document.getElementById('stat-reunited');
+    const statNeverFound = document.getElementById('stat-never-found');
+
+    if (statLost) statLost.textContent = lostCount;
+    if (statFound) statFound.textContent = foundCount;
+    if (statReunited) statReunited.textContent = reunitedCount;
+    if (statNeverFound) statNeverFound.textContent = neverFoundCount;
+  }
+
+  setupImageUpload(type) {
+    const dropArea = document.getElementById(`${type}-drop-area`);
+    const fileInput = document.getElementById(`${type}-image`);
+    const previewContainer = document.getElementById(`${type}-image-preview`);
+    const previewImg = document.getElementById(`${type}-preview-img`);
+    const removeBtn = previewContainer?.querySelector('.remove-image-btn');
+
+    if (!dropArea || !fileInput) return;
+
+    ['dragenter', 'dragover', 'dragleave', 'drop'].forEach((eventName) => {
+      dropArea.addEventListener(eventName, preventDefaults, false);
+    });
+
+    function preventDefaults(e) {
+      e.preventDefault();
+      e.stopPropagation();
     }
 
-    // FIX: New method to restrict future dates
-    setMaxDates() {
-        const today = new Date().toISOString().split('T')[0];
-        const lostDate = document.getElementById('lost-date');
-        const foundDate = document.getElementById('found-date');
-        if (lostDate) lostDate.setAttribute('max', today);
-        if (foundDate) foundDate.setAttribute('max', today);
-    }
+    ['dragenter', 'dragover'].forEach((eventName) => {
+      dropArea.addEventListener(
+        eventName,
+        () => dropArea.classList.add('dragover'),
+        false
+      );
+    });
 
-    cacheDOM() {
-        this.navBtns = document.querySelectorAll('.nav-btn');
-        this.mobileMenuBtn = document.querySelector('.mobile-menu-btn');
-        this.mobileMenu = document.querySelector('.mobile-menu');
-        this.themeToggle = document.getElementById('theme-toggle');
-        this.views = document.querySelectorAll('.view-section');
-        
-        // Forms
-        this.reportLostForm = document.getElementById('report-lost-form');
-        this.reportFoundForm = document.getElementById('report-found-form');
-        
-        // Search & Filters
-        this.searchInput = document.getElementById('search-input');
-        this.typeFilter = document.getElementById('type-filter');
-        this.categoryFilter = document.getElementById('category-filter');
-        
-        // Grids
-        this.homeRecentGrid = document.getElementById('home-recent-listings');
-        this.browseGrid = document.getElementById('browse-listings');
-        this.emptyState = document.getElementById('empty-state');
-        this.detailsContent = document.getElementById('item-details-content');
-        
-        // Toast
-        this.toast = document.getElementById('toast');
-    }
+    ['dragleave', 'drop'].forEach((eventName) => {
+      dropArea.addEventListener(
+        eventName,
+        () => dropArea.classList.remove('dragover'),
+        false
+      );
+    });
 
-    bindEvents() {
-        // Navigation
-        this.navBtns.forEach(btn => {
-            btn.addEventListener('click', (e) => {
-                const view = e.target.getAttribute('data-view');
-                if (view) this.switchView(view);
-                this.mobileMenu.classList.add('hidden');
-            });
-        });
+    dropArea.addEventListener('drop', (e) => {
+      let dt = e.dataTransfer;
+      let files = dt.files;
+      fileInput.files = files;
+      handleFiles(files);
+    });
 
-        // Mobile Menu
-        this.mobileMenuBtn.addEventListener('click', () => {
-            this.mobileMenu.classList.toggle('hidden');
-        });
+    fileInput.addEventListener('change', function () {
+      handleFiles(this.files);
+    });
 
-        // Theme Toggle
-        this.themeToggle.addEventListener('click', () => this.toggleTheme());
+    const handleFiles = (files) => {
+      if (files && files[0]) {
+        const file = files[0];
+        if (!file.type.startsWith('image/')) return;
 
-        // Forms
-        if(this.reportLostForm) {
-            this.reportLostForm.addEventListener('submit', (e) => this.handleReportSubmit(e, 'lost'));
-        }
-        if(this.reportFoundForm) {
-            this.reportFoundForm.addEventListener('submit', (e) => this.handleReportSubmit(e, 'found'));
-        }
-
-        // Filters
-        if(this.searchInput) {
-            this.searchInput.addEventListener('input', () => this.renderBrowseListings());
-        }
-        if(this.typeFilter) {
-            this.typeFilter.addEventListener('change', () => this.renderBrowseListings());
-        }
-        if(this.categoryFilter) {
-            this.categoryFilter.addEventListener('change', () => this.renderBrowseListings());
-        }
-    }
-
-    initTheme() {
-        const storedTheme = localStorage.getItem('theme');
-        if (storedTheme === 'dark') {
-            document.body.setAttribute('data-theme', 'dark');
-            this.themeToggle.innerHTML = '<i class="ph ph-sun"></i>';
-        }
-    }
-
-    toggleTheme() {
-        const isDark = document.body.getAttribute('data-theme') === 'dark';
-        if (isDark) {
-            document.body.removeAttribute('data-theme');
-            localStorage.setItem('theme', 'light');
-            this.themeToggle.innerHTML = '<i class="ph ph-moon"></i>';
-        } else {
-            document.body.setAttribute('data-theme', 'dark');
-            localStorage.setItem('theme', 'dark');
-            this.themeToggle.innerHTML = '<i class="ph ph-sun"></i>';
-        }
-    }
-
-    switchView(viewId) {
-        this.views.forEach(view => {
-            view.classList.add('hidden');
-            view.classList.remove('active');
-        });
-        
-        const targetView = document.getElementById(`view-${viewId}`);
-        if (targetView) {
-            targetView.classList.remove('hidden');
-            void targetView.offsetWidth; 
-            targetView.classList.add('active');
-        }
-
-        this.navBtns.forEach(btn => {
-            if (btn.getAttribute('data-view') === viewId) {
-                btn.classList.add('active');
-            } else {
-                btn.classList.remove('active');
-            }
-        });
-
-        this.currentView = viewId;
-
-        if (viewId === 'home') {
-            this.updateStats();
-            this.renderRecentListings();
-        } else if (viewId === 'browse') {
-            this.renderBrowseListings();
-        }
-        
-        window.scrollTo({ top: 0, behavior: 'smooth' });
-    }
-
-    updateStats() {
-        // Total historical reports
-        const lostCount = this.items.filter(item => item.type === 'lost').length;
-        const foundCount = this.items.filter(item => item.type === 'found').length;
-
-        // Calculate all items successfully resolved (both lost items recovered & found items returned)
-        const reunitedCount = this.items.filter(item => 
-            item.reunionStatus === 'reunited' ||
-            item.status === 'reunited' ||
-            item.reunited === true
-        ).length;
-
-        // Never found: Lost items that have NOT been successfully reunited
-        const neverFoundCount = this.items.filter(item => 
-            item.type === 'lost' && 
-            item.reunionStatus !== 'reunited' &&
-            item.status !== 'reunited' &&
-            item.reunited !== true
-        ).length;
-
-        const statLost = document.getElementById('stat-lost');
-        const statFound = document.getElementById('stat-found');
-        const statReunited = document.getElementById('stat-reunited');
-        const statNeverFound = document.getElementById('stat-never-found');
-
-        if (statLost) statLost.textContent = lostCount;
-        if (statFound) statFound.textContent = foundCount;
-        if (statReunited) statReunited.textContent = reunitedCount;
-        if (statNeverFound) statNeverFound.textContent = neverFoundCount;
-    }
-
-    setupImageUpload(type) {
-        const dropArea = document.getElementById(`${type}-drop-area`);
-        const fileInput = document.getElementById(`${type}-image`);
-        const previewContainer = document.getElementById(`${type}-image-preview`);
-        const previewImg = document.getElementById(`${type}-preview-img`);
-        const removeBtn = previewContainer?.querySelector('.remove-image-btn');
-
-        if (!dropArea || !fileInput) return;
-
-        ['dragenter', 'dragover', 'dragleave', 'drop'].forEach(eventName => {
-            dropArea.addEventListener(eventName, preventDefaults, false);
-        });
-
-        function preventDefaults(e) {
-            e.preventDefault();
-            e.stopPropagation();
-        }
-
-        ['dragenter', 'dragover'].forEach(eventName => {
-            dropArea.addEventListener(eventName, () => dropArea.classList.add('dragover'), false);
-        });
-
-        ['dragleave', 'drop'].forEach(eventName => {
-            dropArea.addEventListener(eventName, () => dropArea.classList.remove('dragover'), false);
-        });
-
-        dropArea.addEventListener('drop', (e) => {
-            let dt = e.dataTransfer;
-            let files = dt.files;
-            fileInput.files = files;
-            handleFiles(files);
-        });
-
-        fileInput.addEventListener('change', function() {
-            handleFiles(this.files);
-        });
-
-        const handleFiles = (files) => {
-            if (files && files[0]) {
-                const file = files[0];
-                if (!file.type.startsWith('image/')) return;
-
-                const reader = new FileReader();
-                reader.onload = (e) => {
-                    previewImg.src = e.target.result;
-                    previewContainer.classList.remove('hidden');
-                    dropArea.classList.add('hidden');
-                };
-                reader.readAsDataURL(file);
-            }
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          previewImg.src = e.target.result;
+          previewContainer.classList.remove('hidden');
+          dropArea.classList.add('hidden');
         };
+        reader.readAsDataURL(file);
+      }
+    };
 
-        if (removeBtn) {
-            removeBtn.addEventListener('click', () => {
-                fileInput.value = '';
-                previewImg.src = '';
-                previewContainer.classList.add('hidden');
-                dropArea.classList.remove('hidden');
-            });
-        }
+    if (removeBtn) {
+      removeBtn.addEventListener('click', () => {
+        fileInput.value = '';
+        previewImg.src = '';
+        previewContainer.classList.add('hidden');
+        dropArea.classList.remove('hidden');
+      });
+    }
+  }
+
+  handleReportSubmit(e, type) {
+    e.preventDefault();
+
+    // FIX: Validate that date is not in the future
+    const dateInput = document.getElementById(`${type}-date`);
+    const selectedDate = new Date(dateInput.value);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (selectedDate > today) {
+      this.showToast('Invalid Date', 'The date lost cannot be in the future.');
+      return;
     }
 
-    handleReportSubmit(e, type) {
-        e.preventDefault();
+    const contactInput = document
+      .getElementById(`${type}-contact`)
+      .value.trim();
 
-        // FIX: Validate that date is not in the future
-        const dateInput = document.getElementById(`${type}-date`);
-        const selectedDate = new Date(dateInput.value);
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-        if (selectedDate > today) {
-            this.showToast('Invalid Date', 'The date lost cannot be in the future.');
-            return;
-        }
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    const phoneRegex = /^[0-9]{10}$/;
 
-        const contactInput = document.getElementById(`${type}-contact`).value.trim();
-        
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        const phoneRegex = /^[0-9]{10}$/;
+    const isValidEmail = emailRegex.test(contactInput);
+    const isValidPhone = phoneRegex.test(contactInput);
 
-        const isValidEmail = emailRegex.test(contactInput);
-        const isValidPhone = phoneRegex.test(contactInput);
-
-        if (!isValidEmail && !isValidPhone) {
-            this.showToast('Invalid Contact Info', 'Please enter a valid 10-digit phone number or a proper email address.');
-            return;
-        }
-        
-        const previewImg = document.getElementById(`${type}-preview-img`);
-        const imageSrc = previewImg.src && !previewImg.src.includes(window.location.host) ? previewImg.src : null;
-        
-        const defaultImage = '';
-
-        const newItem = {
-            id: Date.now().toString(),
-            type: type,
-            name: document.getElementById(`${type}-item-name`).value,
-            category: document.getElementById(`${type}-category`).value,
-            date: document.getElementById(`${type}-date`).value,
-            location: document.getElementById(`${type}-location`).value,
-            description: document.getElementById(`${type}-description`).value,
-            contact: document.getElementById(`${type}-contact`).value,
-            image: imageSrc || defaultImage,
-            reportedAt: new Date().toISOString(),
-            status: 'active'
-        };
-
-        this.items.unshift(newItem);
-        this.saveItems();
-
-        e.target.reset();
-        
-        const fileInput = document.getElementById(`${type}-image`);
-        const previewContainer = document.getElementById(`${type}-image-preview`);
-        const dropArea = document.getElementById(`${type}-drop-area`);
-        
-        if(fileInput) fileInput.value = '';
-        if(previewImg) previewImg.src = '';
-        if(previewContainer) previewContainer.classList.add('hidden');
-        if(dropArea) dropArea.classList.remove('hidden');
-
-        // FIX: Reset max date after form reset
-        this.setMaxDates();
-
-        this.showToast('Success', `Your ${type} item report has been submitted.`);
-        this.switchView('browse');
+    if (!isValidEmail && !isValidPhone) {
+      this.showToast(
+        'Invalid Contact Info',
+        'Please enter a valid 10-digit phone number or a proper email address.'
+      );
+      return;
     }
 
-    createListingCard(item) {
-        const card = document.createElement('div');
-        card.className = 'listing-card glass hover-effect';
-        
-        const dateObj = new Date(item.date);
-        const formattedDate = dateObj.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-        
-        const placeholderSvg = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='240' viewBox='0 0 400 240'%3E%3Crect width='400' height='240' fill='%23e2e8f0'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%2394a3b8' font-family='sans-serif' font-size='16px'%3ENo Image%3C/text%3E%3C/svg%3E";
-        
-        card.innerHTML = `
+    const previewImg = document.getElementById(`${type}-preview-img`);
+    const imageSrc =
+      previewImg.src && !previewImg.src.includes(window.location.host)
+        ? previewImg.src
+        : null;
+
+    const defaultImage = '';
+
+    const newItem = {
+      id: Date.now().toString(),
+      type: type,
+      name: document.getElementById(`${type}-item-name`).value,
+      category: document.getElementById(`${type}-category`).value,
+      date: document.getElementById(`${type}-date`).value,
+      location: document.getElementById(`${type}-location`).value,
+      description: document.getElementById(`${type}-description`).value,
+      contact: document.getElementById(`${type}-contact`).value,
+      image: imageSrc || defaultImage,
+      reportedAt: new Date().toISOString(),
+      status: 'active',
+    };
+
+    this.items.unshift(newItem);
+    this.saveItems();
+
+    e.target.reset();
+
+    const fileInput = document.getElementById(`${type}-image`);
+    const previewContainer = document.getElementById(`${type}-image-preview`);
+    const dropArea = document.getElementById(`${type}-drop-area`);
+
+    if (fileInput) fileInput.value = '';
+    if (previewImg) previewImg.src = '';
+    if (previewContainer) previewContainer.classList.add('hidden');
+    if (dropArea) dropArea.classList.remove('hidden');
+
+    // FIX: Reset max date after form reset
+    this.setMaxDates();
+
+    this.showToast('Success', `Your ${type} item report has been submitted.`);
+    this.switchView('browse');
+  }
+
+  createListingCard(item) {
+    const card = document.createElement('div');
+    card.className = 'listing-card glass hover-effect';
+
+    const dateObj = new Date(item.date);
+    const formattedDate = dateObj.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+
+    const placeholderSvg =
+      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='240' viewBox='0 0 400 240'%3E%3Crect width='400' height='240' fill='%23e2e8f0'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%2394a3b8' font-family='sans-serif' font-size='16px'%3ENo Image%3C/text%3E%3C/svg%3E";
+
+    card.innerHTML = `
             <div class="listing-img-wrapper">
                 <img src="${item.image || placeholderSvg}" alt="${item.name}" class="listing-img" onerror="this.onerror=null; this.src='${placeholderSvg}'">
                 <span class="listing-badge badge-${item.type}">${item.type.toUpperCase()}</span>
@@ -364,73 +421,82 @@ class LostAndFoundApp {
                 </div>
             </div>
         `;
-        return card;
+    return card;
+  }
+
+  renderRecentListings() {
+    if (!this.homeRecentGrid) return;
+
+    this.homeRecentGrid.innerHTML = '';
+    // Filter out reunited items so they do not clutter the active feed
+    const recentItems = this.items
+      .filter((item) => item.status !== 'reunited')
+      .slice(0, 3);
+
+    recentItems.forEach((item) => {
+      this.homeRecentGrid.appendChild(this.createListingCard(item));
+    });
+  }
+
+  renderBrowseListings() {
+    if (!this.browseGrid) return;
+
+    const searchTerm = this.searchInput.value.toLowerCase();
+    const typeFilter = this.typeFilter.value;
+    const categoryFilter = this.categoryFilter.value;
+
+    let filteredItems = this.items.filter((item) => {
+      const matchesSearch =
+        item.name.toLowerCase().includes(searchTerm) ||
+        item.description.toLowerCase().includes(searchTerm) ||
+        item.location.toLowerCase().includes(searchTerm);
+      const matchesType = typeFilter === 'all' || item.type === typeFilter;
+      const matchesCategory =
+        categoryFilter === 'all' || item.category === categoryFilter;
+      // Ensure we only show active items
+      const isActive = item.status !== 'reunited';
+
+      return matchesSearch && matchesType && matchesCategory && isActive;
+    });
+
+    this.browseGrid.innerHTML = '';
+
+    if (filteredItems.length === 0) {
+      this.emptyState.classList.remove('hidden');
+      this.browseGrid.classList.add('hidden');
+    } else {
+      this.emptyState.classList.add('hidden');
+      this.browseGrid.classList.remove('hidden');
+
+      filteredItems.forEach((item) => {
+        this.browseGrid.appendChild(this.createListingCard(item));
+      });
     }
+  }
 
-    renderRecentListings() {
-        if (!this.homeRecentGrid) return;
-        
-        this.homeRecentGrid.innerHTML = '';
-        // Filter out reunited items so they do not clutter the active feed
-        const recentItems = this.items.filter(item => item.status !== 'reunited').slice(0, 3);
-        
-        recentItems.forEach(item => {
-            this.homeRecentGrid.appendChild(this.createListingCard(item));
-        });
-    }
+  resetFilters() {
+    this.searchInput.value = '';
+    this.typeFilter.value = 'all';
+    this.categoryFilter.value = 'all';
+    this.renderBrowseListings();
+  }
 
-    renderBrowseListings() {
-        if (!this.browseGrid) return;
+  viewItemDetails(id) {
+    const item = this.items.find((i) => i.id === id);
+    if (!item) return;
 
-        const searchTerm = this.searchInput.value.toLowerCase();
-        const typeFilter = this.typeFilter.value;
-        const categoryFilter = this.categoryFilter.value;
+    const dateObj = new Date(item.date);
+    const formattedDate = dateObj.toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
+    const reportedDate = new Date(item.reportedAt).toLocaleDateString('en-US');
 
-        let filteredItems = this.items.filter(item => {
-            const matchesSearch = item.name.toLowerCase().includes(searchTerm) || 
-                                item.description.toLowerCase().includes(searchTerm) ||
-                                item.location.toLowerCase().includes(searchTerm);
-            const matchesType = typeFilter === 'all' || item.type === typeFilter;
-            const matchesCategory = categoryFilter === 'all' || item.category === categoryFilter;
-            // Ensure we only show active items
-            const isActive = item.status !== 'reunited';
-            
-            return matchesSearch && matchesType && matchesCategory && isActive;
-        });
+    const placeholderSvg =
+      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='400' viewBox='0 0 600 400'%3E%3Crect width='600' height='400' fill='%23e2e8f0'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%2394a3b8' font-family='sans-serif' font-size='20px'%3ENo Image%3C/text%3E%3C/svg%3E";
 
-        this.browseGrid.innerHTML = '';
-
-        if (filteredItems.length === 0) {
-            this.emptyState.classList.remove('hidden');
-            this.browseGrid.classList.add('hidden');
-        } else {
-            this.emptyState.classList.add('hidden');
-            this.browseGrid.classList.remove('hidden');
-            
-            filteredItems.forEach(item => {
-                this.browseGrid.appendChild(this.createListingCard(item));
-            });
-        }
-    }
-
-    resetFilters() {
-        this.searchInput.value = '';
-        this.typeFilter.value = 'all';
-        this.categoryFilter.value = 'all';
-        this.renderBrowseListings();
-    }
-
-    viewItemDetails(id) {
-        const item = this.items.find(i => i.id === id);
-        if (!item) return;
-
-        const dateObj = new Date(item.date);
-        const formattedDate = dateObj.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
-        const reportedDate = new Date(item.reportedAt).toLocaleDateString('en-US');
-
-        const placeholderSvg = "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='400' viewBox='0 0 600 400'%3E%3Crect width='600' height='400' fill='%23e2e8f0'/%3E%3Ctext x='50%25' y='50%25' dominant-baseline='middle' text-anchor='middle' fill='%2394a3b8' font-family='sans-serif' font-size='20px'%3ENo Image%3C/text%3E%3C/svg%3E";
-
-        this.detailsContent.innerHTML = `
+    this.detailsContent.innerHTML = `
             <div class="details-img-container">
                 <img src="${item.image || placeholderSvg}" alt="${item.name}" class="details-img" onerror="this.onerror=null; this.src='${placeholderSvg}'">
             </div>
@@ -481,65 +547,73 @@ class LostAndFoundApp {
                     <a href="mailto:${item.contact.includes('@') ? item.contact : ''}" class="btn btn-primary btn-full">
                         <i class="ph ph-envelope-simple"></i> Contact Reporter
                     </a>
-                    ${item.status !== 'reunited' ? `
+                    ${
+                      item.status !== 'reunited'
+                        ? `
                         <button class="btn btn-secondary btn-full" onclick="window.app.markAsReunited('${item.id}')">
                             <i class="ph ph-handshake"></i> Mark as Reunited
                         </button>
-                    ` : `
+                    `
+                        : `
                         <div class="btn btn-secondary btn-full" style="opacity: 0.7; cursor: default; border-color: var(--secondary); color: var(--secondary);">
                             <i class="ph ph-check-circle"></i> Item Reunited
                         </div>
-                    `}
+                    `
+                    }
                 </div>
             </div>
         `;
 
-        this.switchView('details');
-    }
+    this.switchView('details');
+  }
 
-    /**
-     * Marks an item as reunited and updates the global application state
-     * @param {string} id - The unique identifier of the item
-     */
-    markAsReunited(id) {
-        try {
-            const itemIndex = this.items.findIndex(item => item.id === id);
-            
-            if (itemIndex !== -1) {
-                // Update the status payload
-                this.items[itemIndex].status = 'reunited';
-                
-                // saveItems() automatically calls updateStats() internally,
-                // which will now trigger the new math added in the main branch
-                this.saveItems(); 
-                
-                // Navigate back to the browse view
-                this.switchView('browse');
-                this.showToast('Success', 'Item has been marked as reunited!');
-            } else {
-                console.warn(`Item with id ${id} not found in local storage.`);
-            }
-        } catch (error) {
-            console.error('Failed to mark item as reunited:', error);
-            this.showToast('Error', 'Failed to update item status. Please try again.');
-        }
-    }
+  /**
+   * Marks an item as reunited and updates the global application state
+   * @param {string} id - The unique identifier of the item
+   */
+  markAsReunited(id) {
+    try {
+      const itemIndex = this.items.findIndex((item) => item.id === id);
 
-    showToast(title, message) {
-        document.getElementById('toast-title').textContent = title;
-        document.getElementById('toast-message').textContent = message;
-        
-        this.toast.classList.remove('hidden');
-        this.toast.classList.remove('fade-out');
-        
-        setTimeout(() => {
-            this.toast.classList.add('fade-out');
-            setTimeout(() => this.toast.classList.add('hidden'), 300);
-        }, 3000);
+      if (itemIndex !== -1) {
+        // Update the status payload
+        this.items[itemIndex].status = 'reunited';
+
+        // saveItems() automatically calls updateStats() internally,
+        // which will now trigger the new math added in the main branch
+        this.saveItems();
+
+        // Navigate back to the browse view
+        this.switchView('browse');
+        this.showToast('Success', 'Item has been marked as reunited!');
+      } else {
+        console.warn(`Item with id ${id} not found in local storage.`);
+      }
+    } catch (error) {
+      console.error('Failed to mark item as reunited:', error);
+      this.showToast(
+        'Error',
+        'Failed to update item status. Please try again.'
+      );
     }
+  }
+
+  showToast(title, message) {
+    document.getElementById('toast-title').textContent = title;
+    document.getElementById('toast-message').textContent = message;
+
+    this.toast.classList.remove('hidden');
+    this.toast.classList.remove('fade-out');
+
+    clearTimeout(this.toastTimer);
+
+    this.toastTimer = setTimeout(() => {
+      this.hideToast();
+    }, 3000);
+  }
 }
 
 // Initialize Application
 document.addEventListener('DOMContentLoaded', () => {
-    window.app = new LostAndFoundApp();
+  window.app = new LostAndFoundApp();
 });

--- a/public/Lost_And_Found_Portal/style.css
+++ b/public/Lost_And_Found_Portal/style.css
@@ -1,1051 +1,1143 @@
 :root {
-    /* Light Theme - Premium Soft */
-    --bg-color: #fafafa;
-    --text-primary: #111827;
-    --text-secondary: #4b5563;
-    --text-muted: #9ca3af;
-    --glass-bg: rgba(255, 255, 255, 0.7);
-    --glass-border: rgba(255, 255, 255, 0.4);
-    --primary: #4f46e5;
-    --primary-hover: #4338ca;
-    --primary-light: rgba(79, 70, 229, 0.1);
-    --secondary: #10b981;
-    --secondary-hover: #059669;
-    --secondary-light: rgba(16, 185, 129, 0.1);
-    --accent: #ec4899;
-    --surface: #ffffff;
-    --border: #e5e7eb;
-    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
-    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
-    --shadow-glass: 0 8px 32px 0 rgba(31, 38, 135, 0.05);
-    --radius-sm: 8px;
-    --radius-md: 12px;
-    --radius-lg: 20px;
-    --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  /* Light Theme - Premium Soft */
+  --bg-color: #fafafa;
+  --text-primary: #111827;
+  --text-secondary: #4b5563;
+  --text-muted: #9ca3af;
+  --glass-bg: rgba(255, 255, 255, 0.7);
+  --glass-border: rgba(255, 255, 255, 0.4);
+  --primary: #4f46e5;
+  --primary-hover: #4338ca;
+  --primary-light: rgba(79, 70, 229, 0.1);
+  --secondary: #10b981;
+  --secondary-hover: #059669;
+  --secondary-light: rgba(16, 185, 129, 0.1);
+  --accent: #ec4899;
+  --surface: #ffffff;
+  --border: #e5e7eb;
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+  --shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  --shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
+  --shadow-glass: 0 8px 32px 0 rgba(31, 38, 135, 0.05);
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+  --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-[data-theme="dark"] {
-    /* Dark Theme - Sleek Modern */
-    --bg-color: #0f172a;
-    --text-primary: #f8fafc;
-    --text-secondary: #cbd5e1;
-    --text-muted: #64748b;
-    --glass-bg: rgba(30, 41, 59, 0.7);
-    --glass-border: rgba(255, 255, 255, 0.08);
-    --primary: #818cf8;
-    --primary-hover: #6366f1;
-    --primary-light: rgba(129, 140, 248, 0.15);
-    --secondary: #34d399;
-    --secondary-hover: #10b981;
-    --secondary-light: rgba(52, 211, 153, 0.15);
-    --accent: #f472b6;
-    --surface: #1e293b;
-    --border: #334155;
-    --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
-    --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
-    --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.2);
-    --shadow-glass: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+[data-theme='dark'] {
+  /* Dark Theme - Sleek Modern */
+  --bg-color: #0f172a;
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5e1;
+  --text-muted: #64748b;
+  --glass-bg: rgba(30, 41, 59, 0.7);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --primary: #818cf8;
+  --primary-hover: #6366f1;
+  --primary-light: rgba(129, 140, 248, 0.15);
+  --secondary: #34d399;
+  --secondary-hover: #10b981;
+  --secondary-light: rgba(52, 211, 153, 0.15);
+  --accent: #f472b6;
+  --surface: #1e293b;
+  --border: #334155;
+  --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
+  --shadow-md:
+    0 4px 6px -1px rgba(0, 0, 0, 0.4), 0 2px 4px -1px rgba(0, 0, 0, 0.2);
+  --shadow-lg:
+    0 10px 15px -3px rgba(0, 0, 0, 0.4), 0 4px 6px -2px rgba(0, 0, 0, 0.2);
+  --shadow-glass: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
 }
 
 /* Base Styles */
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-    font-family: 'Outfit', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  font-family:
+    'Outfit',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
 }
 
 body {
-    background-color: var(--bg-color);
-    color: var(--text-primary);
-    min-height: 100vh;
-    overflow-x: hidden;
-    line-height: 1.6;
-    transition: background-color 0.4s ease, color 0.4s ease;
+  background-color: var(--bg-color);
+  color: var(--text-primary);
+  min-height: 100vh;
+  overflow-x: hidden;
+  line-height: 1.6;
+  transition:
+    background-color 0.4s ease,
+    color 0.4s ease;
 }
 
-h1, h2, h3, h4, h5, h6 {
-    font-weight: 700;
-    line-height: 1.2;
-    color: var(--text-primary);
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--text-primary);
 }
 
 p {
-    color: var(--text-secondary);
+  color: var(--text-secondary);
 }
 
 a {
-    color: var(--primary);
-    text-decoration: none;
-    transition: var(--transition);
+  color: var(--primary);
+  text-decoration: none;
+  transition: var(--transition);
 }
 
 a:hover {
-    color: var(--primary-hover);
+  color: var(--primary-hover);
 }
 
 /* Background Mesh / Blobs */
 .background-elements {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    z-index: -1;
-    overflow: hidden;
-    pointer-events: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: -1;
+  overflow: hidden;
+  pointer-events: none;
 }
 
 .blob {
-    position: absolute;
-    border-radius: 50%;
-    filter: blur(100px);
-    opacity: 0.4;
-    animation: float 20s infinite alternate cubic-bezier(0.4, 0, 0.2, 1);
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(100px);
+  opacity: 0.4;
+  animation: float 20s infinite alternate cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-[data-theme="dark"] .blob {
-    opacity: 0.15;
+[data-theme='dark'] .blob {
+  opacity: 0.15;
 }
 
 .blob-1 {
-    top: -10%;
-    left: -10%;
-    width: 50vw;
-    height: 50vw;
-    background: var(--primary);
-    animation-delay: 0s;
+  top: -10%;
+  left: -10%;
+  width: 50vw;
+  height: 50vw;
+  background: var(--primary);
+  animation-delay: 0s;
 }
 
 .blob-2 {
-    bottom: -20%;
-    right: -10%;
-    width: 60vw;
-    height: 60vw;
-    background: var(--accent);
-    animation-delay: -5s;
-    animation-duration: 25s;
+  bottom: -20%;
+  right: -10%;
+  width: 60vw;
+  height: 60vw;
+  background: var(--accent);
+  animation-delay: -5s;
+  animation-duration: 25s;
 }
 
 .blob-3 {
-    top: 30%;
-    left: 40%;
-    width: 40vw;
-    height: 40vw;
-    background: var(--secondary);
-    animation-delay: -10s;
-    animation-duration: 15s;
+  top: 30%;
+  left: 40%;
+  width: 40vw;
+  height: 40vw;
+  background: var(--secondary);
+  animation-delay: -10s;
+  animation-duration: 15s;
 }
 
 @keyframes float {
-    0% { transform: translate(0, 0) scale(1) rotate(0deg); }
-    33% { transform: translate(5%, 5%) scale(1.1) rotate(10deg); }
-    66% { transform: translate(-5%, 10%) scale(0.9) rotate(-10deg); }
-    100% { transform: translate(10%, -5%) scale(1) rotate(5deg); }
+  0% {
+    transform: translate(0, 0) scale(1) rotate(0deg);
+  }
+  33% {
+    transform: translate(5%, 5%) scale(1.1) rotate(10deg);
+  }
+  66% {
+    transform: translate(-5%, 10%) scale(0.9) rotate(-10deg);
+  }
+  100% {
+    transform: translate(10%, -5%) scale(1) rotate(5deg);
+  }
 }
 
 /* Utilities */
 .glass {
-    background: var(--glass-bg);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
-    border: 1px solid var(--glass-border);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-glass);
+  background: var(--glass-bg);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-glass);
 }
 
 .text-gradient {
-    background: linear-gradient(135deg, var(--primary), var(--accent));
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
 }
 
 .hidden {
-    display: none !important;
+  display: none !important;
 }
 
 .fade-in {
-    animation: fadeIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  animation: fadeIn 0.5s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
 @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(15px); }
-    to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(15px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* Navigation */
 .navbar {
-    position: sticky;
-    top: 1rem;
-    margin: 0 auto;
-    width: calc(75% - 2rem);
-    max-width: 1200px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 1rem 1.5rem;
-    z-index: 100;
-    transition: var(--transition);
+  position: sticky;
+  top: 1rem;
+  margin: 0 auto;
+  width: calc(75% - 2rem);
+  max-width: 1200px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 1.5rem;
+  z-index: 100;
+  transition: var(--transition);
 }
 
 .nav-brand {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    font-size: 1.5rem;
-    font-weight: 700;
-    color: var(--primary);
-    cursor: pointer;
-    
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--primary);
+  cursor: pointer;
 }
 
 .nav-brand i {
-    font-size: 1.8rem;
-    background: linear-gradient(135deg, var(--primary), var(--accent));
-    background-clip: text;
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
+  font-size: 1.8rem;
+  background: linear-gradient(135deg, var(--primary), var(--accent));
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
 }
 
 .nav-links {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
 }
 
 .nav-btn {
-    background: transparent;
-    border: none;
-    color: var(--text-secondary);
-    font-size: 1rem;
-    font-weight: 500;
-    cursor: pointer;
-    padding: 0.5rem 1rem;
-    border-radius: var(--radius-md);
-    transition: var(--transition);
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  border-radius: var(--radius-md);
+  transition: var(--transition);
 }
 
 .nav-btn:hover {
-    color: var(--text-primary);
-    background: var(--surface);
-    box-shadow: var(--shadow-sm);
+  color: var(--text-primary);
+  background: var(--surface);
+  box-shadow: var(--shadow-sm);
 }
 
 .nav-btn.active {
-    color: var(--primary);
-    background: var(--primary-light);
-    font-weight: 600;
+  color: var(--primary);
+  background: var(--primary-light);
+  font-weight: 600;
 }
 
 .icon-btn {
-    background: transparent;
-    border: none;
-    color: var(--text-secondary);
-    font-size: 1.25rem;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 0.5rem;
-    border-radius: 50%;
-    transition: var(--transition);
-    margin-left: 0.5rem;
+  background: transparent;
+  border: none;
+  color: var(--text-secondary);
+  font-size: 1.25rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.5rem;
+  border-radius: 50%;
+  transition: var(--transition);
+  margin-left: 0.5rem;
 }
 
 .icon-btn:hover {
-    color: var(--primary);
-    background: var(--primary-light);
+  color: var(--primary);
+  background: var(--primary-light);
 }
 
 /* Mobile Menu */
 .mobile-menu-btn {
-    display: none;
-    font-size: 1.5rem;
-    color: var(--text-primary);
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    padding: 0.5rem;
+  display: none;
+  font-size: 1.5rem;
+  color: var(--text-primary);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.5rem;
 }
 
 .mobile-menu {
-    position: fixed;
-    top: 5rem;
-    left: 1rem;
-    right: 1rem;
-    display: flex; /* Changed from just missing display */
-    flex-direction: column;
-    padding: 1rem;
-    gap: 0.5rem;
-    z-index: 99;
+  position: fixed;
+  top: 5rem;
+  left: 1rem;
+  right: 1rem;
+  display: flex; /* Changed from just missing display */
+  flex-direction: column;
+  padding: 1rem;
+  gap: 0.5rem;
+  z-index: 99;
 }
 
 .mobile-menu.hidden {
-    display: none !important;
+  display: none !important;
 }
 
 .mobile-menu .nav-btn {
-    width: 100%;
-    text-align: left;
-    padding: 0.75rem 1rem;
+  width: 100%;
+  text-align: left;
+  padding: 0.75rem 1rem;
 }
 
 /* Main Content Area */
 .main-content {
-    max-width: 1200px;
-    margin: 2rem auto;
-    padding: 0 1rem;
-    min-height: calc(100vh - 12rem);
+  max-width: 1200px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  min-height: calc(100vh - 12rem);
 }
 
 .view-section {
-    display: none;
+  display: none;
 }
 
 .view-section.active {
-    display: block;
+  display: block;
 }
 
 /* Buttons */
 .btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0.5rem;
-    padding: 0.75rem 1.5rem;
-    border-radius: var(--radius-md);
-    font-weight: 600;
-    font-size: 1rem;
-    cursor: pointer;
-    border: 1px solid transparent;
-    transition: var(--transition);
-    text-align: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  border: 1px solid transparent;
+  transition: var(--transition);
+  text-align: center;
 }
 
 .btn i {
-    font-size: 1.2rem;
+  font-size: 1.2rem;
 }
 
 .btn-lg {
-    padding: 1rem 2rem;
-    font-size: 1.125rem;
+  padding: 1rem 2rem;
+  font-size: 1.125rem;
 }
 
 .btn-full {
-    width: 100%;
+  width: 100%;
 }
 
 .btn-primary {
-    background: var(--primary);
-    color: #ffffff;
-    box-shadow: 0 4px 6px rgba(79, 70, 229, 0.2);
+  background: var(--primary);
+  color: #ffffff;
+  box-shadow: 0 4px 6px rgba(79, 70, 229, 0.2);
 }
 
 .btn-primary:hover {
-    background: var(--primary-hover);
-    transform: translateY(-2px);
-    box-shadow: 0 6px 12px rgba(79, 70, 229, 0.3);
-    color: #ffffff;
+  background: var(--primary-hover);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 12px rgba(79, 70, 229, 0.3);
+  color: #ffffff;
 }
 
 .btn-secondary {
-    background: var(--surface);
-    color: var(--text-primary);
-    border-color: var(--border);
-    box-shadow: var(--shadow-sm);
+  background: var(--surface);
+  color: var(--text-primary);
+  border-color: var(--border);
+  box-shadow: var(--shadow-sm);
 }
 
 .btn-secondary:hover {
-    background: var(--bg-color);
-    border-color: var(--text-secondary);
-    transform: translateY(-2px);
+  background: var(--bg-color);
+  border-color: var(--text-secondary);
+  transform: translateY(-2px);
 }
 
 .btn-text {
-    background: transparent;
-    color: var(--primary);
-    padding: 0.5rem;
+  background: transparent;
+  color: var(--primary);
+  padding: 0.5rem;
 }
 
 .btn-text:hover {
-    color: var(--primary-hover);
-    gap: 0.75rem; /* For arrow animation */
+  color: var(--primary-hover);
+  gap: 0.75rem; /* For arrow animation */
 }
 
 /* Hero Section */
 .hero {
-    text-align: center;
-    padding: 5rem 1rem;
-    max-width: 800px;
-    margin: 0 auto;
+  text-align: center;
+  padding: 5rem 1rem;
+  max-width: 800px;
+  margin: 0 auto;
 }
 
 .hero h1 {
-    font-size: clamp(2.5rem, 5vw, 4.5rem);
-    letter-spacing: -0.02em;
-    margin-bottom: 1.5rem;
+  font-size: clamp(2.5rem, 5vw, 4.5rem);
+  letter-spacing: -0.02em;
+  margin-bottom: 1.5rem;
 }
 
 .hero p {
-    font-size: clamp(1.1rem, 2vw, 1.25rem);
-    margin-bottom: 2.5rem;
+  font-size: clamp(1.1rem, 2vw, 1.25rem);
+  margin-bottom: 2.5rem;
 }
 
 .hero-actions {
-    display: flex;
-    gap: 1rem;
-    justify-content: center;
-    flex-wrap: wrap;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 /* Stats */
 .stats-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1.5rem;
-    margin-bottom: 4rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 4rem;
 }
 
 .stat-card {
-    min-width: 0;
-    padding: 1.5rem;
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-    transition: var(--transition);
+  min-width: 0;
+  padding: 1.5rem;
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  transition: var(--transition);
 }
 
 .stat-card:hover {
-    transform: translateY(-4px);
-    box-shadow: var(--shadow-lg);
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-lg);
 }
 
 .stat-icon {
-    width: 4rem;
-    height: 4rem;
-    border-radius: var(--radius-md);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 2rem;
-    flex-shrink: 0;
+  width: 4rem;
+  height: 4rem;
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  flex-shrink: 0;
 }
 
-.lost-icon { 
-    background: rgba(239, 68, 68, 0.1); 
-    color: #ef4444; 
+.lost-icon {
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
 }
-.found-icon { 
-    background: rgba(16, 185, 129, 0.1); 
-    color: #10b981; 
+.found-icon {
+  background: rgba(16, 185, 129, 0.1);
+  color: #10b981;
 }
-.reunited-icon { 
-    background: rgba(236, 72, 153, 0.1); 
-    color: #ec4899; 
+.reunited-icon {
+  background: rgba(236, 72, 153, 0.1);
+  color: #ec4899;
 }
-.never-found-icon { 
-    background: rgba(168, 85, 247, 0.1); 
-    color: #a855f7; 
+.never-found-icon {
+  background: rgba(168, 85, 247, 0.1);
+  color: #a855f7;
 }
 
 .stat-info {
-    min-width: 0;
+  min-width: 0;
 }
 
 .stat-info h3 {
-    font-size: 0.875rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--text-muted);
-    margin-bottom: 0.25rem;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+  margin-bottom: 0.25rem;
 }
 
 .stat-number {
-    font-size: 2.25rem;
-    font-weight: 700;
-    color: var(--text-primary);
-    line-height: 1;
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1;
 }
 
 @media (max-width: 640px) {
-    .stat-card {
-        flex-direction: column;
-        text-align: center;
-        gap: 1rem;
-    }
+  .stat-card {
+    flex-direction: column;
+    text-align: center;
+    gap: 1rem;
+  }
 }
 
 /* Listings & Grids */
 .section-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-end;
-    margin-bottom: 2rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-bottom: 2rem;
 }
 
 .section-header h2 {
-    font-size: 2rem;
+  font-size: 2rem;
 }
 
 .listings-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-    gap: 2rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: 2rem;
 }
 
 .listing-card {
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
-    transition: var(--transition);
-    height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  transition: var(--transition);
+  height: 100%;
 }
 
 .listing-card:hover {
-    transform: translateY(-6px);
-    box-shadow: var(--shadow-lg);
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-lg);
 }
 
 .listing-img-wrapper {
-    position: relative;
-    width: 100%;
-    padding-top: 60%; /* 5:3 Aspect Ratio */
-    overflow: hidden;
+  position: relative;
+  width: 100%;
+  padding-top: 60%; /* 5:3 Aspect Ratio */
+  overflow: hidden;
 }
 
 .listing-img {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    transition: transform 0.5s ease;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.5s ease;
 }
 
 .listing-card:hover .listing-img {
-    transform: scale(1.05);
+  transform: scale(1.05);
 }
 
 .listing-badge {
-    position: absolute;
-    top: 1rem;
-    left: 1rem;
-    padding: 0.25rem 0.75rem;
-    border-radius: 9999px;
-    font-size: 0.75rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
 }
 
 .badge-lost {
-    background: rgba(239, 68, 68, 0.9);
-    color: white;
+  background: rgba(239, 68, 68, 0.9);
+  color: white;
 }
 
 .badge-found {
-    background: rgba(16, 185, 129, 0.9);
-    color: white;
+  background: rgba(16, 185, 129, 0.9);
+  color: white;
 }
 
 .listing-content {
-    padding: 1.5rem;
-    display: flex;
-    flex-direction: column;
-    flex: 1;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
 }
 
 .listing-title {
-    font-size: 1.25rem;
-    margin-bottom: 0.75rem;
-    display: -webkit-box;
-    line-clamp: 2;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+  display: -webkit-box;
+  line-clamp: 2;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
 .listing-meta {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .listing-meta i {
-    color: var(--primary);
-    font-size: 1.1rem;
+  color: var(--primary);
+  font-size: 1.1rem;
 }
 
 .listing-footer {
-    margin-top: auto;
-    padding-top: 1.5rem;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  margin-top: auto;
+  padding-top: 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .listing-category {
-    font-size: 0.875rem;
-    color: var(--text-muted);
-    text-transform: capitalize;
-    font-weight: 500;
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  text-transform: capitalize;
+  font-weight: 500;
 }
 
 /* Filters */
 .page-header {
-    text-align: center;
-    margin: 2rem 0 3rem;
+  text-align: center;
+  margin: 2rem 0 3rem;
 }
 
 .page-header h2 {
-    font-size: 2.5rem;
-    margin-bottom: 0.5rem;
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .filters-container {
-    display: flex;
-    gap: 1rem;
-    padding: 1rem;
-    margin-bottom: 3rem;
-    flex-wrap: wrap;
+  display: flex;
+  gap: 1rem;
+  padding: 1rem;
+  margin-bottom: 3rem;
+  flex-wrap: wrap;
 }
 
 .search-bar {
-    flex: 1;
-    min-width: 250px;
-    position: relative;
-    display: flex;
-    align-items: center;
+  flex: 1;
+  min-width: 250px;
+  position: relative;
+  display: flex;
+  align-items: center;
 }
 
 .search-bar i {
-    position: absolute;
-    left: 1rem;
-    color: var(--text-muted);
-    font-size: 1.25rem;
+  position: absolute;
+  left: 1rem;
+  color: var(--text-muted);
+  font-size: 1.25rem;
 }
 
 .search-bar input {
-    width: 100%;
-    padding: 0.875rem 1rem 0.875rem 3rem;
-    border-radius: var(--radius-md);
-    border: 1px solid var(--border);
-    background: var(--surface);
-    color: var(--text-primary);
-    font-size: 1rem;
-    transition: var(--transition);
+  width: 100%;
+  padding: 0.875rem 1rem 0.875rem 3rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: var(--transition);
 }
 
 .search-bar input:focus {
-    outline: none;
-    border-color: var(--primary);
-    box-shadow: 0 0 0 3px var(--primary-light);
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-light);
 }
 
 .filter-controls {
-    display: flex;
-    gap: 1rem;
-    flex-wrap: wrap;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .custom-select {
-    padding: 0.875rem 3rem 0.875rem 1rem;
-    border-radius: var(--radius-md);
-    border: 1px solid var(--border);
-    background: var(--surface) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%236b7280'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'%3E%3C/path%3E%3C/svg%3E") no-repeat right 1rem center / 1.25rem;
-    appearance: none;
-    color: var(--text-primary);
-    font-size: 1rem;
-    cursor: pointer;
-    transition: var(--transition);
-    min-width: 160px;
+  padding: 0.875rem 3rem 0.875rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--surface)
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%236b7280'%3E%3Cpath stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M19 9l-7 7-7-7'%3E%3C/path%3E%3C/svg%3E")
+    no-repeat right 1rem center / 1.25rem;
+  appearance: none;
+  color: var(--text-primary);
+  font-size: 1rem;
+  cursor: pointer;
+  transition: var(--transition);
+  min-width: 160px;
 }
 
 .custom-select:focus {
-    outline: none;
-    border-color: var(--primary);
-    box-shadow: 0 0 0 3px var(--primary-light);
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-light);
 }
 
 /* Empty State */
 .empty-state {
-    text-align: center;
-    padding: 5rem 1rem;
+  text-align: center;
+  padding: 5rem 1rem;
 }
 
 .empty-state i {
-    font-size: 4rem;
-    color: var(--text-muted);
-    margin-bottom: 1rem;
+  font-size: 4rem;
+  color: var(--text-muted);
+  margin-bottom: 1rem;
 }
 
 .empty-state h3 {
-    font-size: 1.5rem;
-    margin-bottom: 0.5rem;
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .empty-state p {
-    margin-bottom: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
 /* Forms */
 .form-container {
-    max-width: 700px;
-    margin: 0 auto;
-    padding: 3rem;
+  max-width: 700px;
+  margin: 0 auto;
+  padding: 3rem;
 }
 
 .form-header {
-    text-align: center;
-    margin-bottom: 3rem;
+  text-align: center;
+  margin-bottom: 3rem;
 }
 
 .form-icon {
-    width: 5rem;
-    height: 5rem;
-    border-radius: var(--radius-lg);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 2.5rem;
-    margin: 0 auto 1.5rem;
-    color: white;
+  width: 5rem;
+  height: 5rem;
+  border-radius: var(--radius-lg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.5rem;
+  margin: 0 auto 1.5rem;
+  color: white;
 }
 
 .form-header h2 {
-    font-size: 2rem;
-    margin-bottom: 0.5rem;
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
 }
 
 .form-group {
-    margin-bottom: 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
 .form-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1.5rem;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
 }
 
 label {
-    display: block;
-    font-weight: 500;
-    margin-bottom: 0.5rem;
-    font-size: 0.9rem;
-    color: var(--text-secondary);
+  display: block;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
 }
 
-input[type="text"], input[type="date"], select, textarea {
-    width: 100%;
-    padding: 0.75rem 1rem;
-    border-radius: var(--radius-md);
-    border: 1px solid var(--border);
-    background: var(--surface);
-    color: var(--text-primary);
-    font-size: 1rem;
-    transition: var(--transition);
+input[type='text'],
+input[type='date'],
+select,
+textarea {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: var(--transition);
 }
 
 textarea {
-    resize: vertical;
-    min-height: 100px;
+  resize: vertical;
+  min-height: 100px;
 }
 
-input:focus, select:focus, textarea:focus {
-    outline: none;
-    border-color: var(--primary);
-    box-shadow: 0 0 0 3px var(--primary-light);
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-light);
 }
 
 /* File Upload */
 .file-drop-area {
-    border: 2px dashed var(--border);
-    border-radius: var(--radius-md);
-    padding: 3rem 2rem;
-    text-align: center;
-    background: var(--surface);
-    cursor: pointer;
-    position: relative;
-    transition: var(--transition);
+  border: 2px dashed var(--border);
+  border-radius: var(--radius-md);
+  padding: 3rem 2rem;
+  text-align: center;
+  background: var(--surface);
+  cursor: pointer;
+  position: relative;
+  transition: var(--transition);
 }
 
-.file-drop-area:hover, .file-drop-area.dragover {
-    border-color: var(--primary);
-    background: var(--primary-light);
+.file-drop-area:hover,
+.file-drop-area.dragover {
+  border-color: var(--primary);
+  background: var(--primary-light);
 }
 
 .file-drop-area i {
-    font-size: 2.5rem;
-    color: var(--primary);
-    margin-bottom: 1rem;
-    display: block;
+  font-size: 2.5rem;
+  color: var(--primary);
+  margin-bottom: 1rem;
+  display: block;
 }
 
 .file-msg {
-    font-weight: 500;
-    color: var(--text-secondary);
+  font-weight: 500;
+  color: var(--text-secondary);
 }
 
 .file-input {
-    position: absolute;
-    left: 0;
-    top: 0;
-    height: 100%;
-    width: 100%;
-    opacity: 0;
-    cursor: pointer;
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: 100%;
+  opacity: 0;
+  cursor: pointer;
 }
 
 .image-preview-container {
-    position: relative;
-    margin-top: 1rem;
-    width: 100%;
-    max-width: 300px;
-    border-radius: var(--radius-md);
-    overflow: hidden;
-    border: 1px solid var(--border);
+  position: relative;
+  margin-top: 1rem;
+  width: 100%;
+  max-width: 300px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--border);
 }
 
 .image-preview-container img {
-    width: 100%;
-    height: auto;
-    display: block;
+  width: 100%;
+  height: auto;
+  display: block;
 }
 
 .remove-image-btn {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    background: rgba(0,0,0,0.6);
-    color: white;
-    border: none;
-    width: 2rem;
-    height: 2rem;
-    border-radius: 50%;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    transition: var(--transition);
-    backdrop-filter: blur(4px);
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  border: none;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: var(--transition);
+  backdrop-filter: blur(4px);
 }
 
 .remove-image-btn:hover {
-    background: #ef4444;
-    transform: scale(1.1);
+  background: #ef4444;
+  transform: scale(1.1);
 }
 
 /* Item Details */
 .back-btn {
-    margin-bottom: 2rem;
+  margin-bottom: 2rem;
 }
 
 .details-container {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 0;
-    overflow: hidden;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+  overflow: hidden;
 }
 
 @media (min-width: 900px) {
-    .details-container {
-        grid-template-columns: 1fr 1fr;
-    }
+  .details-container {
+    grid-template-columns: 1fr 1fr;
+  }
 }
 
 .details-img-container {
-    width: 100%;
-    height: 400px;
+  width: 100%;
+  height: 400px;
 }
 
 @media (min-width: 900px) {
-    .details-img-container {
-        height: 100%;
-        min-height: 500px;
-    }
+  .details-img-container {
+    height: 100%;
+    min-height: 500px;
+  }
 }
 
 .details-img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .details-info {
-    padding: 3rem;
-    display: flex;
-    flex-direction: column;
+  padding: 3rem;
+  display: flex;
+  flex-direction: column;
 }
 
 .details-header {
-    margin-bottom: 2rem;
+  margin-bottom: 2rem;
 }
 
 .details-header .listing-badge {
-    position: static;
-    display: inline-block;
-    margin-bottom: 1rem;
+  position: static;
+  display: inline-block;
+  margin-bottom: 1rem;
 }
 
 .details-header h2 {
-    font-size: 2.5rem;
-    margin-bottom: 0.5rem;
+  font-size: 2.5rem;
+  margin-bottom: 0.5rem;
 }
 
 .details-meta-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 1.5rem;
-    margin-bottom: 2.5rem;
-    padding-bottom: 2.5rem;
-    border-bottom: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 2.5rem;
+  padding-bottom: 2.5rem;
+  border-bottom: 1px solid var(--border);
 }
 
 .meta-item {
-    display: flex;
-    gap: 1rem;
-    align-items: flex-start;
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
 }
 
 .meta-item i {
-    font-size: 1.5rem;
-    color: var(--primary);
-    background: var(--primary-light);
-    padding: 0.5rem;
-    border-radius: var(--radius-sm);
+  font-size: 1.5rem;
+  color: var(--primary);
+  background: var(--primary-light);
+  padding: 0.5rem;
+  border-radius: var(--radius-sm);
 }
 
 .meta-item div span {
-    display: block;
-    font-size: 0.75rem;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-    margin-bottom: 0.25rem;
+  display: block;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  margin-bottom: 0.25rem;
 }
 
 .meta-item div p {
-    font-weight: 500;
-    color: var(--text-primary);
+  font-weight: 500;
+  color: var(--text-primary);
 }
 
 .details-description {
-    margin-bottom: 3rem;
+  margin-bottom: 3rem;
 }
 
 .details-description h3 {
-    font-size: 1.25rem;
-    margin-bottom: 1rem;
+  font-size: 1.25rem;
+  margin-bottom: 1rem;
 }
 
 .details-description p {
-    white-space: pre-line;
+  white-space: pre-line;
 }
 
 .details-actions {
-    margin-top: auto;
-    display: flex;
-    gap: 1rem;
+  margin-top: auto;
+  display: flex;
+  gap: 1rem;
 }
 
 /* Toast */
 .toast {
-    position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-    padding: 1rem 1.5rem;
-    z-index: 1000;
-    animation: slideUp 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-    background: var(--surface);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-md);
-    box-shadow: var(--shadow-lg);
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  z-index: 1000;
+  animation: slideUp 0.4s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-lg);
 }
 
 .toast.fade-out {
-    animation: fadeOut 0.3s ease-in forwards;
+  animation: fadeOut 0.3s ease-in forwards;
 }
 
 @keyframes slideUp {
-    from { transform: translateY(100%); opacity: 0; }
-    to { transform: translateY(0); opacity: 1; }
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 
 @keyframes fadeOut {
-    from { transform: translateY(0); opacity: 1; }
-    to { transform: translateY(20px); opacity: 0; }
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(20px);
+    opacity: 0;
+  }
 }
 
 .toast-icon {
-    font-size: 1.5rem;
-    color: var(--secondary);
+  font-size: 1.5rem;
+  color: var(--secondary);
 }
 
-.toast-content h4 { 
-    margin-bottom: 0.25rem; 
-    font-size: 1rem;
+.toast-content h4 {
+  margin-bottom: 0.25rem;
+  font-size: 1rem;
 }
-.toast-content p { 
-    font-size: 0.875rem; 
-    margin: 0;
+.toast-content p {
+  font-size: 0.875rem;
+  margin: 0;
 }
 
 .toast-close {
-    background: transparent;
-    border: none;
-    color: var(--text-muted);
-    font-size: 1.25rem;
-    cursor: pointer;
-    margin-left: 1rem;
-    padding: 0.25rem;
-    transition: var(--transition);
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  font-size: 1.25rem;
+  cursor: pointer;
+  margin-left: 1rem;
+  padding: 0.25rem;
+  transition: var(--transition);
 }
 
 .toast-close:hover {
-    color: var(--text-primary);
+  color: var(--text-primary);
 }
 
 /* Footer */
 .footer {
-    text-align: center;
-    padding: 2rem;
-    color: var(--text-muted);
-    border-top: 1px solid var(--border);
-    margin-top: 4rem;
+  text-align: center;
+  padding: 2rem;
+  color: var(--text-muted);
+  border-top: 1px solid var(--border);
+  margin-top: 4rem;
 }
 
 /* Responsive */
 @media (max-width: 900px) {
-    .form-row { grid-template-columns: 1fr; gap: 0; }
-    .form-container { padding: 2rem 1.5rem; }
-    .details-info { padding: 2rem; }
-    .hero h1 { font-size: 2.5rem; }
+  .form-row {
+    grid-template-columns: 1fr;
+    gap: 0;
+  }
+  .form-container {
+    padding: 2rem 1.5rem;
+  }
+  .details-info {
+    padding: 2rem;
+  }
+  .hero h1 {
+    font-size: 2.5rem;
+  }
 }
 
 @media (max-width: 640px) {
-    .navbar { padding: 1rem; width: 100%; top: 0; border-radius: 0; border-left: none; border-right: none; border-top: none; }
-    .nav-links { display: none; }
-    .mobile-menu-btn { display: block; }
-    .hero-actions { flex-direction: column; width: 100%; }
-    .hero-actions .btn { width: 100%; }
-    .filters-container { flex-direction: column; }
-    .search-bar, .filter-controls { width: 100%; }
-    .filter-controls { flex-direction: column; }
-    .custom-select { width: 100%; }
-    .details-meta-grid { grid-template-columns: 1fr; }
-    .toast { left: 1rem; right: 1rem; bottom: 1rem; justify-content: space-between; }
+  .navbar {
+    padding: 1rem;
+    width: 100%;
+    top: 0;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    border-top: none;
+  }
+  .nav-links {
+    display: none;
+  }
+  .mobile-menu-btn {
+    display: block;
+  }
+  .hero-actions {
+    flex-direction: column;
+    width: 100%;
+  }
+  .hero-actions .btn {
+    width: 100%;
+  }
+  .filters-container {
+    flex-direction: column;
+  }
+  .search-bar,
+  .filter-controls {
+    width: 100%;
+  }
+  .filter-controls {
+    flex-direction: column;
+  }
+  .custom-select {
+    width: 100%;
+  }
+  .details-meta-grid {
+    grid-template-columns: 1fr;
+  }
+  .toast {
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    justify-content: space-between;
+  }
 }
 
 /* Timestamp update */


### PR DESCRIPTION
## Description

Fixes #9108

### Problem

The toast notification UI includes a close button (`.toast-close`), but no JavaScript event listener is attached to it.

As a result:

- Clicking the close icon has no effect.
- Users must wait for the auto-dismiss timer.
- Multiple notifications can become frustrating to manage.

### Root Cause

The toast component only supported automatic dismissal through a timeout inside `showToast()`.

No handler existed for the close button.

### Changes Made

- Added a cached reference for `.toast-close`.
- Added a click event listener for manual dismissal.
- Created a reusable `hideToast()` helper method.
- Updated `showToast()` to use the shared dismissal logic.
- Cleared existing timers before creating a new toast timer.

### Testing

Verified that:

- Success toast appears normally.
- Clicking the close button immediately hides the toast.
- Auto-dismiss still works after 3 seconds.
- Multiple toast notifications do not create overlapping timers.
- Functionality works in Chrome, Edge, and Firefox.

### Result

Users can now manually dismiss toast notifications using the close button while retaining the existing auto-dismiss behavior.