### PR TITLE
fix: validate repository API responses in GitHub Profile Finder

### DIFF
--- a/public/github_profile_finder/script.js
+++ b/public/github_profile_finder/script.js
@@ -613,8 +613,25 @@ async function fetchUser(username) {
       `https://api.github.com/users/${cleanName}/repos?per_page=100`
     );
 
+    if (!repoResponse.ok) {
+
+      const errorData =
+        await repoResponse.json().catch(() => ({}));
+
+      throw new Error(
+        errorData.message || "Failed to fetch repositories."
+      );
+    }
+
     const repos =
       await repoResponse.json();
+
+    if (!Array.isArray(repos)) {
+
+      throw new Error(
+        "Failed to fetch repositories."
+      );
+    }
 
     const sortedRepos = repos
       .sort(
@@ -692,8 +709,25 @@ async function fetchProfileData(username) {
     `https://api.github.com/users/${cleanName}/repos?per_page=50`
   );
 
+  if (!repoResponse.ok) {
+
+    const errorData =
+      await repoResponse.json().catch(() => ({}));
+
+    throw new Error(
+      errorData.message || "Failed to fetch repositories."
+    );
+  }
+
   const repos =
     await repoResponse.json();
+
+  if (!Array.isArray(repos)) {
+
+    throw new Error(
+      "Failed to fetch repositories."
+    );
+  }
 
   const sortedRepos = repos
     .sort(


### PR DESCRIPTION
## Summary

Fixed a runtime crash in the GitHub Profile Finder project caused by missing validation of repository API responses.

## Changes Made

* Added `repoResponse.ok` validation in `fetchUser()`
* Added `repoResponse.ok` validation in `fetchProfileData()`
* Added `Array.isArray(repos)` check before sorting repositories
* Added user-friendly error messages for API failures

## Issue Fixed

Previously, if GitHub returned an error response (such as API rate limit exceeded), the app parsed the response without validation and attempted to call:

`repos.sort(...)`

This caused:

`TypeError: repos.sort is not a function`

The application now handles repository API failures gracefully without crashing.
