### PR TITLE
ColorProp keyboard shortcuts fixed

### DIFF
--- a/public/colorpop/index.html
+++ b/public/colorpop/index.html
@@ -419,24 +419,24 @@
         </div>
         <div class="modal-body keyboard-shortcuts-list">
           <div class="shortcut-row">
-            <kbd>Spacebar</kbd>
-            <span>Generate new color palette</span>
+            <span class="shortcut-keys"><kbd>Spacebar</kbd></span>
+            <span class="shortcut-desc">Generate new color palette</span>
           </div>
           <div class="shortcut-row">
-            <kbd>1</kbd> - <kbd>5</kbd>
-            <span>Toggle Lock status of color slot 1 to 5</span>
+            <span class="shortcut-keys"><kbd>1</kbd> - <kbd>5</kbd></span>
+            <span class="shortcut-desc">Toggle Lock status of color slot 1 to 5</span>
           </div>
           <div class="shortcut-row">
-            <kbd>C</kbd>
-            <span>Copy active preview color to clipboard</span>
+            <span class="shortcut-keys"><kbd>C</kbd></span>
+            <span class="shortcut-desc">Copy active preview color to clipboard</span>
           </div>
           <div class="shortcut-row">
-            <kbd>S</kbd>
-            <span>Save active color to favorites</span>
+            <span class="shortcut-keys"><kbd>S</kbd></span>
+            <span class="shortcut-desc">Save active color to favorites</span>
           </div>
           <div class="shortcut-row">
-            <kbd>E</kbd>
-            <span>Open Palette Export dialog</span>
+            <span class="shortcut-keys"><kbd>E</kbd></span>
+            <span class="shortcut-desc">Open Palette Export dialog</span>
           </div>
         </div>
       </div>

--- a/public/colorpop/style.css
+++ b/public/colorpop/style.css
@@ -919,6 +919,7 @@ body {
   border-radius: var(--radius-lg);
   width: 90%;
   max-width: 550px;
+  max-height: 90vh;
   box-shadow: var(--shadow-lg);
   transform: scale(0.9) translateY(20px);
   transition: transform 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
@@ -981,6 +982,7 @@ body {
   padding: 24px;
   overflow-y: auto;
   max-height: 300px;
+  flex: 1;
 }
 
 .tab-content {
@@ -1029,6 +1031,7 @@ code {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 16px;
   font-size: 14px;
   border-bottom: 1px dashed rgba(255, 255, 255, 0.05);
   padding-bottom: 12px;
@@ -1037,6 +1040,22 @@ code {
 .shortcut-row:last-child {
   border-bottom: none;
   padding-bottom: 0;
+}
+
+.shortcut-keys {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.shortcut-desc {
+  color: var(--text-secondary);
+  text-align: right;
+  line-height: 1.4;
 }
 
 kbd {
@@ -1048,10 +1067,6 @@ kbd {
   font-size: 11px;
   font-weight: 700;
   box-shadow: 0 2px 0 rgba(0, 0, 0, 0.2);
-}
-
-.shortcut-row span {
-  color: var(--text-secondary);
 }
 
 /* ==========================================================================
@@ -1292,5 +1307,33 @@ kbd {
 
   .empty-favorites-state {
     grid-column: span 2;
+  }
+}
+
+/* Keyboard Shortcuts Modal Mobile Responsiveness */
+@media (max-width: 480px) {
+  .modal-card {
+    width: 92%;
+    margin: 0 auto;
+  }
+
+  .modal-header {
+    padding: 16px 20px;
+  }
+
+  .modal-body {
+    padding: 16px 20px;
+  }
+
+  .shortcut-row {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 8px;
+    padding-bottom: 14px;
+  }
+
+  .shortcut-desc {
+    text-align: left;
+    font-size: 13px;
   }
 }


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #9073

### Summary
Fixed responsiveness issues in the Keyboard Shortcuts / Instructions modal of ColorPop – Premium Hex Code & Palette Generator. The modal now adapts properly to smaller screens, ensuring shortcut labels and descriptions remain readable and well-spaced on mobile devices.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ♻️ Code refactoring / clean-up

---

## 🛠️ Changes Made
Modal Responsiveness Improvements
-Fixed cramped layout issues on small-screen devices.
-Updated modal width to adapt dynamically to viewport size.
-Improved padding and spacing for better readability.
-Prevented content overflow and excessive text wrapping.
Shortcut Layout Enhancements
-Adjusted shortcut rows to stack vertically when needed.
-Improved alignment between shortcut keys and descriptions.
-Enhanced spacing between rows and sections.
-Ensured keyboard labels remain clearly visible.
Mobile Optimization
-Optimized the modal for devices such as Samsung Galaxy S8+ (360×740).
-Improved typography and text wrapping behavior.
-Enhanced touch accessibility and scrolling behavior.
-Maintained a consistent experience across different screen sizes.

---

## 🧪 Testing and Verification

### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [x] Tested and verified in **Mozilla Firefox**
- [x] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [x] Verified responsive layout on Mobile viewports (using DevTools)
- [x] Verified responsive layout on Tablet viewports
- [x] Keyboard navigation and focus outlines checked
- [x] Semantic HTML and ARIA labels checked
---

## 📷 Screenshots / Video Recording
<img width="1920" height="1029" alt="ColorPop — Premium Hex Code   Palette Generator - Brave 22-06-2026 19_46_02" src="https://github.com/user-attachments/assets/d4c59086-b4a7-4168-9b00-44d5d1ce8c0b" />


---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
