### PR TITLE
feat: Add AI-Powered Study Planner using Groq Llama Instant - Fixes #9526

### DIFF
--- a/public/Stydy Sync/Script.js
+++ b/public/Stydy Sync/Script.js
@@ -15,6 +15,7 @@ mobileMenu.innerHTML = `
   <ul>
     <li><a href="#Home">Home</a></li>
     <li><a href="#Features">Features</a></li>
+    <li><a href="#ai-planner">AI Planner</a></li>
     <li><a href="#Prising">Pricing</a></li>
     <li><a href="#Blogs">Blogs</a></li>
     <li><a href="#Contact">Contact</a></li>
@@ -292,11 +293,12 @@ if (newsletterForm && emailInput) {
 // ── 6. ACTIVE NAV LINK on scroll ──────────────────────────────────────────
 
 const sections = [
-  { id: 'Home',     el: document.querySelector('.content') },
-  { id: 'Features', el: document.querySelector('.foot') },
-  { id: 'Prising',  el: document.querySelector('.review-section') },
-  { id: 'Blogs',    el: document.querySelector('.news') },
-  { id: 'Contact',  el: document.querySelector('footer') },
+  { id: 'Home',       el: document.querySelector('.content') },
+  { id: 'Features',   el: document.querySelector('.foot') },
+  { id: 'ai-planner', el: document.querySelector('.ai-planner-section') },
+  { id: 'Prising',    el: document.querySelector('.review-section') },
+  { id: 'Blogs',      el: document.querySelector('.news') },
+  { id: 'Contact',    el: document.querySelector('footer') },
 ];
 
 // Give sections their ids if missing
@@ -319,16 +321,19 @@ window.addEventListener('scroll', () => {
 });
 
 
-// ── 7. "START NOW" BUTTON — scroll to newsletter ──────────────────────────
+// ── 7. "START NOW" BUTTON — scroll to AI Planner ──────────────────────────
 
 const startBtn = document.querySelector('#p4');
 if (startBtn) {
   startBtn.addEventListener('click', (e) => {
     e.preventDefault();
-    const newsSection = document.querySelector('.news');
-    if (newsSection) {
-      newsSection.scrollIntoView({ behavior: 'smooth' });
-      setTimeout(() => emailInput && emailInput.focus(), 700);
+    const plannerSection = document.querySelector('.ai-planner-section');
+    if (plannerSection) {
+      plannerSection.scrollIntoView({ behavior: 'smooth' });
+      setTimeout(() => {
+        const examNameField = document.getElementById('examName');
+        examNameField && examNameField.focus();
+      }, 700);
     }
   });
 }
@@ -455,6 +460,198 @@ document.querySelectorAll('.subcontent .icon').forEach(ic => {
     ic.addEventListener('click', () => window.open(socialLinks[key], '_blank'));
   }
 });
+
+
+// ── 12. AI STUDY PLANNER  (Groq · Llama 3.1 8B Instant) — Issue #9526 ────
+
+const STORAGE_KEY   = 'studysync_groq_api_key';
+const GROQ_MODEL    = 'llama-3.1-8b-instant'; // NOTE: Groq is deprecating this
+                                                // model on 2026-08-16. Switch to
+                                                // 'openai/gpt-oss-20b' before then.
+const GROQ_ENDPOINT = 'https://api.groq.com/openai/v1/chat/completions';
+
+// Elements (only present on pages that include the AI Planner section)
+const apiKeyBox     = document.getElementById('apiKeyBox');
+const apiKeyInput   = document.getElementById('groqApiKeyInput');
+const saveApiKeyBtn = document.getElementById('saveApiKeyBtn');
+const apiKeySaved   = document.getElementById('apiKeySaved');
+const changeKeyBtn  = document.getElementById('changeKeyBtn');
+
+const examNameEl   = document.getElementById('examName');
+const examDateEl   = document.getElementById('examDate');
+const dailyHoursEl = document.getElementById('dailyHours');
+const subjectsEl   = document.getElementById('subjects');
+const weakTopicsEl = document.getElementById('weakTopics');
+const diffBtns     = document.querySelectorAll('.diff-btn');
+
+const generateBtn  = document.getElementById('generateBtn');
+const clearPlanBtn = document.getElementById('clearPlanBtn');
+
+const outputPlaceholder = document.getElementById('outputPlaceholder');
+const outputLoading     = document.getElementById('outputLoading');
+const outputContent     = document.getElementById('outputContent');
+const planText           = document.getElementById('planText');
+const copyPlanBtn        = document.getElementById('copyPlanBtn');
+
+if (generateBtn) {
+
+  let selectedDifficulty = 'Beginner';
+
+  /* ---- API key persistence (localStorage only — no backend, no .env) ---- */
+  function loadApiKey() {
+    return localStorage.getItem(STORAGE_KEY) || '';
+  }
+
+  function showKeySavedState(saved) {
+    apiKeyBox.style.display   = saved ? 'none' : 'block';
+    apiKeySaved.style.display = saved ? 'flex' : 'none';
+  }
+
+  function initApiKeyUI() {
+    showKeySavedState(!!loadApiKey());
+  }
+
+  saveApiKeyBtn.addEventListener('click', () => {
+    const key = apiKeyInput.value.trim();
+    if (!key) {
+      alert('Please paste a valid Groq API key (starts with "gsk_").');
+      return;
+    }
+    localStorage.setItem(STORAGE_KEY, key);
+    apiKeyInput.value = '';
+    showKeySavedState(true);
+  });
+
+  changeKeyBtn.addEventListener('click', () => {
+    apiKeyInput.value = loadApiKey();
+    showKeySavedState(false);
+    apiKeyInput.focus();
+  });
+
+  initApiKeyUI();
+
+  /* ---- Difficulty tab selection ---- */
+  diffBtns.forEach(btn => {
+    btn.addEventListener('click', () => {
+      diffBtns.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      selectedDifficulty = btn.dataset.diff;
+    });
+  });
+
+  /* ---- Output state helper ---- */
+  function setOutputState(state) {
+    // state: 'placeholder' | 'loading' | 'content'
+    outputPlaceholder.style.display = state === 'placeholder' ? 'flex' : 'none';
+    outputLoading.style.display     = state === 'loading'     ? 'flex' : 'none';
+    outputContent.style.display     = state === 'content'     ? 'flex' : 'none';
+  }
+
+  /* ---- Wrap "Day N" markers for the CSS .day-marker badge style ---- */
+  function formatPlan(rawText) {
+    return rawText.replace(/(^|\n)\s*(Day\s*\d+[:.\-]?)/gi, (m, lead, label) => {
+      return `${lead}<span class="day-marker">${label.trim()}</span> `;
+    });
+  }
+
+  /* ---- Build the prompt sent to Groq ---- */
+  function buildPrompt() {
+    const exam     = examNameEl.value.trim() || 'an upcoming exam';
+    const dateVal  = examDateEl.value ? new Date(examDateEl.value).toDateString() : 'not specified';
+    const hours    = dailyHoursEl.value;
+    const subjects = subjectsEl.value.trim() || 'Not specified';
+    const weak     = weakTopicsEl.value.trim() || 'None mentioned';
+
+    return `You are an expert academic study planner. Create a personalized, day-wise study roadmap.
+
+Exam/Goal: ${exam}
+Exam Date: ${dateVal}
+Available Study Time: ${hours} hour(s) per day
+Subjects/Topics: ${subjects}
+Difficulty Level: ${selectedDifficulty}
+Weak Topics (need extra focus): ${weak}
+
+Instructions:
+- Break the plan into "Day 1", "Day 2", etc., up to the exam date (or up to 14 days if no date is given).
+- For each day, list specific topics to study with approximate time allocation.
+- Prioritize the weak topics with dedicated revision slots.
+- Add 1-2 short revision/mock-test days near the end.
+- Keep the tone encouraging and concise. Plain text, clear day-by-day structure, no markdown tables.`;
+  }
+
+  /* ---- Call Groq API and render the plan ---- */
+  async function generatePlan() {
+    const apiKey = loadApiKey();
+
+    if (!apiKey) {
+      alert('Please save your Groq API key first.');
+      apiKeyBox.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      return;
+    }
+    if (!subjectsEl.value.trim()) {
+      alert('Please enter at least one subject/topic to study.');
+      subjectsEl.focus();
+      return;
+    }
+
+    setOutputState('loading');
+    generateBtn.disabled = true;
+
+    try {
+      const response = await fetch(GROQ_ENDPOINT, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${apiKey}`
+        },
+        body: JSON.stringify({
+          model: GROQ_MODEL,
+          messages: [{ role: 'user', content: buildPrompt() }],
+          temperature: 0.6,
+          max_tokens: 1500
+        })
+      });
+
+      if (!response.ok) {
+        const errData = await response.json().catch(() => ({}));
+        throw new Error(errData?.error?.message || `Request failed with status ${response.status}`);
+      }
+
+      const data = await response.json();
+      const text = data?.choices?.[0]?.message?.content?.trim();
+
+      if (!text) throw new Error('Empty response from Groq API.');
+
+      planText.innerHTML = formatPlan(text);
+      setOutputState('content');
+      clearPlanBtn.style.display = 'flex';
+
+    } catch (err) {
+      console.error('Groq API error:', err);
+      setOutputState('placeholder');
+      alert(`Could not generate your plan: ${err.message}`);
+    } finally {
+      generateBtn.disabled = false;
+    }
+  }
+
+  generateBtn.addEventListener('click', generatePlan);
+
+  clearPlanBtn.addEventListener('click', () => {
+    planText.innerHTML = '';
+    setOutputState('placeholder');
+    clearPlanBtn.style.display = 'none';
+  });
+
+  copyPlanBtn.addEventListener('click', () => {
+    navigator.clipboard.writeText(planText.innerText).then(() => {
+      const original = copyPlanBtn.innerHTML;
+      copyPlanBtn.innerHTML = '<i class="fa fa-check"></i> Copied!';
+      setTimeout(() => { copyPlanBtn.innerHTML = original; }, 1800);
+    });
+  });
+
+}
 
 
 console.log('%cStudySync JS loaded ✅', 'color:#2563EB;font-weight:bold;font-size:14px;');

--- a/public/Stydy Sync/index.html
+++ b/public/Stydy Sync/index.html
@@ -17,13 +17,14 @@
             <ul>
                 <li><a href="#Home">Home</a></li>
                 <li><a href="#Features">Features</a></li>
+                <li><a href="#ai-planner">AI Planner</a></li>
                 <li><a href="#Prising">Prising</a></li>
                 <li><a href="#Blogs">Blogs</a></li>
                 <li><a href="#Contact">Contact</a></li>
             </ul>
             <div class="button">
-                <a href="#button" class="contact">
-                    Contact Us
+                <a href="#ai-planner" class="contact">
+                    Try AI Planner
                 </a>
             </div>
             <div class="menu">
@@ -44,10 +45,10 @@
                 </p>
                 <div class="b1">
                     <div class="s1">
-                        <a href="#start" id="p4">Start Now</a>
+                        <a href="#ai-planner" id="p4">Start Now</a>
                     </div>
                     <div class="s2">
-                        <a href="#tour" id="p5">Take tour</a>
+                        <a href="#Features" id="p5">Take tour</a>
                     </div>
                 </div>
             </div>
@@ -66,7 +67,7 @@
                 <div class="icon"><i aria-hidden="true" class="fas fa-envelope"></i>E-Mail</div>
             </div>
         </div>
-        <div class="foot">
+        <div class="foot" id="Features">
             <div class="card-section">
                 <div class="head">
                     <h3>Our Competitive Advantage</h3>
@@ -141,6 +142,129 @@
                 </div>
             </div>
         </div> 
+
+        <!-- ============================================================
+             AI STUDY PLANNER SECTION  — Issue #9526
+             ============================================================ -->
+        <section class="ai-planner-section" id="ai-planner">
+            <div class="ai-planner-inner">
+
+                <!-- Section Header -->
+                <div class="ai-planner-header">
+                    <span class="ai-badge"><i class="fa fa-brain"></i> Powered by Groq · Llama Instant</span>
+                    <h2 class="ai-planner-title">AI Study Planner</h2>
+                    <p class="ai-planner-subtitle">
+                        Enter your exam details and get a personalized day-wise study roadmap generated instantly by AI.
+                    </p>
+                </div>
+
+                <!-- API Key Setup Box -->
+                <div class="api-key-box" id="apiKeyBox">
+                    <div class="api-key-box-inner">
+                        <div class="api-key-icon"><i class="fa fa-key"></i></div>
+                        <div class="api-key-text">
+                            <h4>Setup your Groq API Key</h4>
+                            <p>Your key is saved in your browser only — never sent to any server except Groq.</p>
+                        </div>
+                        <div class="api-key-input-row">
+                            <input type="password" id="groqApiKeyInput" placeholder="gsk_..." autocomplete="off" />
+                            <button id="saveApiKeyBtn"><i class="fa fa-save"></i> Save Key</button>
+                        </div>
+                        <p class="api-key-hint">
+                            Get your free key at <a href="https://console.groq.com/keys" target="_blank" rel="noopener">console.groq.com/keys</a>
+                        </p>
+                    </div>
+                </div>
+
+                <!-- API Key Saved Indicator -->
+                <div class="api-key-saved" id="apiKeySaved" style="display:none;">
+                    <span><i class="fa fa-check-circle"></i> Groq API Key saved</span>
+                    <button id="changeKeyBtn">Change Key</button>
+                </div>
+
+                <!-- Planner Form + Output -->
+                <div class="ai-planner-grid">
+                    <!-- LEFT: Input Form -->
+                    <div class="planner-form-card">
+                        <h3><i class="fa fa-pencil-square-o"></i> Your Study Details</h3>
+
+                        <div class="form-group">
+                            <label for="examName">Exam / Goal Name</label>
+                            <input type="text" id="examName" placeholder="e.g. GATE 2026, JEE Mains, Semester Finals" />
+                        </div>
+
+                        <div class="form-group">
+                            <label for="examDate">Exam Date</label>
+                            <input type="date" id="examDate" />
+                        </div>
+
+                        <div class="form-group">
+                            <label for="dailyHours">Daily Study Hours</label>
+                            <select id="dailyHours">
+                                <option value="1">1 hour/day</option>
+                                <option value="2">2 hours/day</option>
+                                <option value="3" selected>3 hours/day</option>
+                                <option value="4">4 hours/day</option>
+                                <option value="5">5 hours/day</option>
+                                <option value="6">6+ hours/day</option>
+                            </select>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="subjects">Subjects / Topics</label>
+                            <textarea id="subjects" rows="4" placeholder="e.g.&#10;Mathematics - Calculus, Algebra&#10;Physics - Mechanics, Thermodynamics&#10;Chemistry - Organic, Inorganic"></textarea>
+                        </div>
+
+                        <div class="form-group">
+                            <label>Difficulty Level</label>
+                            <div class="difficulty-tabs">
+                                <button class="diff-btn active" data-diff="Beginner">Beginner</button>
+                                <button class="diff-btn" data-diff="Intermediate">Intermediate</button>
+                                <button class="diff-btn" data-diff="Advanced">Advanced</button>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="weakTopics">Weak Topics <span class="optional">(optional)</span></label>
+                            <input type="text" id="weakTopics" placeholder="e.g. Integration, Organic Chemistry" />
+                        </div>
+
+                        <button class="generate-btn" id="generateBtn">
+                            <i class="fa fa-magic"></i> Generate My Study Plan
+                        </button>
+
+                        <button class="clear-btn" id="clearPlanBtn" style="display:none;">
+                            <i class="fa fa-trash"></i> Clear Plan
+                        </button>
+                    </div>
+
+                    <!-- RIGHT: Output -->
+                    <div class="planner-output-card" id="plannerOutput">
+                        <div class="output-placeholder" id="outputPlaceholder">
+                            <div class="placeholder-icon"><i class="fa fa-calendar-check-o"></i></div>
+                            <h4>Your plan will appear here</h4>
+                            <p>Fill in your exam details and click <strong>Generate My Study Plan</strong></p>
+                        </div>
+
+                        <div class="output-loading" id="outputLoading" style="display:none;">
+                            <div class="loader-ring"></div>
+                            <p>Generating your personalized roadmap…</p>
+                        </div>
+
+                        <div class="output-content" id="outputContent" style="display:none;">
+                            <div class="output-toolbar">
+                                <span class="output-label"><i class="fa fa-map"></i> Your Study Roadmap</span>
+                                <button class="copy-btn" id="copyPlanBtn"><i class="fa fa-copy"></i> Copy</button>
+                            </div>
+                            <div class="plan-text" id="planText"></div>
+                        </div>
+                    </div>
+                </div>
+
+            </div>
+        </section>
+        <!-- END AI STUDY PLANNER SECTION -->
+
         <div class="review-section">
             <div class="test">
                 <div class="h">

--- a/public/Stydy Sync/style.css
+++ b/public/Stydy Sync/style.css
@@ -814,3 +814,571 @@ footer {
   .head h3, .test .h { font-size: 1.6rem; }
   .newstext h2 { font-size: 1.4rem; }
 }
+
+
+/* ═══════════════════════════════════════════════════════════
+   AI STUDY PLANNER SECTION  — Issue #9526
+   ═══════════════════════════════════════════════════════════ */
+
+.ai-planner-section {
+  background: linear-gradient(160deg, #f0f4ff 0%, #ffffff 60%, #f8f9ff 100%);
+  border-top: 1px solid var(--gray-border);
+  border-bottom: 1px solid var(--gray-border);
+  padding: 80px 32px;
+}
+
+.ai-planner-inner {
+  max-width: 1100px;
+  margin: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+/* Header */
+.ai-planner-header {
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.ai-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: linear-gradient(135deg, #2563EB, #7c3aed);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 5px 16px;
+  border-radius: 100px;
+  width: fit-content;
+}
+
+.ai-planner-title {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 3.5vw, 2.8rem);
+  font-weight: 800;
+  color: var(--navy);
+  letter-spacing: -0.03em;
+}
+
+.ai-planner-subtitle {
+  color: var(--gray-mid);
+  font-size: 1rem;
+  max-width: 520px;
+  line-height: 1.7;
+}
+
+/* API Key Box */
+.api-key-box {
+  background: var(--white);
+  border: 1.5px dashed #93C5FD;
+  border-radius: var(--radius-md);
+  padding: 24px 28px;
+  box-shadow: 0 2px 12px rgba(37,99,235,0.07);
+}
+
+.api-key-box-inner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
+}
+
+.api-key-icon {
+  width: 44px;
+  height: 44px;
+  background: linear-gradient(135deg, #2563EB, #7c3aed);
+  border-radius: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.api-key-icon i {
+  color: #fff;
+  font-size: 1rem;
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  width: auto;
+  height: auto;
+}
+
+.api-key-text {
+  flex: 1;
+  min-width: 180px;
+}
+
+.api-key-text h4 {
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--navy);
+  margin-bottom: 3px;
+}
+
+.api-key-text p {
+  font-size: 0.8rem;
+  color: var(--gray-mid);
+}
+
+.api-key-input-row {
+  display: flex;
+  gap: 10px;
+  flex: 2;
+  min-width: 260px;
+}
+
+.api-key-input-row input {
+  flex: 1;
+  padding: 10px 14px;
+  border: 1.5px solid var(--gray-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  color: var(--navy);
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.api-key-input-row input:focus {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgba(37,99,235,0.1);
+}
+
+.api-key-input-row input::placeholder {
+  color: #9CA3AF;
+  font-family: monospace;
+}
+
+#saveApiKeyBtn {
+  padding: 10px 18px;
+  background: var(--blue);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s, transform 0.15s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+#saveApiKeyBtn:hover {
+  background: var(--blue-light);
+  transform: translateY(-1px);
+}
+
+.api-key-hint {
+  width: 100%;
+  font-size: 0.75rem;
+  color: var(--gray-mid);
+  margin-top: 4px;
+}
+
+.api-key-hint a {
+  color: var(--blue);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.api-key-hint a:hover {
+  text-decoration: underline;
+}
+
+/* API Key Saved Indicator */
+.api-key-saved {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #ECFDF5;
+  border: 1px solid #6EE7B7;
+  border-radius: var(--radius-sm);
+  padding: 12px 20px;
+  font-size: 0.875rem;
+  color: #065F46;
+  font-weight: 600;
+}
+
+.api-key-saved i {
+  font-size: 1rem;
+  color: #10B981;
+}
+
+#changeKeyBtn {
+  margin-left: auto;
+  padding: 6px 14px;
+  background: transparent;
+  border: 1px solid #10B981;
+  color: #065F46;
+  border-radius: var(--radius-sm);
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  font-family: var(--font-body);
+  transition: background 0.2s;
+}
+
+#changeKeyBtn:hover {
+  background: #D1FAE5;
+}
+
+/* Grid: Form + Output */
+.ai-planner-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.3fr;
+  gap: 24px;
+  align-items: start;
+}
+
+/* Form Card */
+.planner-form-card {
+  background: var(--white);
+  border: 1px solid var(--gray-border);
+  border-radius: var(--radius-md);
+  padding: 28px 24px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.planner-form-card h3 {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--navy);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--gray-border);
+}
+
+.planner-form-card h3 i {
+  color: var(--blue);
+  font-size: 0.95rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.form-group label {
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--gray-dark);
+  letter-spacing: 0.01em;
+}
+
+.form-group .optional {
+  font-weight: 400;
+  color: var(--gray-mid);
+}
+
+.form-group input,
+.form-group select,
+.form-group textarea {
+  padding: 10px 14px;
+  border: 1.5px solid var(--gray-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: 0.875rem;
+  color: var(--navy);
+  outline: none;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  background: var(--white);
+  resize: vertical;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+  border-color: var(--blue);
+  box-shadow: 0 0 0 3px rgba(37,99,235,0.1);
+}
+
+.form-group input::placeholder,
+.form-group textarea::placeholder {
+  color: #9CA3AF;
+}
+
+/* Difficulty Tabs */
+.difficulty-tabs {
+  display: flex;
+  gap: 8px;
+}
+
+.diff-btn {
+  flex: 1;
+  padding: 8px 12px;
+  border: 1.5px solid var(--gray-border);
+  border-radius: var(--radius-sm);
+  background: var(--white);
+  font-family: var(--font-body);
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: var(--gray-mid);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.diff-btn:hover {
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+.diff-btn.active {
+  background: var(--blue);
+  border-color: var(--blue);
+  color: #fff;
+}
+
+/* Generate Button */
+.generate-btn {
+  width: 100%;
+  padding: 13px;
+  background: linear-gradient(135deg, #2563EB, #7c3aed);
+  color: #fff;
+  border: none;
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  font-weight: 700;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: opacity 0.2s, transform 0.15s, box-shadow 0.2s;
+  box-shadow: 0 4px 14px rgba(37,99,235,0.35);
+  letter-spacing: 0.01em;
+}
+
+.generate-btn:hover {
+  opacity: 0.92;
+  transform: translateY(-2px);
+  box-shadow: 0 8px 24px rgba(37,99,235,0.4);
+}
+
+.generate-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+/* Clear Button */
+.clear-btn {
+  width: 100%;
+  padding: 10px;
+  background: transparent;
+  color: var(--gray-mid);
+  border: 1px solid var(--gray-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  transition: background 0.2s, color 0.2s;
+}
+
+.clear-btn:hover {
+  background: #FEF2F2;
+  color: #EF4444;
+  border-color: #FCA5A5;
+}
+
+/* Output Card */
+.planner-output-card {
+  background: var(--white);
+  border: 1px solid var(--gray-border);
+  border-radius: var(--radius-md);
+  min-height: 480px;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+/* Placeholder */
+.output-placeholder {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+  padding: 48px 32px;
+  text-align: center;
+}
+
+.placeholder-icon {
+  width: 64px;
+  height: 64px;
+  background: var(--blue-pale);
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.placeholder-icon i {
+  font-size: 1.6rem;
+  color: var(--blue);
+  background: none;
+  padding: 0;
+  border-radius: 0;
+  width: auto;
+  height: auto;
+}
+
+.output-placeholder h4 {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--navy);
+}
+
+.output-placeholder p {
+  font-size: 0.85rem;
+  color: var(--gray-mid);
+  line-height: 1.6;
+  max-width: 280px;
+}
+
+/* Loading */
+.output-loading {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  padding: 48px;
+}
+
+.loader-ring {
+  width: 44px;
+  height: 44px;
+  border: 3px solid var(--blue-pale);
+  border-top-color: var(--blue);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.output-loading p {
+  font-size: 0.9rem;
+  color: var(--gray-mid);
+  font-weight: 500;
+}
+
+/* Output Content */
+.output-content {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.output-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  border-bottom: 1px solid var(--gray-border);
+  background: var(--gray-light);
+}
+
+.output-label {
+  font-size: 0.82rem;
+  font-weight: 700;
+  color: var(--navy);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  letter-spacing: 0.01em;
+}
+
+.output-label i {
+  color: var(--blue);
+}
+
+.copy-btn {
+  padding: 6px 14px;
+  background: var(--white);
+  border: 1px solid var(--gray-border);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-body);
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--gray-dark);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.copy-btn:hover {
+  background: var(--blue-pale);
+  border-color: var(--blue);
+  color: var(--blue);
+}
+
+/* Plan Text */
+.plan-text {
+  padding: 24px 20px;
+  font-size: 0.875rem;
+  color: var(--gray-dark);
+  line-height: 1.8;
+  white-space: pre-wrap;
+  overflow-y: auto;
+  max-height: 520px;
+  font-family: var(--font-body);
+}
+
+/* Highlight day markers */
+.plan-text .day-marker {
+  display: inline-block;
+  background: linear-gradient(135deg, #2563EB, #7c3aed);
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 700;
+  padding: 2px 10px;
+  border-radius: 100px;
+  margin-right: 6px;
+  letter-spacing: 0.04em;
+}
+
+/* ── AI Planner Responsive ───────────────────────── */
+@media (max-width: 880px) {
+  .ai-planner-section { padding: 56px 20px; }
+  .ai-planner-grid { grid-template-columns: 1fr; }
+  .api-key-box-inner { flex-direction: column; align-items: flex-start; }
+  .api-key-input-row { width: 100%; }
+  .difficulty-tabs { flex-wrap: wrap; }
+}
+
+@media (max-width: 640px) {
+  .ai-planner-title { font-size: 1.8rem; }
+  .plan-text { font-size: 0.82rem; }
+}


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #9526

### Summary
Adds an AI-Powered Study Planner to the existing StudySync project. Users enter their exam details, subjects, available daily study hours, and difficulty level, and the app generates a personalized day-wise study roadmap using Groq's Llama 3.1 8B Instant model — called directly from the browser, with no backend or `.env` file required.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added a new **AI Study Planner** section (`#ai-planner`) to `index.html`, with a form for exam name, exam date, daily study hours, subjects/topics, difficulty level (Beginner/Intermediate/Advanced), and optional weak topics.
- Added a client-side Groq API key setup box — the key is stored in the browser's `localStorage` only and is sent directly to Groq's API, never to any third-party server.
- Integrated Groq's `llama-3.1-8b-instant` model via `fetch()` to `https://api.groq.com/openai/v1/chat/completions`, generating a structured, day-by-day study roadmap based on the user's inputs.
- Added loading, empty-placeholder, and result states for the output panel, with a "Day N" badge highlight, copy-to-clipboard button, and clear/reset button.
- Updated `Script.js` to wire up all of the above (API key save/change, difficulty tab selection, plan generation/clear/copy), guarded so it only runs if the planner section is present on the page.
- Updated the nav bar, mobile dropdown menu, and "Start Now" CTA button to link to/scroll to the new AI Planner section.
- Updated active-nav-link scroll tracking to include the new `ai-planner` section.
- Added matching styles in `style.css` for the planner section, form card, output card, API key box, and responsive breakpoints — consistent with the existing editorial design language of the site.

---

## 📷 Screenshots / Video Recording
<img width="1117" height="862" alt="image" src="https://github.com/user-attachments/assets/cc69201d-10f0-47b0-a912-6be572a42d50" />

<img width="1140" height="786" alt="image" src="https://github.com/user-attachments/assets/8c3a199f-70a4-451f-a809-3a808f4eefe5" />

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.