### PR TITLE
fix: prevent repeated keyboard events while gesture remains active

### DIFF
--- a/public/hand-gesture-controller/gesture-engine.js
+++ b/public/hand-gesture-controller/gesture-engine.js
@@ -10,124 +10,153 @@ const eventLog = document.getElementById('event-log');
 
 // Helper to append virtual keystroke execution logs to UI
 function logKeystroke(message) {
-    const line = document.createElement('div');
-    line.textContent = `[${new Date().toLocaleTimeString()}] 🚀 ${message}`;
-    eventLog.appendChild(line);
-    eventLog.scrollTop = eventLog.scrollHeight;
+  const line = document.createElement('div');
+  line.textContent = `[${new Date().toLocaleTimeString()}] 🚀 ${message}`;
+  eventLog.appendChild(line);
+  eventLog.scrollTop = eventLog.scrollHeight;
 }
 
 // ========================================================
 // CORE ALGORITHMIC GESTURE EVALUATOR
 // ========================================================
 function evaluateGestures(landmarks) {
-    // MediaPipe Hand Landmarks Indices:
-    // Thumb: Tip(4), IP Joint(3). Index: Tip(8), PIP Joint(6). Middle: Tip(12), PIP Joint(10)
-    const indexTipY = landmarks[8].y;
-    const indexKnuckleY = landmarks[6].y;
+  const indexTipY = landmarks[8].y;
+  const indexKnuckleY = landmarks[6].y;
 
-    const middleTipY = landmarks[12].y;
-    const middleKnuckleY = landmarks[10].y;
+  const middleTipY = landmarks[12].y;
+  const middleKnuckleY = landmarks[10].y;
 
-    const thumbX = landmarks[4].x;
-    const thumbBaseX = landmarks[2].x;
+  const thumbX = landmarks[4].x;
+  const thumbBaseX = landmarks[2].x;
 
-    let detectedAction = "No Action / Neutral";
+  let detectedAction = 'No Action / Neutral';
 
-    // 1. GESTURE: Move UP (Only Index finger extended upright)
-    if (indexTipY < indexKnuckleY && middleTipY > middleKnuckleY) {
-        detectedAction = "ArrowUp";
-        triggerSyntheticKey("ArrowUp");
-    }
-    // 2. GESTURE: Move DOWN (Index and Middle both extended upright)
-    else if (indexTipY < indexKnuckleY && middleTipY < middleKnuckleY) {
-        detectedAction = "ArrowDown";
-        triggerSyntheticKey("ArrowDown");
-    }
-    // 3. GESTURE: Move LEFT (Thumb extended widely outward horizontally)
-    else if (Math.abs(thumbX - thumbBaseX) > 0.1 && indexTipY > indexKnuckleY) {
-        detectedAction = "ArrowLeft";
-        triggerSyntheticKey("ArrowLeft");
-    }
+  // Arrow Up
+  if (indexTipY < indexKnuckleY && middleTipY > middleKnuckleY) {
+    detectedAction = 'ArrowUp';
+  }
 
-    gestureStatus.textContent = detectedAction;
+  // Arrow Down
+  else if (indexTipY < indexKnuckleY && middleTipY < middleKnuckleY) {
+    detectedAction = 'ArrowDown';
+  }
+
+  // Arrow Left
+  else if (Math.abs(thumbX - thumbBaseX) > 0.1 && indexTipY > indexKnuckleY) {
+    detectedAction = 'ArrowLeft';
+  }
+
+  gestureStatus.textContent = detectedAction;
+
+  // ==================================================
+  // FIRE ONLY WHEN GESTURE CHANGES
+  // ==================================================
+  if (
+    detectedAction !== 'No Action / Neutral' &&
+    (gestureReleased || detectedAction !== lastDetectedGesture)
+  ) {
+    triggerSyntheticKey(detectedAction);
+
+    lastDetectedGesture = detectedAction;
+    gestureReleased = false;
+  }
+
+  // Reset state when hand returns to neutral
+  if (detectedAction === 'No Action / Neutral') {
+    gestureReleased = true;
+    lastDetectedGesture = detectedAction;
+  }
 }
 
 // ========================================================
 // SYNTHETIC BROWSER KEYBOARD INJECTION PIPELINE
 // ========================================================
 let lastTriggerTime = 0;
-const throttleDelay = 200; // Limits events to once every 200ms to prevent game flooding
+const throttleDelay = 200;
+
+// Track gesture state to prevent repeated firing
+let lastDetectedGesture = 'No Action / Neutral';
+let gestureReleased = true; // Limits events to once every 200ms to prevent game flooding
 
 function triggerSyntheticKey(keyCode) {
-    const now = performance.now();
-    if (now - lastTriggerTime < throttleDelay) return;
-    lastTriggerTime = now;
+  const now = performance.now();
+  if (now - lastTriggerTime < throttleDelay) return;
+  lastTriggerTime = now;
 
-    logKeystroke(`Dispatched Virtual Key: ${keyCode}`);
+  logKeystroke(`Dispatched Virtual Key: ${keyCode}`);
 
-    // Create and dispatch the "keydown" structural event natively
-    const keydownEvent = new KeyboardEvent('keydown', {
-        key: keyCode,
-        code: keyCode,
-        bubbles: true,
-        cancelable: true
+  // Create and dispatch the "keydown" structural event natively
+  const keydownEvent = new KeyboardEvent('keydown', {
+    key: keyCode,
+    code: keyCode,
+    bubbles: true,
+    cancelable: true,
+  });
+  window.dispatchEvent(keydownEvent);
+
+  // Instantly fire the trailing "keyup" event to reset state
+  setTimeout(() => {
+    const keyupEvent = new KeyboardEvent('keyup', {
+      key: keyCode,
+      code: keyCode,
+      bubbles: true,
+      cancelable: true,
     });
-    window.dispatchEvent(keydownEvent);
-
-    // Instantly fire the trailing "keyup" event to reset state
-    setTimeout(() => {
-        const keyupEvent = new KeyboardEvent('keyup', {
-            key: keyCode,
-            code: keyCode,
-            bubbles: true,
-            cancelable: true
-        });
-        window.dispatchEvent(keyupEvent);
-    }, 50);
+    window.dispatchEvent(keyupEvent);
+  }, 50);
 }
 
 // ========================================================
 // MEDIAPIPE PIPELINE SETUP & INTERFACE RENDERING
 // ========================================================
 function onResults(results) {
-    canvasCtx.clearRect(0, 0, canvasElement.width, canvasElement.height);
+  canvasCtx.clearRect(0, 0, canvasElement.width, canvasElement.height);
 
-    if (results.multiHandLandmarks && results.multiHandLandmarks.length > 0) {
-        const handLandmarks = results.multiHandLandmarks[0];
+  if (results.multiHandLandmarks && results.multiHandLandmarks.length > 0) {
+    const handLandmarks = results.multiHandLandmarks[0];
 
-        // Draw visual landmark coordinates on the debugging overlay canvas
-        for (const landmark of handLandmarks) {
-            canvasCtx.beginPath();
-            canvasCtx.arc(landmark.x * canvasElement.width, landmark.y * canvasElement.height, 4, 0, 2 * Math.PI);
-            canvasCtx.fillStyle = '#00ffaa';
-            canvasCtx.fill();
-        }
-
-        // Run gesture evaluation metrics against the extracted landmark matrix array
-        evaluateGestures(handLandmarks);
-    } else {
-        gestureStatus.textContent = "No Hand Detected";
+    // Draw visual landmark coordinates on the debugging overlay canvas
+    for (const landmark of handLandmarks) {
+      canvasCtx.beginPath();
+      canvasCtx.arc(
+        landmark.x * canvasElement.width,
+        landmark.y * canvasElement.height,
+        4,
+        0,
+        2 * Math.PI
+      );
+      canvasCtx.fillStyle = '#00ffaa';
+      canvasCtx.fill();
     }
+
+    // Run gesture evaluation metrics against the extracted landmark matrix array
+    evaluateGestures(handLandmarks);
+  } else {
+    gestureStatus.textContent = 'No Hand Detected';
+
+    gestureReleased = true;
+    lastDetectedGesture = 'No Action / Neutral';
+  }
 }
 
 const hands = new Hands({
-    locateFile: (file) => `https://cdn.jsdelivr.net/npm/@mediapipe/hands/${file}`
+  locateFile: (file) => `https://cdn.jsdelivr.net/npm/@mediapipe/hands/${file}`,
 });
 
 hands.setOptions({
-    maxNumHands: 1,
-    modelComplexity: 1,
-    minDetectionConfidence: 0.5,
-    minTrackingConfidence: 0.5
+  maxNumHands: 1,
+  modelComplexity: 1,
+  minDetectionConfidence: 0.5,
+  minTrackingConfidence: 0.5,
 });
 hands.onResults(onResults);
 
 // Initialize background hardware camera listener pipeline loop
 const camera = new Camera(videoElement, {
-    onFrame: async () => {
-        await hands.send({ image: videoElement });
-    },
-    width: 400,
-    height: 300
+  onFrame: async () => {
+    await hands.send({ image: videoElement });
+  },
+  width: 400,
+  height: 300,
 });
 camera.start();

--- a/public/hand-gesture-controller/index.html
+++ b/public/hand-gesture-controller/index.html
@@ -1,85 +1,91 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>HCI Hand-Gesture Controller Overlay</title>
     <style>
-        body {
-            background: #0f172a;
-            color: #f8fafc;
-            font-family: monospace;
-            padding: 20px;
-            text-align: center;
-        }
+      body {
+        background: #0f172a;
+        color: #f8fafc;
+        font-family: monospace;
+        padding: 20px;
+        text-align: center;
+      }
 
-        #video-container {
-            position: relative;
-            width: 400px;
-            height: 300px;
-            margin: 15px auto;
-            border: 2px solid #334155;
-            border-radius: 8px;
-            overflow: hidden;
-        }
+      #video-container {
+        position: relative;
+        width: 400px;
+        height: 300px;
+        margin: 15px auto;
+        border: 2px solid #334155;
+        border-radius: 8px;
+        overflow: hidden;
+      }
 
-        video,
-        canvas {
-            position: absolute;
-            top: 0;
-            left: 0;
-            transform: scaleX(-1);
-            /* Mirror view for natural interaction */
-        }
+      video,
+      canvas {
+        position: absolute;
+        top: 0;
+        left: 0;
+        transform: scaleX(-1);
+        /* Mirror view for natural interaction */
+      }
 
-        .status-panel {
-            background: #1e293b;
-            padding: 12px;
-            border-radius: 6px;
-            width: 380px;
-            margin: 10px auto;
-            font-size: 12px;
-            border: 1px solid #00ffaa;
-        }
+      .status-panel {
+        background: #1e293b;
+        padding: 12px;
+        border-radius: 6px;
+        width: 380px;
+        margin: 10px auto;
+        font-size: 12px;
+        border: 1px solid #00ffaa;
+      }
 
-        .log-box {
-            width: 380px;
-            height: 100px;
-            background: #020617;
-            margin: 10px auto;
-            padding: 10px;
-            overflow-y: auto;
-            border-radius: 4px;
-            text-align: left;
-            font-size: 11px;
-            color: #8899a6;
-        }
+      .log-box {
+        width: 380px;
+        height: 100px;
+        background: #020617;
+        margin: 10px auto;
+        padding: 10px;
+        overflow-y: auto;
+        border-radius: 4px;
+        text-align: left;
+        font-size: 11px;
+        color: #8899a6;
+      }
     </style>
 
-    <script src="https://cdn.jsdelivr.net/npm/@mediapipe/camera_utils/camera_utils.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands.js" crossorigin="anonymous"></script>
-</head>
+    <script
+      src="https://cdn.jsdelivr.net/npm/@mediapipe/camera_utils/camera_utils.js"
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/@mediapipe/hands/hands.js"
+      crossorigin="anonymous"
+    ></script>
+  </head>
 
-<body>
-
-    <h2 style="color: #00ffaa;">✋ HCI Hand-Gesture Controller Framework</h2>
-    <p style="font-size: 11px; color: #94a3b8;">Maps physical hand configurations to synthetic browser KeyboardEvents.
+  <body>
+    <h2 style="color: #00ffaa">✋ HCI Hand-Gesture Controller Framework</h2>
+    <p style="font-size: 11px; color: #94a3b8">
+      Maps physical hand configurations to synthetic browser KeyboardEvents.
     </p>
 
     <div id="video-container">
-        <video id="webcam" width="400" height="300" autoplay playsinline></video>
-        <canvas id="output-canvas" width="400" height="300"></canvas>
+      <video id="webcam" width="400" height="300" autoplay playsinline></video>
+      <canvas id="output-canvas" width="400" height="300"></canvas>
     </div>
 
     <div class="status-panel">
-        <strong>Active Native Mapping Status:</strong> <span id="current-gesture"
-            style="color: #fff; font-weight: bold;">Detecting...</span>
+      <strong>Active Native Mapping Status:</strong>
+      <span id="current-gesture" style="color: #fff; font-weight: bold"
+        >Detecting...</span
+      >
     </div>
 
     <div class="log-box" id="event-log"></div>
 
     <script src="gesture-engine.js"></script>
-</body>
-
+  </body>
 </html>


### PR DESCRIPTION

### Related Issue
Closes #9506

### Problem

The gesture controller continuously dispatched keyboard events while the same gesture remained visible.

Although a throttle existed, the same action was still triggered every 200ms, causing:

- Repeated unintended inputs
- Poor control precision
- Input flooding in games and interactive applications

### Root Cause

The gesture engine throttled events but did not track gesture state.

As a result, every processed frame re-triggered the same action.

### Changes Made

- Added gesture state tracking.
- Added gesture release detection.
- Trigger keyboard events only when:
  - a new gesture appears, or
  - the user returns to a neutral state and performs the gesture again.
- Reset gesture state when no hand is detected.

### Result

Before:

ArrowUp → ArrowUp → ArrowUp → ArrowUp ...

After:

ArrowUp

(held gesture generates no additional events)

### Testing

- [x] ArrowUp fires once per gesture.
- [x] ArrowDown fires once per gesture.
- [x] ArrowLeft fires once per gesture.
- [x] Re-trigger works after returning to neutral.
- [x] No-hand state resets gesture tracking.

Closes #9506