### PR TITLE
fix: prevent empty markdown lines from generating paragraph tags

### DIFF
--- a/public/Live-Editor/index.html
+++ b/public/Live-Editor/index.html
@@ -1,65 +1,123 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en" class="dark">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ForgeEdit Pro — Premium Workspace</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
-</head>
-<body>
-
+    <link rel="stylesheet" href="style.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
     <header class="pro-navbar">
-        <div class="brand-group">
-            <div class="brand-glyph"></div>
-            <span class="brand-name">ForgeEdit <span class="badge-premium">PRO</span></span>
-        </div>
-        <div class="utility-group">
-            <button id="themeToggle" class="icon-action-btn" aria-label="Toggle Interface Theme">
-                <svg class="sun-vector" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><circle cx="12" cy="12" r="5"></circle><line x1="12" y1="1" x2="12" y2="3"></line><line x1="12" y1="21" x2="12" y2="23"></line><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line><line x1="1" y1="12" x2="3" y2="12"></line><line x1="21" y1="12" x2="23" y2="12"></line><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line><line x1="18.36" y1="4.22" x2="19.78" y2="5.64"></line></svg>
-                <svg class="moon-vector" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path></svg>
-            </button>
-            <button id="exportDocument" class="cta-action-btn">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path><polyline points="7 10 12 15 17 10"></polyline><line x1="12" y1="15" x2="12" y2="3"></line></svg>
-                Compile & Export
-            </button>
-        </div>
+      <div class="brand-group">
+        <div class="brand-glyph"></div>
+        <span class="brand-name"
+          >ForgeEdit <span class="badge-premium">PRO</span></span
+        >
+      </div>
+      <div class="utility-group">
+        <button
+          id="themeToggle"
+          class="icon-action-btn"
+          aria-label="Toggle Interface Theme"
+        >
+          <svg
+            class="sun-vector"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+          >
+            <circle cx="12" cy="12" r="5"></circle>
+            <line x1="12" y1="1" x2="12" y2="3"></line>
+            <line x1="12" y1="21" x2="12" y2="23"></line>
+            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+            <line x1="1" y1="12" x2="3" y2="12"></line>
+            <line x1="21" y1="12" x2="23" y2="12"></line>
+            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+            <line x1="18.36" y1="4.22" x2="19.78" y2="5.64"></line>
+          </svg>
+          <svg
+            class="moon-vector"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+          >
+            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+          </svg>
+        </button>
+        <button id="exportDocument" class="cta-action-btn">
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"></path>
+            <polyline points="7 10 12 15 17 10"></polyline>
+            <line x1="12" y1="15" x2="12" y2="3"></line>
+          </svg>
+          Compile & Export
+        </button>
+      </div>
     </header>
 
     <div class="workspace-viewport">
-        <section class="workspace-blade" id="sourceBlade">
-            <div class="blade-tab-bar">
-                <div class="tab-element active-tab">
-                    <span class="tab-icon markdown-icon"></span>
-                    <span class="tab-label">index.md</span>
-                </div>
-                <div class="blade-metrics">Lines: <span id="lineMetricCounter">1</span></div>
-            </div>
-            
-            <div class="code-engine-container">
-                <div class="gutter-line-numbers" id="editorGutterLines"><div>1</div></div>
-                <div class="interactive-surface-wrapper">
-                    <textarea id="rawCodeSource" autocomplete="off" autocapitalize="off" spellcheck="false" placeholder="Write markdown document elements..."></textarea>
-                    <pre id="highlightedSyntaxRender" aria-hidden="true"><code id="syntaxTokenTarget"></code></pre>
-                </div>
-            </div>
-        </section>
+      <section class="workspace-blade" id="sourceBlade">
+        <div class="blade-tab-bar">
+          <div class="tab-element active-tab">
+            <span class="tab-icon markdown-icon"></span>
+            <span class="tab-label">index.md</span>
+          </div>
+          <div class="blade-metrics">
+            Lines: <span id="lineMetricCounter">1</span>
+          </div>
+        </div>
 
-        <section class="workspace-blade" id="viewportBlade">
-            <div class="blade-tab-bar">
-                <div class="tab-element active-tab">
-                    <span class="tab-icon execution-icon"></span>
-                    <span class="tab-label">Live Preview Output</span>
-                </div>
-            </div>
-            <div class="compiled-viewport-body">
-                <div id="sandboxRenderOutput" class="premium-prose-engine"></div>
-            </div>
-        </section>
+        <div class="code-engine-container">
+          <div class="gutter-line-numbers" id="editorGutterLines">
+            <div>1</div>
+          </div>
+          <div class="interactive-surface-wrapper">
+            <textarea
+              id="rawCodeSource"
+              autocomplete="off"
+              autocapitalize="off"
+              spellcheck="false"
+              placeholder="Write markdown document elements..."
+            ></textarea>
+            <pre
+              id="highlightedSyntaxRender"
+              aria-hidden="true"
+            ><code id="syntaxTokenTarget"></code></pre>
+          </div>
+        </div>
+      </section>
+
+      <section class="workspace-blade" id="viewportBlade">
+        <div class="blade-tab-bar">
+          <div class="tab-element active-tab">
+            <span class="tab-icon execution-icon"></span>
+            <span class="tab-label">Live Preview Output</span>
+          </div>
+        </div>
+        <div class="compiled-viewport-body">
+          <div id="sandboxRenderOutput" class="premium-prose-engine"></div>
+        </div>
+      </section>
     </div>
 
     <script src="script.js"></script>
-</body>
+  </body>
 </html>

--- a/public/Live-Editor/script.js
+++ b/public/Live-Editor/script.js
@@ -1,80 +1,114 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const rawCodeSource = document.getElementById('rawCodeSource');
-    const syntaxTokenTarget = document.getElementById('syntaxTokenTarget');
-    const editorGutterLines = document.getElementById('editorGutterLines');
-    const sandboxRenderOutput = document.getElementById('sandboxRenderOutput');
-    const lineMetricCounter = document.getElementById('lineMetricCounter');
-    const themeToggle = document.getElementById('themeToggle');
-    const exportDocument = document.getElementById('exportDocument');
+  const rawCodeSource = document.getElementById('rawCodeSource');
+  const syntaxTokenTarget = document.getElementById('syntaxTokenTarget');
+  const editorGutterLines = document.getElementById('editorGutterLines');
+  const sandboxRenderOutput = document.getElementById('sandboxRenderOutput');
+  const lineMetricCounter = document.getElementById('lineMetricCounter');
+  const themeToggle = document.getElementById('themeToggle');
+  const exportDocument = document.getElementById('exportDocument');
 
-    function processTokenStyling(rawText) {
-        if (!rawText) return ' ';
-        
-        let dynamicTokens = rawText
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
+  function processTokenStyling(rawText) {
+    if (!rawText) return ' ';
 
-        dynamicTokens = dynamicTokens.replace(/^(#+\s+.*)$/gm, '<span class="tok-header">$1</span>');
-        dynamicTokens = dynamicTokens.replace(/^(\s*-\s+.*)$/gm, '<span class="tok-list">$1</span>');
+    let dynamicTokens = rawText
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
 
-        return dynamicTokens;
+    dynamicTokens = dynamicTokens.replace(
+      /^(#+\s+.*)$/gm,
+      '<span class="tok-header">$1</span>'
+    );
+    dynamicTokens = dynamicTokens.replace(
+      /^(\s*-\s+.*)$/gm,
+      '<span class="tok-list">$1</span>'
+    );
+
+    return dynamicTokens;
+  }
+  function renderDocumentPreview(markdown) {
+    let compiledStructure = markdown
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+
+    compiledStructure = compiledStructure.replace(
+      /^(?:^|\n)((?:\s*-\s+.*\n?)+)/g,
+      (match) => {
+        const items = match
+          .trim()
+          .split('\n')
+          .map((item) => {
+            return `  <li>${item.replace(/^\s*-\s+/, '')}</li>`;
+          })
+          .join('\n');
+
+        return `\n<ul>\n${items}\n</ul>\n`;
+      }
+    );
+
+    compiledStructure = compiledStructure.replace(
+      /^#\s+(.*)$/gm,
+      '<h1>$1</h1>'
+    );
+
+    compiledStructure = compiledStructure.replace(
+      /^##\s+(.*)$/gm,
+      '<h2>$1</h2>'
+    );
+
+    // Remove empty lines before paragraph generation
+    compiledStructure = compiledStructure
+      .split('\n')
+      .filter((line) => line.trim() !== '')
+      .join('\n');
+
+    compiledStructure = compiledStructure.replace(
+      /^(?!<h[1-2]|<ul|<li)(.+)$/gm,
+      '<p>$1</p>'
+    );
+
+    return compiledStructure;
+  }
+
+  function synchronizeEditorEngine() {
+    const currentPayload = rawCodeSource.value;
+
+    syntaxTokenTarget.innerHTML = processTokenStyling(currentPayload);
+    sandboxRenderOutput.innerHTML = renderDocumentPreview(currentPayload);
+
+    const lineArray = currentPayload.split('\n');
+    const countMetrics = lineArray.length;
+
+    lineMetricCounter.textContent = countMetrics;
+
+    let trackingGutterDOM = '';
+    for (let iteration = 1; iteration <= countMetrics; iteration++) {
+      trackingGutterDOM += `<div>${iteration}</div>`;
     }
+    editorGutterLines.innerHTML = trackingGutterDOM;
+  }
 
-    function renderDocumentPreview(markdown) {
-        let compiledStructure = markdown
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
+  rawCodeSource.addEventListener('scroll', () => {
+    document.getElementById('highlightedSyntaxRender').scrollTop =
+      rawCodeSource.scrollTop;
+    document.getElementById('highlightedSyntaxRender').scrollLeft =
+      rawCodeSource.scrollLeft;
+    editorGutterLines.scrollTop = rawCodeSource.scrollTop;
+  });
 
-        compiledStructure = compiledStructure.replace(/^(?:^|\n)((?:\s*-\s+.*\n?)+)/g, (match) => {
-            const items = match.trim().split('\n').map(item => {
-                return `  <li>${item.replace(/^\s*-\s+/, '')}</li>`;
-            }).join('\n');
-            return `\n<ul>\n${items}\n</ul>\n`;
-        });
+  themeToggle.addEventListener('click', () => {
+    document.documentElement.classList.toggle('light');
+    document.documentElement.classList.toggle('dark');
+  });
 
-        compiledStructure = compiledStructure.replace(/^#\s+(.*)$/gm, '<h1>$1</h1>');
-        compiledStructure = compiledStructure.replace(/^##\s+(.*)$/gm, '<h2>$1</h2>');
-        compiledStructure = compiledStructure.replace(/^(?!<h[1-2]|<ul|<li)(.+)$/gm, '<p>$1</p>');
+  exportDocument.addEventListener('click', () => {
+    const bodyContent = sandboxRenderOutput.innerHTML;
+    const targetTheme = document.documentElement.classList.contains('light')
+      ? 'light'
+      : 'dark';
 
-        return compiledStructure;
-    }
-
-    function synchronizeEditorEngine() {
-        const currentPayload = rawCodeSource.value;
-        
-        syntaxTokenTarget.innerHTML = processTokenStyling(currentPayload);
-        sandboxRenderOutput.innerHTML = renderDocumentPreview(currentPayload);
-
-        const lineArray = currentPayload.split('\n');
-        const countMetrics = lineArray.length;
-        
-        lineMetricCounter.textContent = countMetrics;
-
-        let trackingGutterDOM = '';
-        for (let iteration = 1; iteration <= countMetrics; iteration++) {
-            trackingGutterDOM += `<div>${iteration}</div>`;
-        }
-        editorGutterLines.innerHTML = trackingGutterDOM;
-    }
-
-    rawCodeSource.addEventListener('scroll', () => {
-        document.getElementById('highlightedSyntaxRender').scrollTop = rawCodeSource.scrollTop;
-        document.getElementById('highlightedSyntaxRender').scrollLeft = rawCodeSource.scrollLeft;
-        editorGutterLines.scrollTop = rawCodeSource.scrollTop;
-    });
-
-    themeToggle.addEventListener('click', () => {
-        document.documentElement.classList.toggle('light');
-        document.documentElement.classList.toggle('dark');
-    });
-
-    exportDocument.addEventListener('click', () => {
-        const bodyContent = sandboxRenderOutput.innerHTML;
-        const targetTheme = document.documentElement.classList.contains('light') ? 'light' : 'dark';
-        
-        const standaloneBoilerplate = `<!DOCTYPE html>
+    const standaloneBoilerplate = `<!DOCTYPE html>
 <html lang="en" class="${targetTheme}">
 <head>
     <meta charset="UTF-8">
@@ -97,19 +131,21 @@ document.addEventListener('DOMContentLoaded', () => {
 </body>
 </html>`;
 
-        const transportBlob = new Blob([standaloneBoilerplate], { type: 'text/html' });
-        const temporaryLinkAddress = URL.createObjectURL(transportBlob);
-        const virtualAnchor = document.createElement('a');
-        virtualAnchor.href = temporaryLinkAddress;
-        virtualAnchor.download = 'compiled-artifact.html';
-        document.body.appendChild(virtualAnchor);
-        virtualAnchor.click();
-        document.body.removeChild(virtualAnchor);
-        URL.revokeObjectURL(temporaryLinkAddress);
+    const transportBlob = new Blob([standaloneBoilerplate], {
+      type: 'text/html',
     });
+    const temporaryLinkAddress = URL.createObjectURL(transportBlob);
+    const virtualAnchor = document.createElement('a');
+    virtualAnchor.href = temporaryLinkAddress;
+    virtualAnchor.download = 'compiled-artifact.html';
+    document.body.appendChild(virtualAnchor);
+    virtualAnchor.click();
+    document.body.removeChild(virtualAnchor);
+    URL.revokeObjectURL(temporaryLinkAddress);
+  });
 
-    rawCodeSource.addEventListener('input', synchronizeEditorEngine);
+  rawCodeSource.addEventListener('input', synchronizeEditorEngine);
 
-    rawCodeSource.value = `# Deep Dive Exploration\n\n- Real-time engine acceleration\n- High-contrast context layers\n- Synchronized viewports rendering inline`;
-    synchronizeEditorEngine();
-}); 
+  rawCodeSource.value = `# Deep Dive Exploration\n\n- Real-time engine acceleration\n- High-contrast context layers\n- Synchronized viewports rendering inline`;
+  synchronizeEditorEngine();
+});

--- a/public/Live-Editor/style.css
+++ b/public/Live-Editor/style.css
@@ -1,331 +1,343 @@
 :root {
-    --canvas-bg: #08090c;
-    --surface-panel: #0f1115;
-    --surface-header: #14171f;
-    --interstitial-border: #1e2330;
-    --typography-primary: #f8fafc;
-    --typography-secondary: #94a3b8;
-    --brand-accent: #6366f1;
-    --brand-accent-glow: rgba(99, 102, 241, 0.35);
-    
-    --syntax-token-tag: #f43f5e;
-    --syntax-token-string: #10b981;
-    --syntax-token-keyword: #38bdf8;
-    --syntax-token-body: #e2e8f0;
+  --canvas-bg: #08090c;
+  --surface-panel: #0f1115;
+  --surface-header: #14171f;
+  --interstitial-border: #1e2330;
+  --typography-primary: #f8fafc;
+  --typography-secondary: #94a3b8;
+  --brand-accent: #6366f1;
+  --brand-accent-glow: rgba(99, 102, 241, 0.35);
 
-    --font-ui: 'Plus Jakarta Sans', sans-serif;
-    --font-editor: 'Fira Code', monospace;
+  --syntax-token-tag: #f43f5e;
+  --syntax-token-string: #10b981;
+  --syntax-token-keyword: #38bdf8;
+  --syntax-token-body: #e2e8f0;
+
+  --font-ui: 'Plus Jakarta Sans', sans-serif;
+  --font-editor: 'Fira Code', monospace;
 }
 
 html.light {
-    --canvas-bg: #f1f5f9;
-    --surface-panel: #ffffff;
-    --surface-header: #f8fafc;
-    --interstitial-border: #cbd5e1;
-    --typography-primary: #0f172a;
-    --typography-secondary: #64748b;
-    --brand-accent: #4f46e5;
-    --brand-accent-glow: rgba(79, 70, 229, 0.15);
+  --canvas-bg: #f1f5f9;
+  --surface-panel: #ffffff;
+  --surface-header: #f8fafc;
+  --interstitial-border: #cbd5e1;
+  --typography-primary: #0f172a;
+  --typography-secondary: #64748b;
+  --brand-accent: #4f46e5;
+  --brand-accent-glow: rgba(79, 70, 229, 0.15);
 
-    --syntax-token-tag: #dc2626;
-    --syntax-token-string: #15803d;
-    --syntax-token-keyword: #1d4ed8;
-    --syntax-token-body: #334155;
+  --syntax-token-tag: #dc2626;
+  --syntax-token-string: #15803d;
+  --syntax-token-keyword: #1d4ed8;
+  --syntax-token-body: #334155;
 }
 
 * {
-    box-sizing: border-box;
-    margin: 0;
-    padding: 0;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
 }
 
 body {
-    font-family: var(--font-ui);
-    background-color: var(--canvas-bg);
-    color: var(--typography-primary);
-    height: 100vh;
-    display: flex;
-    flex-direction: column;
-    overflow: hidden;
+  font-family: var(--font-ui);
+  background-color: var(--canvas-bg);
+  color: var(--typography-primary);
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 .pro-navbar {
-    height: 64px;
-    background-color: var(--surface-header);
-    border-bottom: 1px solid var(--interstitial-border);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 24px;
-    flex-shrink: 0;
+  height: 64px;
+  background-color: var(--surface-header);
+  border-bottom: 1px solid var(--interstitial-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 24px;
+  flex-shrink: 0;
 }
 
 .brand-group {
-    display: flex;
-    align-items: center;
-    gap: 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
 }
 
 .brand-glyph {
-    width: 14px;
-    height: 14px;
-    background-color: var(--brand-accent);
-    border-radius: 4px;
-    box-shadow: 0 0 12px var(--brand-accent-glow);
+  width: 14px;
+  height: 14px;
+  background-color: var(--brand-accent);
+  border-radius: 4px;
+  box-shadow: 0 0 12px var(--brand-accent-glow);
 }
 
 .brand-name {
-    font-weight: 700;
-    font-size: 1.1rem;
-    letter-spacing: -0.03em;
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: -0.03em;
 }
 
 .badge-premium {
-    font-size: 0.65rem;
-    background-color: var(--brand-accent);
-    color: #ffffff;
-    padding: 2px 8px;
-    border-radius: 6px;
-    font-weight: 800;
-    margin-left: 6px;
-    letter-spacing: 0.05em;
+  font-size: 0.65rem;
+  background-color: var(--brand-accent);
+  color: #ffffff;
+  padding: 2px 8px;
+  border-radius: 6px;
+  font-weight: 800;
+  margin-left: 6px;
+  letter-spacing: 0.05em;
 }
 
 .utility-group {
-    display: flex;
-    align-items: center;
-    gap: 16px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
 
 .icon-action-btn {
-    background: transparent;
-    border: 1px solid var(--interstitial-border);
-    color: var(--typography-secondary);
-    width: 40px;
-    height: 40px;
-    border-radius: 8px;
-    cursor: pointer;
-    display: grid;
-    place-items: center;
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+  background: transparent;
+  border: 1px solid var(--interstitial-border);
+  color: var(--typography-secondary);
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .icon-action-btn:hover {
-    color: var(--typography-primary);
-    border-color: var(--typography-secondary);
+  color: var(--typography-primary);
+  border-color: var(--typography-secondary);
 }
 
 .icon-action-btn svg {
-    width: 18px;
-    height: 18px;
+  width: 18px;
+  height: 18px;
 }
 
-html.dark .sun-vector { display: block; }
-html.dark .moon-vector { display: none; }
-html.light .sun-vector { display: none; }
-html.light .moon-vector { display: block; }
+html.dark .sun-vector {
+  display: block;
+}
+html.dark .moon-vector {
+  display: none;
+}
+html.light .sun-vector {
+  display: none;
+}
+html.light .moon-vector {
+  display: block;
+}
 
 .cta-action-btn {
-    background-color: var(--brand-accent);
-    color: #ffffff;
-    border: none;
-    border-radius: 8px;
-    font-size: 0.875rem;
-    font-weight: 600;
-    padding: 10px 18px;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    box-shadow: 0 4px 12px var(--brand-accent-glow);
-    transition: transform 0.1s, opacity 0.2s;
+  background-color: var(--brand-accent);
+  color: #ffffff;
+  border: none;
+  border-radius: 8px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  padding: 10px 18px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  box-shadow: 0 4px 12px var(--brand-accent-glow);
+  transition:
+    transform 0.1s,
+    opacity 0.2s;
 }
 
 .cta-action-btn:hover {
-    opacity: 0.95;
+  opacity: 0.95;
 }
 
 .cta-action-btn:active {
-    transform: scale(0.98);
+  transform: scale(0.98);
 }
 
 .cta-action-btn svg {
-    width: 16px;
-    height: 16px;
+  width: 16px;
+  height: 16px;
 }
 
 .workspace-viewport {
-    flex: 1;
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    overflow: hidden;
+  flex: 1;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  overflow: hidden;
 }
 
 .workspace-blade {
-    display: flex;
-    flex-direction: column;
-    background-color: var(--surface-panel);
-    overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--surface-panel);
+  overflow: hidden;
 }
 
 #sourceBlade {
-    border-right: 1px solid var(--interstitial-border);
+  border-right: 1px solid var(--interstitial-border);
 }
 
 .blade-tab-bar {
-    height: 42px;
-    background-color: var(--surface-header);
-    border-bottom: 1px solid var(--interstitial-border);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 16px;
+  height: 42px;
+  background-color: var(--surface-header);
+  border-bottom: 1px solid var(--interstitial-border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
 }
 
 .tab-element {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 0 16px;
-    height: 100%;
-    border-bottom: 2px solid transparent;
-    user-select: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 16px;
+  height: 100%;
+  border-bottom: 2px solid transparent;
+  user-select: none;
 }
 
 .active-tab {
-    border-bottom-color: var(--brand-accent);
-    background-color: var(--surface-panel);
+  border-bottom-color: var(--brand-accent);
+  background-color: var(--surface-panel);
 }
 
 .tab-label {
-    font-size: 0.8rem;
-    font-weight: 600;
-    color: var(--typography-primary);
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--typography-primary);
 }
 
 .blade-metrics {
-    font-size: 0.75rem;
-    color: var(--typography-secondary);
+  font-size: 0.75rem;
+  color: var(--typography-secondary);
 }
 
 .code-engine-container {
-    flex: 1;
-    display: flex;
-    position: relative;
-    overflow: hidden;
+  flex: 1;
+  display: flex;
+  position: relative;
+  overflow: hidden;
 }
 
 .gutter-line-numbers {
-    width: 48px;
-    background-color: var(--surface-header);
-    border-right: 1px solid var(--interstitial-border);
-    padding: 24px 0;
-    font-family: var(--font-editor);
-    font-size: 0.9rem;
-    line-height: 1.6rem;
-    color: var(--typography-secondary);
-    text-align: right;
-    padding-right: 12px;
-    user-select: none;
-    overflow: hidden;
+  width: 48px;
+  background-color: var(--surface-header);
+  border-right: 1px solid var(--interstitial-border);
+  padding: 24px 0;
+  font-family: var(--font-editor);
+  font-size: 0.9rem;
+  line-height: 1.6rem;
+  color: var(--typography-secondary);
+  text-align: right;
+  padding-right: 12px;
+  user-select: none;
+  overflow: hidden;
 }
 
 .interactive-surface-wrapper {
-    flex: 1;
-    position: relative;
-    overflow: hidden;
-    background-color: var(--surface-panel);
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+  background-color: var(--surface-panel);
 }
 
-#rawCodeSource, #highlightedSyntaxRender {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    padding: 24px;
-    font-family: var(--font-editor);
-    font-size: 0.95rem;
-    line-height: 1.6rem;
-    white-space: pre-wrap;
-    word-wrap: break-word;
-    border: none;
-    outline: none;
-    overflow-y: auto;
-    
-    letter-spacing: normal;
-    text-transform: none;
-    tab-size: 4;
+#rawCodeSource,
+#highlightedSyntaxRender {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 24px;
+  font-family: var(--font-editor);
+  font-size: 0.95rem;
+  line-height: 1.6rem;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  border: none;
+  outline: none;
+  overflow-y: auto;
+
+  letter-spacing: normal;
+  text-transform: none;
+  tab-size: 4;
 }
 
 #rawCodeSource {
-    background: transparent;
-    color: transparent;
-    -webkit-text-fill-color: transparent;
-    caret-color: var(--typography-primary);
-    resize: none;
-    z-index: 2;
+  background: transparent;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  caret-color: var(--typography-primary);
+  resize: none;
+  z-index: 2;
 }
 
 #highlightedSyntaxRender {
-    background: transparent;
-    z-index: 1;
-    pointer-events: none;
-    color: var(--typography-primary);
+  background: transparent;
+  z-index: 1;
+  pointer-events: none;
+  color: var(--typography-primary);
 }
 
 .tok-header {
-    color: var(--syntax-token-tag);
-    font-weight: 600;
+  color: var(--syntax-token-tag);
+  font-weight: 600;
 }
 
 .tok-list {
-    color: var(--syntax-token-keyword);
-    font-weight: 500;
+  color: var(--syntax-token-keyword);
+  font-weight: 500;
 }
 
 .tok-text {
-    color: var(--syntax-token-body);
+  color: var(--syntax-token-body);
 }
 
 .compiled-viewport-body {
-    flex: 1;
-    padding: 32px;
-    overflow-y: auto;
+  flex: 1;
+  padding: 32px;
+  overflow-y: auto;
 }
 
 .premium-prose-engine {
-    font-size: 1rem;
-    line-height: 1.8;
+  font-size: 1rem;
+  line-height: 1.8;
 }
 
-.premium-prose-engine h1, .premium-prose-engine h2 {
-    margin-bottom: 16px;
-    font-weight: 700;
-    letter-spacing: -0.02em;
+.premium-prose-engine h1,
+.premium-prose-engine h2 {
+  margin-bottom: 16px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
 }
 
 .premium-prose-engine ul {
-    padding-left: 24px;
-    margin-bottom: 16px;
+  padding-left: 24px;
+  margin-bottom: 16px;
 }
 
 .premium-prose-engine li {
-    margin-bottom: 6px;
+  margin-bottom: 6px;
 }
 
 .premium-prose-engine p {
-    margin-bottom: 16px;
+  margin-bottom: 16px;
 }
 
 @media (max-width: 992px) {
-    .workspace-viewport {
-        grid-template-columns: 1fr;
-        grid-template-rows: 1fr 1fr;
-    }
-    #sourceBlade {
-        border-right: none;
-        border-bottom: 1px solid var(--interstitial-border);
-    }
+  .workspace-viewport {
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr 1fr;
+  }
+  #sourceBlade {
+    border-right: none;
+    border-bottom: 1px solid var(--interstitial-border);
+  }
 }


### PR DESCRIPTION
## Description

Fixes #9109

### Problem

Blank lines in the Markdown editor were being converted into empty paragraph elements:

```html
<p></p>
```

This produced unnecessary DOM nodes, inconsistent spacing, and malformed preview output for documents containing multiple blank lines.

### Root Cause

The paragraph generation regex:

```js
/^(?!<h[1-2]|<ul|<li)(.+)$/gm
```

processed whitespace-only lines as valid paragraph content.

### Changes Made

- Filtered empty and whitespace-only lines before paragraph generation.
- Preserved existing heading and list rendering behavior.
- Prevented creation of empty `<p></p>` elements.
- Reduced unnecessary DOM nodes in preview output.

### Testing

Tested with:

```md
# Title


## Subtitle


- Item 1
- Item 2
```

Preview now renders:

```html
<h1>Title</h1>
<h2>Subtitle</h2>
<ul>
  <li>Item 1</li>
  <li>Item 2</li>
</ul>
```

No empty paragraph tags are generated.

### Result

- Cleaner HTML output
- Improved rendering efficiency
- Consistent spacing in preview
- Reduced DOM size for large markdown documents