### PR TITLE
fix: allow repeated casting of reducto spell

### DIFF
--- a/public/Harry-Potter/index.html
+++ b/public/Harry-Potter/index.html
@@ -1,39 +1,50 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Interactive Wizarding World</title>
-    <link rel="stylesheet" href="style.css">
-</head>
-<body>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
     <div class="container" id="main-container">
-        <h1>Interactive Wizarding World</h1>
+      <h1>Interactive Wizarding World</h1>
 
-        <section class="spell-caster">
-            <h2>✨ Spell Caster</h2>
-            <p>Type a spell to change the UI: <strong>Lumos</strong> (Light), <strong>Nox</strong> (Dark), <strong>Reducto</strong> (Shake)</p>
-            <input type="text" id="spell-input" placeholder="Cast a spell..." autocomplete="off">
-        </section>
+      <section class="spell-caster">
+        <h2>✨ Spell Caster</h2>
+        <p>
+          Type a spell to change the UI: <strong>Lumos</strong> (Light),
+          <strong>Nox</strong> (Dark), <strong>Reducto</strong> (Shake)
+        </p>
+        <input
+          type="text"
+          id="spell-input"
+          placeholder="Cast a spell..."
+          autocomplete="off"
+        />
+      </section>
 
-        <section class="character-search">
-            <h2>🏰 House Sorter & Roster</h2>
-            <div class="filters">
-                <select id="house-filter">
-                    <option value="">All Houses</option>
-                    <option value="Gryffindor">Gryffindor</option>
-                    <option value="Slytherin">Slytherin</option>
-                    <option value="Hufflepuff">Hufflepuff</option>
-                    <option value="Ravenclaw">Ravenclaw</option>
-                </select>
-                <input type="text" id="char-search" placeholder="Search character by name...">
-            </div>
-            
-            <div id="character-list" class="character-grid">
-                </div>
-        </section>
+      <section class="character-search">
+        <h2>🏰 House Sorter & Roster</h2>
+        <div class="filters">
+          <select id="house-filter">
+            <option value="">All Houses</option>
+            <option value="Gryffindor">Gryffindor</option>
+            <option value="Slytherin">Slytherin</option>
+            <option value="Hufflepuff">Hufflepuff</option>
+            <option value="Ravenclaw">Ravenclaw</option>
+          </select>
+          <input
+            type="text"
+            id="char-search"
+            placeholder="Search character by name..."
+          />
+        </div>
+
+        <div id="character-list" class="character-grid"></div>
+      </section>
     </div>
 
     <script src="script.js"></script>
-</body>
+  </body>
 </html>

--- a/public/Harry-Potter/script.js
+++ b/public/Harry-Potter/script.js
@@ -4,69 +4,79 @@ const charSearch = document.getElementById('char-search');
 const characterList = document.getElementById('character-list');
 const mainContainer = document.getElementById('main-container');
 
+mainContainer.addEventListener('animationend', (event) => {
+  if (event.animationName === 'shake') {
+    mainContainer.classList.remove('reducto-shake');
+  }
+});
+
 let characters = [];
 
 // Fetch Characters from API
 async function fetchCharacters() {
-    try {
-        const response = await fetch('https://hp-api.onrender.com/api/characters');
-        characters = await response.json();
-        const charactersWithImages = characters.filter(char => char.image !== "").slice(0, 30);
-        displayCharacters(charactersWithImages);
-    } catch (error) {
-        console.error("Error fetching characters:", error);
-        characterList.innerHTML = '<p>Failed to load wizarding data.</p>';
-    }
+  try {
+    const response = await fetch('https://hp-api.onrender.com/api/characters');
+    characters = await response.json();
+    const charactersWithImages = characters
+      .filter((char) => char.image !== '')
+      .slice(0, 30);
+    displayCharacters(charactersWithImages);
+  } catch (error) {
+    console.error('Error fetching characters:', error);
+    characterList.innerHTML = '<p>Failed to load wizarding data.</p>';
+  }
 }
 
 // Render Character Cards
 function displayCharacters(chars) {
-    characterList.innerHTML = '';
-    
-    if (chars.length === 0) {
-        characterList.innerHTML = '<p>No characters found.</p>';
-        return;
-    }
+  characterList.innerHTML = '';
 
-    chars.forEach(char => {
-        const card = document.createElement('div');
-        card.classList.add('card');
-        card.innerHTML = `
+  if (chars.length === 0) {
+    characterList.innerHTML = '<p>No characters found.</p>';
+    return;
+  }
+
+  chars.forEach((char) => {
+    const card = document.createElement('div');
+    card.classList.add('card');
+    card.innerHTML = `
             <img src="${char.image}" alt="${char.name}" onerror="this.style.display='none'">
             <h3>${char.name}</h3>
             <p><strong>House:</strong> ${char.house || 'Unknown'}</p>
         `;
-        characterList.appendChild(card);
-    });
+    characterList.appendChild(card);
+  });
 }
 
 function applyFilters() {
-    const searchTerm = charSearch.value.toLowerCase();
-    const selectedHouse = houseFilter.value;
+  const searchTerm = charSearch.value.toLowerCase();
+  const selectedHouse = houseFilter.value;
 
-    const filteredChars = characters.filter(char => {
-        const matchesName = char.name.toLowerCase().includes(searchTerm);
-        const matchesHouse = selectedHouse === "" || char.house === selectedHouse;
-        return matchesName && matchesHouse && char.image !== ""; 
-    });
+  const filteredChars = characters.filter((char) => {
+    const matchesName = char.name.toLowerCase().includes(searchTerm);
+    const matchesHouse = selectedHouse === '' || char.house === selectedHouse;
+    return matchesName && matchesHouse && char.image !== '';
+  });
 
-    displayCharacters(filteredChars);
+  displayCharacters(filteredChars);
 }
 
 spellInput.addEventListener('input', (e) => {
-    const spell = e.target.value.trim().toLowerCase();
+  const spell = e.target.value.trim().toLowerCase();
 
+  mainContainer.classList.remove('reducto-shake');
+
+  if (spell === 'lumos') {
+    document.body.classList.add('lumos-mode');
+  } else if (spell === 'nox') {
+    document.body.classList.remove('lumos-mode');
+  } else if (spell === 'reducto') {
     mainContainer.classList.remove('reducto-shake');
 
-    if (spell === 'lumos') {
-        document.body.classList.add('lumos-mode');
-    } else if (spell === 'nox') {
-        document.body.classList.remove('lumos-mode');
-    } else if (spell === 'reducto') {
-        setTimeout(() => {
-            mainContainer.classList.add('reducto-shake');
-        }, 10);
-    }
+    void mainContainer.offsetWidth;
+
+    mainContainer.classList.add('reducto-shake');
+  }
 });
 
 houseFilter.addEventListener('change', applyFilters);

--- a/public/Harry-Potter/style.css
+++ b/public/Harry-Potter/style.css
@@ -1,111 +1,134 @@
 /* Base Styles (Nox / Dark Mode by default) */
 body {
-    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    background-color: #121212;
-    color: #e0e0e0;
-    transition: background-color 0.5s ease, color 0.5s ease, text-shadow 0.5s ease;
-    margin: 0;
-    padding: 20px;
-    display: flex;
-    justify-content: center;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  background-color: #121212;
+  color: #e0e0e0;
+  transition:
+    background-color 0.5s ease,
+    color 0.5s ease,
+    text-shadow 0.5s ease;
+  margin: 0;
+  padding: 20px;
+  display: flex;
+  justify-content: center;
 }
 
 .container {
-    max-width: 900px;
-    width: 100%;
+  max-width: 900px;
+  width: 100%;
 }
 
-h1, h2 {
-    text-align: center;
-    border-bottom: 2px solid rgba(255, 255, 255, 0.1);
-    padding-bottom: 10px;
+h1,
+h2 {
+  text-align: center;
+  border-bottom: 2px solid rgba(255, 255, 255, 0.1);
+  padding-bottom: 10px;
 }
 
 /* Lumos State (Light Mode / Glow) */
 body.lumos-mode {
-    background-color: #fdf6e3;
-    color: #2c3e50;
-    text-shadow: 0 0 15px rgba(241, 196, 15, 0.6);
+  background-color: #fdf6e3;
+  color: #2c3e50;
+  text-shadow: 0 0 15px rgba(241, 196, 15, 0.6);
 }
 
-body.lumos-mode h1, body.lumos-mode h2 {
-    border-bottom: 2px solid rgba(0, 0, 0, 0.1);
+body.lumos-mode h1,
+body.lumos-mode h2 {
+  border-bottom: 2px solid rgba(0, 0, 0, 0.1);
 }
 
 /* Reducto State (Shake Animation) */
 .reducto-shake {
-    animation: shake 0.5s cubic-bezier(.36,.07,.19,.97) both;
+  animation: shake 0.5s cubic-bezier(0.36, 0.07, 0.19, 0.97) both;
 }
 
 @keyframes shake {
-    10%, 90% { transform: translate3d(-2px, 0, 0); }
-    20%, 80% { transform: translate3d(4px, 0, 0); }
-    30%, 50%, 70% { transform: translate3d(-8px, 0, 0); }
-    40%, 60% { transform: translate3d(8px, 0, 0); }
+  10%,
+  90% {
+    transform: translate3d(-2px, 0, 0);
+  }
+  20%,
+  80% {
+    transform: translate3d(4px, 0, 0);
+  }
+  30%,
+  50%,
+  70% {
+    transform: translate3d(-8px, 0, 0);
+  }
+  40%,
+  60% {
+    transform: translate3d(8px, 0, 0);
+  }
 }
 
-.spell-caster, .filters {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin-bottom: 30px;
+.spell-caster,
+.filters {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-bottom: 30px;
 }
 
 .filters {
-    flex-direction: row;
-    justify-content: center;
-    gap: 15px;
+  flex-direction: row;
+  justify-content: center;
+  gap: 15px;
 }
 
-input, select {
-    padding: 12px;
-    font-size: 16px;
-    border-radius: 8px;
-    border: 1px solid #555;
-    background-color: #2a2a2a;
-    color: #fff;
-    outline: none;
-    width: 100%;
-    max-width: 400px;
-    transition: all 0.3s ease;
+input,
+select {
+  padding: 12px;
+  font-size: 16px;
+  border-radius: 8px;
+  border: 1px solid #555;
+  background-color: #2a2a2a;
+  color: #fff;
+  outline: none;
+  width: 100%;
+  max-width: 400px;
+  transition: all 0.3s ease;
 }
 
-body.lumos-mode input, body.lumos-mode select {
-    background-color: #fff;
-    color: #333;
-    border: 1px solid #ccc;
-    box-shadow: 0 0 10px rgba(241, 196, 15, 0.3);
+body.lumos-mode input,
+body.lumos-mode select {
+  background-color: #fff;
+  color: #333;
+  border: 1px solid #ccc;
+  box-shadow: 0 0 10px rgba(241, 196, 15, 0.3);
 }
 
 .character-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-    gap: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 20px;
 }
 
 .card {
-    background: #1e1e1e;
-    padding: 20px;
-    border-radius: 10px;
-    border: 1px solid #333;
-    text-align: center;
-    transition: transform 0.2s ease, background 0.5s ease;
+  background: #1e1e1e;
+  padding: 20px;
+  border-radius: 10px;
+  border: 1px solid #333;
+  text-align: center;
+  transition:
+    transform 0.2s ease,
+    background 0.5s ease;
 }
 
 .card img {
-    width: 100px;
-    height: 140px;
-    object-fit: cover;
-    border-radius: 8px;
-    margin-bottom: 15px;
+  width: 100px;
+  height: 140px;
+  object-fit: cover;
+  border-radius: 8px;
+  margin-bottom: 15px;
 }
 
 .card:hover {
-    transform: translateY(-5px);
+  transform: translateY(-5px);
 }
 
 body.lumos-mode .card {
-    background: #fff;
-    border: 1px solid #ddd;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+  background: #fff;
+  border: 1px solid #ddd;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
 }


### PR DESCRIPTION

### Related Issue
Closes #9508

### Problem

The Reducto spell animation only played reliably the first time it was cast. The `reducto-shake` class remained attached after the animation completed, preventing consistent re-triggering of the same animation.

### Changes Made

- Added an `animationend` listener to remove the `reducto-shake` class after the shake animation completes.
- Added forced reflow using `offsetWidth` before reapplying the animation class.
- Ensured the shake animation can be restarted every time the Reducto spell is cast.

### Result

Before:
- First cast triggered the animation.
- Subsequent casts could fail to replay the shake effect.

After:
- Every Reducto cast reliably restarts the shake animation.
- No page refresh is required.

### Testing

- [x] First Reducto cast triggers animation.
- [x] Consecutive Reducto casts trigger animation repeatedly.
- [x] Lumos and Nox functionality remain unchanged.
- [x] No console errors introduced.

Closes #9508