### PR TITLE
fix: prevent duplicate activations during hologram loading state

### DIFF
--- a/public/Holo Button/index.html
+++ b/public/Holo Button/index.html
@@ -1,60 +1,112 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="style.css">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="style.css" />
     <script defer type="module" src="main.js"></script>
     <link rel="icon" href="../favv.png" type="image/x-icon" />
     <title>Hologram Button</title>
-</head>
-<body>
-<a href="/" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 16px;border-radius:8px;background:#1e293b;color:#3b82f6;border:1px solid #3b82f6;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;transition:all 0.2s ease;" onmouseover="this.style.background='#3b82f6';this.style.color='#fff'" onmouseout="this.style.background='#1e293b';this.style.color='#3b82f6'">← Back to Home</a>
+  </head>
+  <body>
+    <a
+      href="/"
+      class="project-back-button"
+      style="
+        position: fixed;
+        left: 18px;
+        top: 18px;
+        padding: 8px 16px;
+        border-radius: 8px;
+        background: #1e293b;
+        color: #3b82f6;
+        border: 1px solid #3b82f6;
+        text-decoration: none;
+        z-index: 9999;
+        font-weight: 700;
+        font-family: Inter, system-ui, sans-serif;
+        transition: all 0.2s ease;
+      "
+      onmouseover="
+        this.style.background = '#3b82f6';
+        this.style.color = '#fff';
+      "
+      onmouseout="
+        this.style.background = '#1e293b';
+        this.style.color = '#3b82f6';
+      "
+      >← Back to Home</a
+    >
 
-    <div id='container'>
-        <div class="animated-image-bg"></div>
+    <div id="container">
+      <div class="animated-image-bg"></div>
 
-        <canvas id="canvas3d"></canvas>
+      <canvas id="canvas3d"></canvas>
 
-        <main class="holo-interface" aria-labelledby="holo-title">
-            <section class="status-panel" aria-live="polite">
-                <p class="eyebrow">Interactive UI Component</p>
-                <h1 id="holo-title">Hologram Button</h1>
-                <p id="statusText">Standby mode. Choose a theme or activate the assistant.</p>
-            </section>
+      <main class="holo-interface" aria-labelledby="holo-title">
+        <section class="status-panel" aria-live="polite">
+          <p class="eyebrow">Interactive UI Component</p>
+          <h1 id="holo-title">Hologram Button</h1>
+          <p id="statusText">
+            Standby mode. Choose a theme or activate the assistant.
+          </p>
+        </section>
 
+        <button
+          class="holo-button"
+          id="holoButton"
+          type="button"
+          data-action="activate-assistant"
+          aria-describedby="statusText"
+        >
+          <span class="button-ring"></span>
+          <span class="button-core">
+            <span class="button-label">Activate AI</span>
+            <span class="button-subtext">Ready</span>
+          </span>
+        </button>
+
+        <section class="controls" aria-label="Hologram button controls">
+          <div class="theme-switcher" role="group" aria-label="Theme color">
             <button
-                class="holo-button"
-                id="holoButton"
-                type="button"
-                data-action="activate-assistant"
-                aria-describedby="statusText"
-            >
-                <span class="button-ring"></span>
-                <span class="button-core">
-                    <span class="button-label">Activate AI</span>
-                    <span class="button-subtext">Ready</span>
-                </span>
-            </button>
+              type="button"
+              class="theme-option is-active"
+              data-theme="cyan"
+              aria-label="Use cyan theme"
+            ></button>
+            <button
+              type="button"
+              class="theme-option"
+              data-theme="violet"
+              aria-label="Use violet theme"
+            ></button>
+            <button
+              type="button"
+              class="theme-option"
+              data-theme="amber"
+              aria-label="Use amber theme"
+            ></button>
+          </div>
 
-            <section class="controls" aria-label="Hologram button controls">
-                <div class="theme-switcher" role="group" aria-label="Theme color">
-                    <button type="button" class="theme-option is-active" data-theme="cyan" aria-label="Use cyan theme"></button>
-                    <button type="button" class="theme-option" data-theme="violet" aria-label="Use violet theme"></button>
-                    <button type="button" class="theme-option" data-theme="amber" aria-label="Use amber theme"></button>
-                </div>
+          <button type="button" class="utility-button" id="demoAction">
+            Run Demo Action
+          </button>
+          <button type="button" class="utility-button" id="navigationDemo">
+            Navigation Demo
+          </button>
+        </section>
+      </main>
 
-                <button type="button" class="utility-button" id="demoAction">Run Demo Action</button>
-                <button type="button" class="utility-button" id="navigationDemo">Navigation Demo</button>
-            </section>
-        </main>
-
-        <div class="toast" id="toast" role="status" aria-live="polite" aria-atomic="true">
-            <span class="toast-icon" aria-hidden="true"></span>
-            <span id="toastMessage">Action complete.</span>
-        </div>
+      <div
+        class="toast"
+        id="toast"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        <span class="toast-icon" aria-hidden="true"></span>
+        <span id="toastMessage">Action complete.</span>
       </div>
-      
-      
-</body>
+    </div>
+  </body>
 </html>

--- a/public/Holo Button/main.js
+++ b/public/Holo Button/main.js
@@ -1,4 +1,4 @@
-const fileName = "4SvKgmIrnw7KodjP";
+const fileName = '4SvKgmIrnw7KodjP';
 const canvas = document.getElementById('canvas3d');
 const holoButton = document.getElementById('holoButton');
 const statusText = document.getElementById('statusText');
@@ -8,13 +8,14 @@ const toast = document.getElementById('toast');
 const toastMessage = document.getElementById('toastMessage');
 const themeButtons = document.querySelectorAll('.theme-option');
 let toastTimer;
+let isProcessing = false;
 
 const messages = {
   standby: 'Standby mode. Choose a theme or activate the assistant.',
   hover: 'Target locked. Click to run the hologram action.',
   loading: 'Initializing secure hologram channel...',
   active: 'AI assistant activated. This button can now trigger app logic.',
-  demo: 'Demo action complete: notification, loading state, and callback fired.'
+  demo: 'Demo action complete: notification, loading state, and callback fired.',
 };
 
 async function loadSplineScene() {
@@ -24,7 +25,10 @@ async function loadSplineScene() {
     await app.load(`https://prod.spline.design/${fileName}/scene.splinecode`);
   } catch (error) {
     canvas.hidden = true;
-    console.warn('Spline scene could not be loaded. The button UI is still available.', error);
+    console.warn(
+      'Spline scene could not be loaded. The button UI is still available.',
+      error
+    );
   }
 }
 
@@ -41,10 +45,16 @@ function playFeedbackTone() {
 
   oscillator.type = 'sine';
   oscillator.frequency.setValueAtTime(440, audioContext.currentTime);
-  oscillator.frequency.exponentialRampToValueAtTime(880, audioContext.currentTime + 0.12);
+  oscillator.frequency.exponentialRampToValueAtTime(
+    880,
+    audioContext.currentTime + 0.12
+  );
   gain.gain.setValueAtTime(0.001, audioContext.currentTime);
   gain.gain.exponentialRampToValueAtTime(0.18, audioContext.currentTime + 0.02);
-  gain.gain.exponentialRampToValueAtTime(0.001, audioContext.currentTime + 0.18);
+  gain.gain.exponentialRampToValueAtTime(
+    0.001,
+    audioContext.currentTime + 0.18
+  );
 
   oscillator.connect(gain);
   gain.connect(audioContext.destination);
@@ -55,7 +65,8 @@ function playFeedbackTone() {
 function setButtonState(state, message) {
   holoButton.classList.toggle('is-loading', state === 'loading');
   holoButton.classList.toggle('is-active', state === 'active');
-  holoButton.querySelector('.button-subtext').textContent = state === 'loading' ? 'Syncing' : state;
+  holoButton.querySelector('.button-subtext').textContent =
+    state === 'loading' ? 'Syncing' : state;
   statusText.textContent = message;
 }
 
@@ -69,20 +80,36 @@ function showToast(message) {
   }, 3200);
 }
 
-function triggerHologramAction(message = messages.active, toastText = 'AI assistant activated successfully.') {
+function triggerHologramAction(
+  message = messages.active,
+  toastText = 'AI assistant activated successfully.'
+) {
+  if (isProcessing) return;
+
+  isProcessing = true;
+
+  holoButton.disabled = true;
+
   playFeedbackTone();
   setButtonState('loading', messages.loading);
 
   window.setTimeout(() => {
     setButtonState('active', message);
+
     showToast(toastText);
-    holoButton.dispatchEvent(new CustomEvent('hologram:activated', {
-      bubbles: true,
-      detail: {
-        action: holoButton.dataset.action,
-        theme: document.body.dataset.theme || 'cyan'
-      }
-    }));
+
+    holoButton.dispatchEvent(
+      new CustomEvent('hologram:activated', {
+        bubbles: true,
+        detail: {
+          action: holoButton.dataset.action,
+          theme: document.body.dataset.theme || 'cyan',
+        },
+      })
+    );
+
+    isProcessing = false;
+    holoButton.disabled = false;
   }, 900);
 }
 
@@ -104,22 +131,28 @@ holoButton.addEventListener('click', () => triggerHologramAction());
 
 demoAction.addEventListener('click', () => {
   holoButton.dataset.action = 'demo-notification';
-  triggerHologramAction(messages.demo, 'Demo action completed. Event callback fired.');
+  triggerHologramAction(
+    messages.demo,
+    'Demo action completed. Event callback fired.'
+  );
 });
 
 navigationDemo.addEventListener('click', () => {
-  const message = 'Navigation module opened. Connect this action to a route or menu in your app.';
+  const message =
+    'Navigation module opened. Connect this action to a route or menu in your app.';
   holoButton.dataset.action = 'open-navigation';
   statusText.textContent = message;
   showToast('Navigation demo triggered. No page redirect needed.');
 
-  holoButton.dispatchEvent(new CustomEvent('hologram:activated', {
-    bubbles: true,
-    detail: {
-      action: holoButton.dataset.action,
-      theme: document.body.dataset.theme || 'cyan'
-    }
-  }));
+  holoButton.dispatchEvent(
+    new CustomEvent('hologram:activated', {
+      bubbles: true,
+      detail: {
+        action: holoButton.dataset.action,
+        theme: document.body.dataset.theme || 'cyan',
+      },
+    })
+  );
 });
 
 themeButtons.forEach((button) => {

--- a/public/Holo Button/style.css
+++ b/public/Holo Button/style.css
@@ -18,16 +18,23 @@ body {
   overflow-y: auto;
   background-color: #071014;
   color: var(--text);
-  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
 }
 
-body[data-theme="violet"] {
+body[data-theme='violet'] {
   --accent: #b46cff;
   --accent-strong: #e3c3ff;
   --accent-soft: rgba(180, 108, 255, 0.2);
 }
 
-body[data-theme="amber"] {
+body[data-theme='amber'] {
   --accent: #ffcc4d;
   --accent-strong: #ffe7a3;
   --accent-soft: rgba(255, 204, 77, 0.2);
@@ -58,7 +65,11 @@ body[data-theme="amber"] {
   width: 100%;
   height: 100%;
   background:
-    radial-gradient(circle at center, rgba(255, 255, 255, 0.08), transparent 38%),
+    radial-gradient(
+      circle at center,
+      rgba(255, 255, 255, 0.08),
+      transparent 38%
+    ),
     url('circle.png') repeat,
     #071014;
   background-size: 200px 200px;
@@ -138,6 +149,11 @@ body[data-theme="amber"] {
   filter: drop-shadow(0 0 32px var(--accent-soft));
 }
 
+.holo-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
 .button-ring,
 .button-core {
   position: absolute;
@@ -148,13 +164,27 @@ body[data-theme="amber"] {
   inset: 0;
   border: 2px solid var(--accent);
   background:
-    radial-gradient(circle, transparent 46%, var(--accent-soft) 47%, transparent 68%),
-    conic-gradient(from 0deg, transparent, var(--accent), transparent 34%, var(--accent-strong), transparent);
+    radial-gradient(
+      circle,
+      transparent 46%,
+      var(--accent-soft) 47%,
+      transparent 68%
+    ),
+    conic-gradient(
+      from 0deg,
+      transparent,
+      var(--accent),
+      transparent 34%,
+      var(--accent-strong),
+      transparent
+    );
   box-shadow:
     0 0 38px var(--accent-soft),
     inset 0 0 28px var(--accent-soft);
   animation: spin 7s linear infinite;
-  transition: transform 220ms ease, box-shadow 220ms ease;
+  transition:
+    transform 220ms ease,
+    box-shadow 220ms ease;
 }
 
 .button-core {
@@ -164,7 +194,12 @@ body[data-theme="amber"] {
   align-content: center;
   gap: 4px;
   border: 1px solid rgba(255, 255, 255, 0.28);
-  background: radial-gradient(circle at 50% 24%, rgba(255, 255, 255, 0.34), var(--accent-soft) 42%, rgba(2, 8, 12, 0.92));
+  background: radial-gradient(
+    circle at 50% 24%,
+    rgba(255, 255, 255, 0.34),
+    var(--accent-soft) 42%,
+    rgba(2, 8, 12, 0.92)
+  );
   box-shadow: inset 0 0 28px rgba(255, 255, 255, 0.12);
 }
 
@@ -234,15 +269,15 @@ body[data-theme="amber"] {
   cursor: pointer;
 }
 
-.theme-option[data-theme="cyan"] {
+.theme-option[data-theme='cyan'] {
   background: #34f5ff;
 }
 
-.theme-option[data-theme="violet"] {
+.theme-option[data-theme='violet'] {
   background: #b46cff;
 }
 
-.theme-option[data-theme="amber"] {
+.theme-option[data-theme='amber'] {
   background: #ffcc4d;
 }
 
@@ -263,7 +298,10 @@ body[data-theme="amber"] {
   font-weight: 700;
   text-decoration: none;
   cursor: pointer;
-  transition: border-color 180ms ease, transform 180ms ease, background 180ms ease;
+  transition:
+    border-color 180ms ease,
+    transform 180ms ease,
+    background 180ms ease;
 }
 
 .utility-button:hover {
@@ -293,7 +331,9 @@ body[data-theme="amber"] {
   opacity: 0;
   pointer-events: none;
   translate: 0 16px;
-  transition: opacity 180ms ease, translate 180ms ease;
+  transition:
+    opacity 180ms ease,
+    translate 180ms ease;
 }
 
 .toast.is-visible {


### PR DESCRIPTION

### Related Issue
Closes #9509

### Problem

Rapid clicks on the hologram button created multiple pending activation timers.

This caused:

- Duplicate `hologram:activated` events
- Multiple toast notifications
- Repeated audio playback
- Overlapping UI state transitions

### Root Cause

The activation handler did not prevent new activations while an existing activation sequence was already running.

### Changes Made

- Added an `isProcessing` guard to block repeated activations.
- Disabled the hologram button during the loading state.
- Re-enabled the button after activation completes.
- Prevented duplicate timers, notifications, and event dispatches.

### Result

Before:
- Multiple clicks created multiple activation cycles.

After:
- Only one activation cycle can run at a time.
- Additional clicks are ignored until completion.

### Testing

- [x] Rapid clicking no longer creates duplicate events.
- [x] Only one toast notification appears.
- [x] Audio feedback plays once per activation.
- [x] Button becomes clickable again after activation completes.
- [x] Existing functionality remains unchanged.

Closes #9509