### PR TITLE
feat: add PNG export functionality for pixel art

### DIFF
--- a/public/pixel-art/index.html
+++ b/public/pixel-art/index.html
@@ -32,6 +32,9 @@
         <div class="control-group">
             <button id="clear-btn" class="clear-btn">Clear Canvas</button>
         </div>
+        <div class="control-group">
+            <button id="download-btn">Download PNG</button>
+        </div>
     </div>
 
     <div class="canvas-container">

--- a/public/pixel-art/script.js
+++ b/public/pixel-art/script.js
@@ -10,11 +10,101 @@ let isDrawing = false;
 let isRubberMode = false;
 const CELL_SIZE = 25;
 
+const downloadBtn =
+document.getElementById("download-btn");
+
+downloadBtn.addEventListener(
+    "click",
+    downloadPixelArt
+);
+
+function downloadPixelArt() {
+
+    const width =
+        parseInt(widthInput.value) || 16;
+
+    const height =
+        parseInt(heightInput.value) || 16;
+
+    const cells =
+        document.querySelectorAll(".cell");
+
+    const canvas =
+        document.createElement("canvas");
+
+    canvas.width = width;
+    canvas.height = height;
+
+    const ctx =
+        canvas.getContext("2d");
+
+    cells.forEach((cell, index) => {
+
+        const row =
+            Math.floor(index / width);
+
+        const col =
+            index % width;
+
+        const color =
+            getComputedStyle(cell)
+            .backgroundColor;
+
+        ctx.fillStyle =
+            color === "rgba(0, 0, 0, 0)"
+                ? "#ffffff"
+                : color;
+
+        ctx.fillRect(
+            col,
+            row,
+            1,
+            1
+        );
+    });
+
+    const exportCanvas =
+        document.createElement("canvas");
+
+    const scale = 20;
+
+    exportCanvas.width =
+        width * scale;
+
+    exportCanvas.height =
+        height * scale;
+
+    const exportCtx =
+        exportCanvas.getContext("2d");
+
+    exportCtx.imageSmoothingEnabled =
+        false;
+
+    exportCtx.drawImage(
+        canvas,
+        0,
+        0,
+        exportCanvas.width,
+        exportCanvas.height
+    );
+
+    const link =
+        document.createElement("a");
+
+    link.download =
+        "pixel-art.png";
+
+    link.href =
+        exportCanvas.toDataURL("image/png");
+
+    link.click();
+}
+
 function makeGrid() {
   grid.innerHTML = "";
 
-  const width = parseInt(widthInput.value) || 16;
-  const height = parseInt(heightInput.value) || 16;
+  let width = parseInt(widthInput.value) || 16;
+  let height = parseInt(heightInput.value) || 16;
 
   console.log(width, height);
 

--- a/public/pixel-art/style.css
+++ b/public/pixel-art/style.css
@@ -21,6 +21,20 @@ h1 {
   margin-bottom: 20px;
 }
 
+#download-btn{
+    background:#28a745;
+    color:white;
+    border:none;
+    padding:10px 16px;
+    border-radius:6px;
+    cursor:pointer;
+    font-weight:600;
+}
+
+#download-btn:hover{
+    background:#218838;
+}
+
 .controls {
   background-color: var(--panel-color);
   padding: 15px 25px;


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #9433 

### Summary

Added PNG export functionality to the Pixel Art Maker, allowing users to download their creations as image files. The exported PNG accurately preserves the current state of the pixel grid, making it easy to save and share artwork.

### Type of Change

* [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New project addition
* [x] 🚀 New feature or UI/UX enhancement
* [ ] ♻️ Code refactoring / clean-up
* [ ] 📝 Documentation update
* [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made

* Added a **Download PNG** button to the control panel.
* Implemented canvas-based PNG export functionality.
* Generated downloadable images from the current pixel grid state.
* Preserved pixel-art appearance by disabling image smoothing during export.
* Ensured exported images reflect the exact colors and dimensions of the current artwork.

---

## 🧪 Testing and Verification

### Local Validation

* [x] Verified PNG files are generated successfully.
* [x] Confirmed exported images match the current canvas content.
* [x] Tested with different grid dimensions and color combinations.

### Browser Compatibility Check

* [x] Tested and verified in **Google Chrome**
* [ ] Tested and verified in **Mozilla Firefox**
* [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks

* [x] Verified feature works on desktop and responsive layouts.
* [x] Confirmed existing drawing functionality remains unaffected.

---

## 📷 Screenshots / Video Recording

### Before

* Users could create pixel art but had no way to save or share their work.

### After

* Users can click **Download PNG** and instantly save their artwork as an image file.

---

## 🤝 Contributor Checklist

* [x] My code follows the code style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have updated the documentation / README files accordingly.
* [x] My changes generate no new warnings or console errors.
* [x] There are no unrelated changes or formatter noise in this PR.
