### PR TITLE
fix: add noscript fallback for users with JavaScript disabled

### DIFF
--- a/index.html
+++ b/index.html
@@ -413,7 +413,13 @@
           </button>
         </div>
 
-        <div class="project-grid" id="projectGrid"></div>
+        <div class="project-grid" id="projectGrid">
+          <noscript>
+            <p style="grid-column: 1 / -1; text-align: center; padding: 3rem 1rem; color: var(--text-secondary, #888); font-size: 1rem;">
+              JavaScript is required to view the interactive project archive. Please enable JavaScript in your browser settings and reload the page.
+            </p>
+          </noscript>
+        </div>
 
         <div class="no-results" id="noResults" role="status" aria-live="assertive">
           <i class="fas fa-search" aria-hidden="true"></i>


### PR DESCRIPTION
## What
Adds a `<noscript>` tag inside the `#projectGrid` container in `index.html`.

## Why
The entire project grid is dynamically generated by `index.js`. If JavaScript is disabled or blocked (strict browser shields, corporate proxies, etc.), the user sees a completely blank `#projectGrid` div with no explanation. The `<noscript>` tag is the semantic HTML standard for providing fallback content in this exact scenario. The message is styled inline using CSS custom properties already defined in the project so it respects both light and dark themes.

## Changes
- `index.html`: Added a `<noscript>` block inside `#projectGrid` with a descriptive user-facing message.

Closes #9249