### PR TITLE
fix: use selectedIndex=0 to reliably reset all filter dropdowns on clear

### DIFF
--- a/index.js
+++ b/index.js
@@ -1717,15 +1717,15 @@ function resetAllFilters() {
   searchQuery = "";
 
   const techStack = document.getElementById("techStackFilter");
-  if (techStack) techStack.value = "all";
+  if (techStack) techStack.selectedIndex = 0;
   techStackFilter = "all";
 
   const difficultyElement = document.getElementById("difficultyFilter");
-  if (difficultyElement) difficultyElement.value = "all";
+  if (difficultyElement) difficultyElement.selectedIndex = 0;
   difficultyFilter = "all";
 
   const sortSelect = document.getElementById("sortProjects");
-  if (sortSelect) sortSelect.value = "default";
+  if (sortSelect) sortSelect.selectedIndex = 0;
   sortOption = "default";
 
   if (typeof updateURL === "function") {


### PR DESCRIPTION
## What
Changes the "Clear Filters" reset logic in `resetAllFilters()` to use `selectedIndex = 0` instead of `.value = "all"` / `.value = "default"` for all `<select>` elements.

## Why
In certain browser environments (particularly Safari and some Chromium versions), setting `.value` on a `<select>` to a specific string only works reliably if that string exactly matches an option's value attribute. Using `.selectedIndex = 0` is the guaranteed cross-browser standard to visually reset a dropdown to its first option, regardless of the value string.

## Changes
- `index.js`: Updated `resetAllFilters()` to use `selectedIndex = 0` for `#techStackFilter`, `#difficultyFilter`, and `#sortProjects`.

Closes #9247