### PR TITLE
fix: remove broken favorites.html nav link in Movie-Matcher

### DIFF
--- a/public/Movie-Matcher/index.html
+++ b/public/Movie-Matcher/index.html
@@ -38,12 +38,6 @@
       </a>
     </li>
 
-    <li>
-      <a href="favorites.html">
-        Favorites
-      </a>
-    </li>
-
   </ul>
    <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
     <span class="toggle-icon">☀️</span>


### PR DESCRIPTION
Fixes #9328

## Description
The navigation bar in public/Movie-Matcher/index.html contained
a link to favorites.html, but this file does not exist anywhere
in the Movie-Matcher project folder. Clicking the Favorites nav
button resulted in a 404 page not found error. The project only
has movies.html and watchlist.html.

## Fix
Removed the broken Favorites nav link entirely since no
corresponding favorites.html page exists in the project.

## Testing
- Verified favorites.html does not exist in public/Movie-Matcher/
- Verified the broken nav link is fully removed
- No remaining references to favorites.html

## Checklist
- [x] Tested locally
- [x] No new console errors
- [x] Follows existing code style