### PR TITLE
fix: add missing meta robots tag to improve SEO indexing

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
       content="web development, HTML, CSS, JavaScript, React, Node.js, projects, learning, 100 days, open source, GSSoC"
     />
     <meta name="author" content="Dhairya Gothi and Contributors" />
+    <meta name="robots" content="index, follow" />
     <meta name="theme-color" content="#0a0a1a" />
     <script src="theme.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4"></script>


### PR DESCRIPTION
## What
Adds the missing `<meta name="robots" content="index, follow" />` tag to `index.html`.

## Why
Without this tag, search engine crawlers have no explicit instruction to index the site or follow its links. While most crawlers index by default, the absence of this tag is considered an SEO deficiency and fails Lighthouse best-practice audits. Adding it explicitly ensures compliant, predictable indexing behavior across all crawlers (Googlebot, Bingbot, etc.).

## Changes
- `index.html`: Added `<meta name="robots" content="index, follow" />` in the `<head>` section.

Closes #9246