### PR TITLE
fix: reset stale UI state on invalid GitHub search

### DIFF
--- a/public/github_profile_finder/script.js
+++ b/public/github_profile_finder/script.js
@@ -47,6 +47,8 @@ const Nodes = {
 
 const CACHE_DURATION = 300000;
 
+const activeCounterIntervals = [];
+
 /* =========================================================
    CACHE ENGINE
 ========================================================= */
@@ -210,6 +212,46 @@ function animateCounter(element, targetValue) {
       current.toLocaleString();
 
   }, 20);
+
+  activeCounterIntervals.push(interval);
+}
+
+function stopActiveCounters() {
+
+  activeCounterIntervals.forEach(
+    (interval) => clearInterval(interval)
+  );
+
+  activeCounterIntervals.length = 0;
+}
+
+function resetStatCounters() {
+
+  stopActiveCounters();
+
+  if (Nodes.repoCount)
+    Nodes.repoCount.textContent = "0";
+
+  if (Nodes.followers)
+    Nodes.followers.textContent = "0";
+
+  if (Nodes.following)
+    Nodes.following.textContent = "0";
+
+  if (Nodes.gists)
+    Nodes.gists.textContent = "0";
+}
+
+function resetProfileUI() {
+
+  resetStatCounters();
+
+  UI.profileCard?.classList.add("hidden");
+  UI.reposSection?.classList.add("hidden");
+  UI.analyticsPanel?.classList.add("hidden");
+
+  if (UI.reposList)
+    UI.reposList.innerHTML = "";
 }
 
 /* =========================================================
@@ -464,6 +506,8 @@ function renderProfile(user) {
   Nodes.profileLink.href =
     user.html_url;
 
+  stopActiveCounters();
+
   animateCounter(
     Nodes.repoCount,
     user.public_repos
@@ -656,6 +700,8 @@ async function fetchUser(username) {
     hideStatus();
 
   } catch (error) {
+
+    resetProfileUI();
 
     showStatus(
       error.message,


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #9406

### Summary

This PR fixes the stale UI issue in **GitHub Profile Finder** when searching for an invalid username after a successful search.

### What I changed

* Added logic to track all active counter animation intervals.
* Created a function to stop ongoing counter animations before starting new ones.
* Added a reset function to set all profile stats counters back to `0`.
* Added a UI reset function to clear stale profile data and hide:

  * profile card
  * analytics panel
  * repositories section
* Updated the `fetchUser()` error handler to call the UI reset function before showing the error message.
* Ensured previous counter animations are cleared before rendering a new profile.

### Result

Now, when a user searches for an invalid GitHub username after a valid search:

<img width="1100" height="621" alt="image" src="https://github.com/user-attachments/assets/233a834e-e934-4bc7-bb84-ba554734526f" />

* Previous profile data is no longer visible
* Stat counters reset correctly
* Broken/stuck counter animations no longer occur
* UI remains clean without requiring a manual refresh