### PR TITLE
Feature: Client-Side Image Compression using HTML5 Canvas

### DIFF
--- a/public/Lost_And_Found_Portal/script.js
+++ b/public/Lost_And_Found_Portal/script.js
@@ -296,9 +296,55 @@ class LostAndFoundApp {
 
         const reader = new FileReader();
         reader.onload = (e) => {
-          previewImg.src = e.target.result;
-          previewContainer.classList.remove('hidden');
-          dropArea.classList.add('hidden');
+          try {
+            // Create an off-screen image object to process the upload
+            const img = new Image();
+            
+            img.onload = () => {
+              // Setup canvas and calculate new proportional dimensions
+              const canvas = document.createElement('canvas');
+              const MAX_WIDTH = 800; // Cap width to prevent massive payloads
+              let newWidth = img.width;
+              let newHeight = img.height;
+
+              // Only scale down if the image is wider than the maximum allowed
+              if (img.width > MAX_WIDTH) {
+                const scaleRatio = MAX_WIDTH / img.width;
+                newWidth = MAX_WIDTH;
+                newHeight = img.height * scaleRatio;
+              }
+
+              // Draw scaled image to the canvas
+              canvas.width = newWidth;
+              canvas.height = newHeight;
+              const ctx = canvas.getContext('2d');
+              ctx.drawImage(img, 0, 0, newWidth, newHeight);
+
+              // Export compressed image (JPEG format, 60% quality ratio)
+              const compressedDataUrl = canvas.toDataURL('image/jpeg', 0.6);
+
+              // Update the UI with the tiny compressed image payload
+              previewImg.src = compressedDataUrl;
+              previewContainer.classList.remove('hidden');
+              dropArea.classList.add('hidden');
+            };
+
+            img.onerror = () => {
+              console.error('Failed to load image for compression.');
+              // Fallback to uncompressed original if loading fails
+              previewImg.src = e.target.result;
+              previewContainer.classList.remove('hidden');
+              dropArea.classList.add('hidden');
+            };
+
+            img.src = e.target.result;
+          } catch (error) {
+            console.error('Error during image canvas compression:', error);
+            // Graceful error handling: Fallback to raw Base64
+            previewImg.src = e.target.result;
+            previewContainer.classList.remove('hidden');
+            dropArea.classList.add('hidden');
+          }
         };
         reader.readAsDataURL(file);
       }


### PR DESCRIPTION
### Related Issue
Closes #9186

### Summary
This PR resolves the `QuotaExceededError` crashes caused by uploading high-resolution images. It implements native client-side image compression using the HTML5 `<canvas>` API, drastically reducing Base64 string payloads before they are saved to `localStorage`.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature or UI/UX enhancement

---

## 🛠️ Changes Made
- Intercepted the `FileReader` output inside `setupImageUpload()`.
- Implemented an off-screen HTML5 `<canvas>` to draw and resize images (capped at an 800px width threshold).
- Exported the compressed payload using `.toDataURL('image/jpeg', 0.6)`, shrinking large image sizes by up to 90% while maintaining UI visual fidelity.
- Added graceful `try/catch` fallbacks to default to the raw image if the canvas context fails to load.

---

## 🧪 Testing and Verification

### Local Validation
- Tested uploading a 5.2MB image. Prior to this PR, it crashed the portal. Post-PR, it compresses seamlessly and `saveItems()` executes without hitting quota limits.
- **Note regarding Linting:** I formatted the code manually via my IDE. Running `npm run format` currently throws a YAML parsing error (`Cannot read properties of undefined (reading 'indexOf')`) originating from the root `.prettierrc` file, so I bypassed the automated script to avoid pushing unrelated config changes in this PR.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [x] Tested and verified in **Microsoft Edge**

---

## 📷 Screenshots / Proof of Compression
*The vedio below demonstrates the console output measuring the Base64 string length after the new canvas compression runs on a 5MB image:*


https://github.com/user-attachments/assets/51efb41a-8412-416d-9e15-6f84b0d2453c



---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
