### PR TITLE
refactor: migrate dynamic project form listeners to event delegation

### DIFF
--- a/public/Portfolio_Studio/script.js
+++ b/public/Portfolio_Studio/script.js
@@ -31,6 +31,7 @@ function initializeApp() {
     themeSelect.addEventListener('change', updateLivePreview);
     addProjectBtn.addEventListener('click', addNewProjectRow);
 
+    initProjectFormDelegation();
     renderProjectForms();
     updateLivePreview();
 }
@@ -97,25 +98,26 @@ function renderProjectForms() {
         // Append to container
         projectsFormContainer.appendChild(box);
     });
+}
+function initProjectFormDelegation() {
+    projectsFormContainer.addEventListener('input', (e) => {
+        const input = e.target.closest('.proj-input');
+        if (!input) return;
 
-    // Mirror input text adjustments straight into preview states
-    document.querySelectorAll('.proj-input').forEach(input => {
-        input.addEventListener('input', (e) => {
-            const idx = e.target.dataset.idx;
-            const field = e.target.dataset.field;
-            projectDataList[idx][field] = e.target.value;
-            updateLivePreview();
-        });
+        const idx = input.dataset.idx;
+        const field = input.dataset.field;
+        projectDataList[idx][field] = input.value;
+        updateLivePreview();
     });
 
-    // Bind array cell splice deletion commands
-    document.querySelectorAll('.btn-delete').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-            const idx = parseInt(e.target.dataset.idx);
-            projectDataList.splice(idx, 1);
-            renderProjectForms();
-            updateLivePreview();
-        });
+    projectsFormContainer.addEventListener('click', (e) => {
+        const btn = e.target.closest('.btn-delete');
+        if (!btn) return;
+
+        const idx = parseInt(btn.dataset.idx, 10);
+        projectDataList.splice(idx, 1);
+        renderProjectForms();
+        updateLivePreview();
     });
 }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #9666 

### Summary
Refactors the dynamic project form's event binding from per-element listeners to event delegation. Previously, `renderProjectForms()` attached new `input` and `click` listeners to every project field and delete button on each render. This scales linearly with the number of projects and re-creates listeners unnecessarily every time a project is added or removed. Listeners are now bound once to the parent `projectsFormContainer`, and events are routed to the correct element using `event.target.closest()`.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [x] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Removed the two `document.querySelectorAll(...).forEach(...)` blocks inside `renderProjectForms()` that re-attached `input` and `click` listeners to every `.proj-input` and `.btn-delete` element on every render.
- Added a new standalone `initProjectFormDelegation()` function that attaches a single `input` listener and a single `click` listener to `projectsFormContainer`, using `event.target.closest()` to identify the actual `.proj-input` or `.btn-delete` element that triggered the event.
- Called `initProjectFormDelegation()` once inside `initializeApp()`, before the initial `renderProjectForms()` call, so the delegated listeners are bound exactly once at app startup rather than on every render.
- No changes to data model logic — `projectDataList` updates and `updateLivePreview()` calls behave identically to before.

## 🧪 Testing and Verification

### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [ ] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [x] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

### Manual Verification
- [x] Added a new project row and confirmed it renders with empty/default fields.
- [x] Edited title/tech/desc fields on multiple project rows and confirmed `projectDataList` updates correctly and the live preview reflects changes.
- [x] Deleted a project from the middle of the list and confirmed the correct row is removed and remaining rows still edit correctly (index re-stamping works as expected after re-render).
- [x] Confirmed via DevTools Event Listeners panel that `projectsFormContainer` has exactly one `input` and one `click` listener, and individual `.proj-input`/`.btn-delete` elements have none.

---

## 📷 Screenshots / Video Recording
N/A — no visual changes. This PR only changes how event listeners are bound internally; rendered markup and styling are unchanged.
---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
