### PR TITLE
fix: add scroll-padding-top to prevent anchor links hiding under sticky navbar

### DIFF
--- a/style.css
+++ b/style.css
@@ -136,6 +136,7 @@ body.light-mode {
 
 html {
   scroll-behavior: smooth;
+  scroll-padding-top: 80px;
 }
 
 body {


### PR DESCRIPTION
## What
Adds `scroll-padding-top: 80px` to the `html` selector in `style.css`.

## Why
The site uses a sticky/fixed navbar approximately 70-80px tall. When a user clicks any internal anchor link (e.g., "Browse all projects" → `#projects`, "Back to top" → `#hero`), the browser scrolls so the anchor target is at the very top of the viewport — directly hidden underneath the navbar. `scroll-padding-top` is the modern CSS-native solution for this exact problem and works for all anchor navigation including keyboard `Tab` focus jumps.

## Changes
- `style.css`: Added `scroll-padding-top: 80px` to the existing `html {}` selector.

Closes #9248