### PR TITLE
fix: prevent duplicate board names in Advanced Kanban Board (#9615)

### DIFF
--- a/public/Kanban_Board/index.html
+++ b/public/Kanban_Board/index.html
@@ -1,285 +1,193 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
+  <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Advanced Kanban Board</title>
     <link rel="stylesheet" href="style.css" />
-</head>
-<body>
-
+  </head>
+  <body>
     <!-- HEADER -->
     <header>
-        <div class="header-left">
-            <h1>🚀 Advanced Kanban Board</h1>
-            <p>Manage Projects Like a Pro</p>
-        </div>
+      <div class="header-left">
+        <h1>🚀 Advanced Kanban Board</h1>
+        <p>Manage Projects Like a Pro</p>
+      </div>
 
-        <div class="header-right">
-            <button id="themeToggle">🌙 Dark Mode</button>
-        </div>
+      <div class="header-right">
+        <button id="themeToggle">🌙 Dark Mode</button>
+      </div>
     </header>
 
     <!-- MAIN APP -->
     <div class="app-container">
+      <!-- SIDEBAR -->
+      <aside class="sidebar">
+        <div class="sidebar-header">
+          <h2>Boards</h2>
+          <button id="addBoardBtn">+</button>
+        </div>
 
-        <!-- SIDEBAR -->
-        <aside class="sidebar">
+        <div id="boardList" class="board-list">
+          <!-- Boards Render Here -->
+        </div>
+      </aside>
 
-            <div class="sidebar-header">
-                <h2>Boards</h2>
-                <button id="addBoardBtn">+</button>
-            </div>
+      <!-- CONTENT -->
+      <section class="content-area">
+        <!-- DASHBOARD -->
+        <section class="dashboard">
+          <div class="stat-card">
+            <h3>Total Tasks</h3>
+            <span id="totalTasks">0</span>
+          </div>
 
-            <div id="boardList" class="board-list">
-                <!-- Boards Render Here -->
-            </div>
+          <div class="stat-card">
+            <h3>Completed</h3>
+            <span id="completedTasks">0</span>
+          </div>
 
-        </aside>
+          <div class="stat-card">
+            <h3>In Progress</h3>
+            <span id="progressTasks">0</span>
+          </div>
 
-        <!-- CONTENT -->
-        <section class="content-area">
+          <div class="stat-card">
+            <h3>Pending</h3>
+            <span id="pendingTasks">0</span>
+          </div>
 
-            <!-- DASHBOARD -->
-            <section class="dashboard">
-
-                <div class="stat-card">
-                    <h3>Total Tasks</h3>
-                    <span id="totalTasks">0</span>
-                </div>
-
-                <div class="stat-card">
-                    <h3>Completed</h3>
-                    <span id="completedTasks">0</span>
-                </div>
-
-                <div class="stat-card">
-                    <h3>In Progress</h3>
-                    <span id="progressTasks">0</span>
-                </div>
-
-                <div class="stat-card">
-                    <h3>Pending</h3>
-                    <span id="pendingTasks">0</span>
-                </div>
-
-                <div class="stat-card">
-                    <h3>Completion</h3>
-                    <span id="completionRate">0%</span>
-                </div>
-
-            </section>
-
-            <!-- ACTIVE BOARD TITLE -->
-            <div class="current-board-container">
-
-                <div>
-                    <h2 id="currentBoardTitle">My Board</h2>
-                    <p>Organize tasks efficiently</p>
-                </div>
-
-                <button id="renameBoardBtn">
-                    ✏ Rename Board
-                </button>
-
-            </div>
-
-            <!-- KANBAN BOARD -->
-            <main class="board">
-
-                <!-- TODO -->
-                <div class="column">
-
-                    <div class="column-header">
-                        <h3>📋 To Do</h3>
-
-                        <button
-                            class="add-column-task"
-                            data-status="todo">
-                            +
-                        </button>
-                    </div>
-
-                    <div
-                        class="task-container"
-                        id="todo">
-                    </div>
-
-                </div>
-
-                <!-- IN PROGRESS -->
-                <div class="column">
-
-                    <div class="column-header">
-                        <h3>⚡ In Progress</h3>
-
-                        <button
-                            class="add-column-task"
-                            data-status="progress">
-                            +
-                        </button>
-                    </div>
-
-                    <div
-                        class="task-container"
-                        id="progress">
-                    </div>
-
-                </div>
-
-                <!-- REVIEW -->
-                <div class="column">
-
-                    <div class="column-header">
-                        <h3>🔍 Review</h3>
-
-                        <button
-                            class="add-column-task"
-                            data-status="review">
-                            +
-                        </button>
-                    </div>
-
-                    <div
-                        class="task-container"
-                        id="review">
-                    </div>
-
-                </div>
-
-                <!-- COMPLETED -->
-                <div class="column">
-
-                    <div class="column-header">
-                        <h3>✅ Completed</h3>
-
-                        <button
-                            class="add-column-task"
-                            data-status="completed">
-                            +
-                        </button>
-                    </div>
-
-                    <div
-                        class="task-container"
-                        id="completed">
-                    </div>
-
-                </div>
-
-            </main>
-
+          <div class="stat-card">
+            <h3>Completion</h3>
+            <span id="completionRate">0%</span>
+          </div>
         </section>
 
+        <!-- ACTIVE BOARD TITLE -->
+        <div class="current-board-container">
+          <div>
+            <h2 id="currentBoardTitle">My Board</h2>
+            <p>Organize tasks efficiently</p>
+          </div>
+
+          <button id="renameBoardBtn">✏ Rename Board</button>
+        </div>
+
+        <!-- KANBAN BOARD -->
+        <main class="board">
+          <!-- TODO -->
+          <div class="column">
+            <div class="column-header">
+              <h3>📋 To Do</h3>
+
+              <button class="add-column-task" data-status="todo">+</button>
+            </div>
+
+            <div class="task-container" id="todo"></div>
+          </div>
+
+          <!-- IN PROGRESS -->
+          <div class="column">
+            <div class="column-header">
+              <h3>⚡ In Progress</h3>
+
+              <button class="add-column-task" data-status="progress">+</button>
+            </div>
+
+            <div class="task-container" id="progress"></div>
+          </div>
+
+          <!-- REVIEW -->
+          <div class="column">
+            <div class="column-header">
+              <h3>🔍 Review</h3>
+
+              <button class="add-column-task" data-status="review">+</button>
+            </div>
+
+            <div class="task-container" id="review"></div>
+          </div>
+
+          <!-- COMPLETED -->
+          <div class="column">
+            <div class="column-header">
+              <h3>✅ Completed</h3>
+
+              <button class="add-column-task" data-status="completed">+</button>
+            </div>
+
+            <div class="task-container" id="completed"></div>
+          </div>
+        </main>
+      </section>
     </div>
 
     <!-- ADD TASK MODAL -->
     <div id="taskModal" class="modal">
-
-        <div class="modal-content">
-
-            <div class="modal-header">
-                <h2>Create Task</h2>
-                <span class="close-modal">&times;</span>
-            </div>
-
-            <div class="modal-body">
-
-                <input
-                    type="text"
-                    id="taskTitle"
-                    placeholder="Task Title"
-                />
-
-                <textarea
-                    id="taskDescription"
-                    placeholder="Task Description"
-                ></textarea>
-
-                <div class="subtask-section">
-
-                    <div class="subtask-header">
-                        <h4>Subtasks</h4>
-
-                        <button
-                            id="addSubtaskBtn"
-                            type="button">
-                            + Add
-                        </button>
-                    </div>
-
-                    <div id="subtaskContainer">
-                        <!-- Dynamic Subtasks -->
-                    </div>
-
-                </div>
-
-            </div>
-
-            <div class="modal-footer">
-
-                <button id="saveTaskBtn">
-                    Save Task
-                </button>
-
-            </div>
-
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Create Task</h2>
+          <span class="close-modal">&times;</span>
         </div>
 
+        <div class="modal-body">
+          <input type="text" id="taskTitle" placeholder="Task Title" />
+
+          <textarea
+            id="taskDescription"
+            placeholder="Task Description"
+          ></textarea>
+
+          <div class="subtask-section">
+            <div class="subtask-header">
+              <h4>Subtasks</h4>
+
+              <button id="addSubtaskBtn" type="button">+ Add</button>
+            </div>
+
+            <div id="subtaskContainer">
+              <!-- Dynamic Subtasks -->
+            </div>
+          </div>
+        </div>
+
+        <div class="modal-footer">
+          <button id="saveTaskBtn">Save Task</button>
+        </div>
+      </div>
     </div>
 
     <!-- TASK DETAILS MODAL -->
     <div id="taskDetailsModal" class="modal">
-
-        <div class="modal-content task-details">
-
-            <div class="modal-header">
-                <h2 id="detailTaskTitle"></h2>
-                <span class="close-details">&times;</span>
-            </div>
-
-            <div class="modal-body">
-
-                <p id="detailTaskDescription"></p>
-
-                <div class="progress-section">
-
-                    <div class="progress-info">
-                        <span>Progress</span>
-                        <span id="detailProgressPercent">
-                            0%
-                        </span>
-                    </div>
-
-                    <div class="progress-bar">
-                        <div
-                            id="detailProgressFill"
-                            class="progress-fill">
-                        </div>
-                    </div>
-
-                </div>
-
-                <div
-                    id="detailSubtaskList"
-                    class="detail-subtasks">
-                </div>
-
-                <div class="task-actions">
-
-                    <button id="deleteTaskBtn">
-                        Delete Task
-                    </button>
-
-                </div>
-
-            </div>
-
+      <div class="modal-content task-details">
+        <div class="modal-header">
+          <h2 id="detailTaskTitle"></h2>
+          <span class="close-details">&times;</span>
         </div>
 
+        <div class="modal-body">
+          <p id="detailTaskDescription"></p>
+
+          <div class="progress-section">
+            <div class="progress-info">
+              <span>Progress</span>
+              <span id="detailProgressPercent"> 0% </span>
+            </div>
+
+            <div class="progress-bar">
+              <div id="detailProgressFill" class="progress-fill"></div>
+            </div>
+          </div>
+
+          <div id="detailSubtaskList" class="detail-subtasks"></div>
+
+          <div class="task-actions">
+            <button id="deleteTaskBtn">Delete Task</button>
+          </div>
+        </div>
+      </div>
     </div>
 
     <script src="script.js"></script>
-
-</body>
+  </body>
 </html>

--- a/public/Kanban_Board/script.js
+++ b/public/Kanban_Board/script.js
@@ -2,125 +2,71 @@
    STORAGE
 ===================================== */
 
-const STORAGE_KEY = "advancedKanbanData";
+const STORAGE_KEY = 'advancedKanbanData';
 
-let appData =
-    JSON.parse(localStorage.getItem(STORAGE_KEY)) ||
+let appData = JSON.parse(localStorage.getItem(STORAGE_KEY)) || {
+  activeBoardId: 1,
+  boards: [
     {
-        activeBoardId: 1,
-        boards: [
-            {
-                id: 1,
-                name: "My Board",
-                tasks: []
-            }
-        ]
-    };
+      id: 1,
+      name: 'My Board',
+      tasks: [],
+    },
+  ],
+};
 
 function saveData() {
-    localStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify(appData)
-    );
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(appData));
 }
 
 /* =====================================
    DOM
 ===================================== */
 
-const boardList = document.getElementById("boardList");
+const boardList = document.getElementById('boardList');
 
-const currentBoardTitle =
-    document.getElementById(
-        "currentBoardTitle"
-    );
+const currentBoardTitle = document.getElementById('currentBoardTitle');
 
-const addBoardBtn =
-    document.getElementById(
-        "addBoardBtn"
-    );
+const addBoardBtn = document.getElementById('addBoardBtn');
 
-const renameBoardBtn =
-    document.getElementById(
-        "renameBoardBtn"
-    );
+const renameBoardBtn = document.getElementById('renameBoardBtn');
 
 /* Analytics */
 
-const totalTasksEl =
-    document.getElementById(
-        "totalTasks"
-    );
+const totalTasksEl = document.getElementById('totalTasks');
 
-const completedTasksEl =
-    document.getElementById(
-        "completedTasks"
-    );
+const completedTasksEl = document.getElementById('completedTasks');
 
-const progressTasksEl =
-    document.getElementById(
-        "progressTasks"
-    );
+const progressTasksEl = document.getElementById('progressTasks');
 
-const pendingTasksEl =
-    document.getElementById(
-        "pendingTasks"
-    );
+const pendingTasksEl = document.getElementById('pendingTasks');
 
-const completionRateEl =
-    document.getElementById(
-        "completionRate"
-    );
+const completionRateEl = document.getElementById('completionRate');
 
 /* Modals */
 
-const taskModal =
-    document.getElementById(
-        "taskModal"
-    );
+const taskModal = document.getElementById('taskModal');
 
-const taskDetailsModal =
-    document.getElementById(
-        "taskDetailsModal"
-    );
+const taskDetailsModal = document.getElementById('taskDetailsModal');
 
 /* Task Inputs */
 
-const taskTitleInput =
-    document.getElementById(
-        "taskTitle"
-    );
+const taskTitleInput = document.getElementById('taskTitle');
 
-const taskDescriptionInput =
-    document.getElementById(
-        "taskDescription"
-    );
+const taskDescriptionInput = document.getElementById('taskDescription');
 
-const addSubtaskBtn =
-    document.getElementById(
-        "addSubtaskBtn"
-    );
+const addSubtaskBtn = document.getElementById('addSubtaskBtn');
 
-const saveTaskBtn =
-    document.getElementById(
-        "saveTaskBtn"
-    );
+const saveTaskBtn = document.getElementById('saveTaskBtn');
 
-const subtaskContainer =
-    document.getElementById(
-        "subtaskContainer"
-    );
+const subtaskContainer = document.getElementById('subtaskContainer');
 
 /* =====================================
    ACTIVE BOARD
 ===================================== */
 
 function getActiveBoard() {
-    return appData.boards.find(
-        board =>
-            board.id ===
-            appData.activeBoardId
-    );
+  return appData.boards.find((board) => board.id === appData.activeBoardId);
 }
 
 /* =====================================
@@ -128,193 +74,140 @@ function getActiveBoard() {
 ===================================== */
 
 function renderBoards() {
+  boardList.innerHTML = '';
 
-    boardList.innerHTML = "";
+  appData.boards.forEach((board) => {
+    const item = document.createElement('div');
 
-    appData.boards.forEach(board => {
+    item.className = 'board-item';
 
-        const item =
-            document.createElement(
-                "div"
-            );
+    if (board.id === appData.activeBoardId) {
+      item.classList.add('active');
+    }
 
-        item.className =
-            "board-item";
-
-        if (
-            board.id ===
-            appData.activeBoardId
-        ) {
-            item.classList.add(
-                "active"
-            );
-        }
-
-        item.innerHTML = `
+    item.innerHTML = `
             <span>${board.name}</span>
         `;
 
-        item.addEventListener(
-            "click",
-            () => {
+    item.addEventListener('click', () => {
+      appData.activeBoardId = board.id;
 
-                appData.activeBoardId =
-                    board.id;
+      saveData();
 
-                saveData();
-
-                renderBoards();
-                renderTasks();
-                updateDashboard();
-            }
-        );
-
-        boardList.appendChild(item);
+      renderBoards();
+      renderTasks();
+      updateDashboard();
     });
 
-    const activeBoard =
-        getActiveBoard();
+    boardList.appendChild(item);
+  });
 
-    currentBoardTitle.textContent =
-        activeBoard.name;
+  const activeBoard = getActiveBoard();
+
+  currentBoardTitle.textContent = activeBoard.name;
 }
 
 /* =====================================
    ADD BOARD
 ===================================== */
 
-addBoardBtn.addEventListener(
-    "click",
-    () => {
+addBoardBtn.addEventListener('click', () => {
+  const boardName = prompt('Enter board name');
 
-        const boardName =
-            prompt(
-                "Enter board name"
-            );
+  if (!boardName || !boardName.trim()) return;
 
-        if (
-            !boardName ||
-            !boardName.trim()
-        )
-            return;
+  const trimmedName = boardName.trim();
 
-        const newBoard = {
-            id: Date.now(),
-            name: boardName.trim(),
-            tasks: []
-        };
+  const duplicateBoard = appData.boards.some(
+    (board) => board.name.toLowerCase() === trimmedName.toLowerCase()
+  );
 
-        appData.boards.push(
-            newBoard
-        );
+  if (duplicateBoard) {
+    alert('A board with this name already exists.');
+    return;
+  }
 
-        appData.activeBoardId =
-            newBoard.id;
+  const newBoard = {
+    id: Date.now(),
+    name: trimmedName,
+    tasks: [],
+  };
 
-        saveData();
+  appData.boards.push(newBoard);
 
-        renderBoards();
-        renderTasks();
-        updateDashboard();
-    }
-);
+  appData.activeBoardId = newBoard.id;
+
+  saveData();
+
+  renderBoards();
+  renderTasks();
+  updateDashboard();
+});
 
 /* =====================================
    RENAME BOARD
 ===================================== */
 
-renameBoardBtn.addEventListener(
-    "click",
-    () => {
+renameBoardBtn.addEventListener('click', () => {
+  const board = getActiveBoard();
 
-        const board =
-            getActiveBoard();
+  const newName = prompt('Rename board', board.name);
 
-        const newName =
-            prompt(
-                "Rename board",
-                board.name
-            );
+  if (!newName || !newName.trim()) return;
 
-        if (
-            !newName ||
-            !newName.trim()
-        )
-            return;
+  const trimmedName = newName.trim();
 
-        board.name =
-            newName.trim();
+  const duplicateBoard = appData.boards.some(
+    (b) =>
+      b.id !== board.id && b.name.toLowerCase() === trimmedName.toLowerCase()
+  );
 
-        saveData();
+  if (duplicateBoard) {
+    alert('A board with this name already exists.');
+    return;
+  }
 
-        renderBoards();
-    }
-);
+  board.name = trimmedName;
+
+  saveData();
+
+  renderBoards();
+});
 
 /* =====================================
    TASK MODAL
 ===================================== */
 
-let currentTaskStatus =
-    "todo";
+let currentTaskStatus = 'todo';
 
-document
-    .querySelectorAll(
-        ".add-column-task"
-    )
-    .forEach(btn => {
+document.querySelectorAll('.add-column-task').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    currentTaskStatus = btn.dataset.status;
 
-        btn.addEventListener(
-            "click",
-            () => {
+    taskModal.classList.add('show');
 
-                currentTaskStatus =
-                    btn.dataset.status;
+    taskTitleInput.value = '';
 
-                taskModal.classList.add(
-                    "show"
-                );
+    taskDescriptionInput.value = '';
 
-                taskTitleInput.value =
-                    "";
+    subtaskContainer.innerHTML = '';
+  });
+});
 
-                taskDescriptionInput.value =
-                    "";
+document.querySelector('.close-modal').addEventListener('click', () => {
+  taskModal.classList.remove('show');
+});
 
-                subtaskContainer.innerHTML =
-                    "";
-            }
-        );
-    });
-
-document
-    .querySelector(
-        ".close-modal"
-    )
-    .addEventListener(
-        "click",
-        () => {
-            taskModal.classList.remove(
-                "show"
-            );
-        }
-    );
-
-    /* =====================================
+/* =====================================
    SUBTASKS
 ===================================== */
 
-addSubtaskBtn.addEventListener(
-    "click",
-    () => {
+addSubtaskBtn.addEventListener('click', () => {
+  const wrapper = document.createElement('div');
 
-        const wrapper =
-            document.createElement("div");
+  wrapper.className = 'subtask-item';
 
-        wrapper.className =
-            "subtask-item";
-
-        wrapper.innerHTML = `
+  wrapper.innerHTML = `
             <input
                 type="text"
                 class="subtask-input"
@@ -327,154 +220,102 @@ addSubtaskBtn.addEventListener(
             </button>
         `;
 
-        wrapper
-            .querySelector(
-                ".remove-subtask"
-            )
-            .addEventListener(
-                "click",
-                () => wrapper.remove()
-            );
+  wrapper
+    .querySelector('.remove-subtask')
+    .addEventListener('click', () => wrapper.remove());
 
-        subtaskContainer.appendChild(
-            wrapper
-        );
-    }
-);
+  subtaskContainer.appendChild(wrapper);
+});
 
 /* =====================================
    CREATE TASK
 ===================================== */
 
-saveTaskBtn.addEventListener(
-    "click",
-    () => {
+saveTaskBtn.addEventListener('click', () => {
+  const title = taskTitleInput.value.trim();
 
-        const title =
-            taskTitleInput.value.trim();
+  const description = taskDescriptionInput.value.trim();
 
-        const description =
-            taskDescriptionInput.value.trim();
+  if (!title) {
+    alert('Task title is required');
+    return;
+  }
 
-        if (!title) {
-            alert(
-                "Task title is required"
-            );
-            return;
-        }
+  const subtasks = [];
 
-        const subtasks = [];
+  document.querySelectorAll('.subtask-input').forEach((input) => {
+    const value = input.value.trim();
 
-        document
-            .querySelectorAll(
-                ".subtask-input"
-            )
-            .forEach(input => {
-
-                const value =
-                    input.value.trim();
-
-                if (value) {
-
-                    subtasks.push({
-                        id: Date.now() +
-                            Math.random(),
-                        text: value,
-                        completed: false
-                    });
-                }
-            });
-
-        const task = {
-            id: Date.now(),
-
-            title,
-
-            description,
-
-            status:
-                currentTaskStatus,
-
-            subtasks
-        };
-
-        const board =
-            getActiveBoard();
-
-        board.tasks.push(task);
-
-        saveData();
-
-        taskModal.classList.remove(
-            "show"
-        );
-
-        renderTasks();
-        updateDashboard();
+    if (value) {
+      subtasks.push({
+        id: Date.now() + Math.random(),
+        text: value,
+        completed: false,
+      });
     }
-);
+  });
+
+  const task = {
+    id: Date.now(),
+
+    title,
+
+    description,
+
+    status: currentTaskStatus,
+
+    subtasks,
+  };
+
+  const board = getActiveBoard();
+
+  board.tasks.push(task);
+
+  saveData();
+
+  taskModal.classList.remove('show');
+
+  renderTasks();
+  updateDashboard();
+});
 
 /* =====================================
    PROGRESS
 ===================================== */
 
-function calculateProgress(
-    task
-) {
+function calculateProgress(task) {
+  if (!task.subtasks || task.subtasks.length === 0) {
+    return 0;
+  }
 
-    if (
-        !task.subtasks ||
-        task.subtasks.length === 0
-    ) {
-        return 0;
-    }
+  const completed = task.subtasks.filter((s) => s.completed).length;
 
-    const completed =
-        task.subtasks.filter(
-            s => s.completed
-        ).length;
-
-    return Math.round(
-        (
-            completed /
-            task.subtasks.length
-        ) * 100
-    );
+  return Math.round((completed / task.subtasks.length) * 100);
 }
 
 /* =====================================
    TASK CARD
 ===================================== */
 
-function createTaskElement(
-    task
-) {
+function createTaskElement(task) {
+  const progress = calculateProgress(task);
 
-    const progress =
-        calculateProgress(task);
+  const div = document.createElement('div');
 
-    const div =
-        document.createElement("div");
+  div.className = 'task';
 
-    div.className =
-        "task";
+  div.draggable = true;
 
-    div.draggable = true;
+  div.dataset.id = task.id;
 
-    div.dataset.id =
-        task.id;
-
-    div.innerHTML = `
+  div.innerHTML = `
 
         <div class="task-title">
             ${task.title}
         </div>
 
         <div class="task-description">
-            ${
-                task.description ||
-                "No description"
-            }
+            ${task.description || 'No description'}
         </div>
 
         <div class="task-progress">
@@ -501,32 +342,19 @@ function createTaskElement(
 
     `;
 
-    div.addEventListener(
-        "dragstart",
-        () => {
-            div.classList.add(
-                "dragging"
-            );
-        }
-    );
+  div.addEventListener('dragstart', () => {
+    div.classList.add('dragging');
+  });
 
-    div.addEventListener(
-        "dragend",
-        () => {
-            div.classList.remove(
-                "dragging"
-            );
-        }
-    );
+  div.addEventListener('dragend', () => {
+    div.classList.remove('dragging');
+  });
 
-    div.addEventListener(
-        "click",
-        () => {
-            openTaskDetails(task.id);
-        }
-    );
+  div.addEventListener('click', () => {
+    openTaskDetails(task.id);
+  });
 
-    return div;
+  return div;
 }
 
 /* =====================================
@@ -534,51 +362,29 @@ function createTaskElement(
 ===================================== */
 
 function renderTasks() {
+  document.querySelectorAll('.task-container').forEach((container) => {
+    container.innerHTML = '';
+  });
 
-    document
-        .querySelectorAll(
-            ".task-container"
-        )
-        .forEach(container => {
-            container.innerHTML = "";
-        });
+  const board = getActiveBoard();
 
-    const board =
-        getActiveBoard();
+  board.tasks.forEach((task) => {
+    const column = document.getElementById(task.status);
 
-    board.tasks.forEach(task => {
+    if (!column) return;
 
-        const column =
-            document.getElementById(
-                task.status
-            );
+    column.appendChild(createTaskElement(task));
+  });
 
-        if (!column) return;
-
-        column.appendChild(
-            createTaskElement(task)
-        );
-    });
-
-    document
-        .querySelectorAll(
-            ".task-container"
-        )
-        .forEach(container => {
-
-            if (
-                container.children
-                    .length === 0
-            ) {
-
-                container.innerHTML =
-                    `
+  document.querySelectorAll('.task-container').forEach((container) => {
+    if (container.children.length === 0) {
+      container.innerHTML = `
                     <div class="empty-column">
                         No tasks yet
                     </div>
                     `;
-            }
-        });
+    }
+  });
 }
 
 /* =====================================
@@ -586,177 +392,93 @@ function renderTasks() {
 ===================================== */
 
 function updateDashboard() {
+  const board = getActiveBoard();
 
-    const board =
-        getActiveBoard();
+  const tasks = board.tasks;
 
-    const tasks =
-        board.tasks;
+  const total = tasks.length;
 
-    const total =
-        tasks.length;
+  const completed = tasks.filter((t) => t.status === 'completed').length;
 
-    const completed =
-        tasks.filter(
-            t =>
-                t.status ===
-                "completed"
-        ).length;
+  const inProgress = tasks.filter((t) => t.status === 'progress').length;
 
-    const inProgress =
-        tasks.filter(
-            t =>
-                t.status ===
-                "progress"
-        ).length;
+  const pending = tasks.filter(
+    (t) => t.status === 'todo' || t.status === 'review'
+  ).length;
 
-    const pending =
-        tasks.filter(
-            t =>
-                t.status ===
-                    "todo" ||
-                t.status ===
-                    "review"
-        ).length;
+  const percentage = total === 0 ? 0 : Math.round((completed / total) * 100);
 
-    const percentage =
-        total === 0
-            ? 0
-            : Math.round(
-                  (
-                      completed /
-                      total
-                  ) * 100
-              );
+  totalTasksEl.textContent = total;
 
-    totalTasksEl.textContent =
-        total;
+  completedTasksEl.textContent = completed;
 
-    completedTasksEl.textContent =
-        completed;
+  progressTasksEl.textContent = inProgress;
 
-    progressTasksEl.textContent =
-        inProgress;
+  pendingTasksEl.textContent = pending;
 
-    pendingTasksEl.textContent =
-        pending;
-
-    completionRateEl.textContent =
-        percentage + "%";
+  completionRateEl.textContent = percentage + '%';
 }
 
 /* =====================================
    TASK DETAILS MODAL
 ===================================== */
 
-const detailTaskTitle =
-    document.getElementById(
-        "detailTaskTitle"
-    );
+const detailTaskTitle = document.getElementById('detailTaskTitle');
 
-const detailTaskDescription =
-    document.getElementById(
-        "detailTaskDescription"
-    );
+const detailTaskDescription = document.getElementById('detailTaskDescription');
 
-const detailProgressPercent =
-    document.getElementById(
-        "detailProgressPercent"
-    );
+const detailProgressPercent = document.getElementById('detailProgressPercent');
 
-const detailProgressFill =
-    document.getElementById(
-        "detailProgressFill"
-    );
+const detailProgressFill = document.getElementById('detailProgressFill');
 
-const detailSubtaskList =
-    document.getElementById(
-        "detailSubtaskList"
-    );
+const detailSubtaskList = document.getElementById('detailSubtaskList');
 
-const deleteTaskBtn =
-    document.getElementById(
-        "deleteTaskBtn"
-    );
+const deleteTaskBtn = document.getElementById('deleteTaskBtn');
 
 let selectedTaskId = null;
 
-function openTaskDetails(
-    taskId
-) {
+function openTaskDetails(taskId) {
+  const board = getActiveBoard();
 
-    const board =
-        getActiveBoard();
+  const task = board.tasks.find((t) => t.id === taskId);
 
-    const task =
-        board.tasks.find(
-            t => t.id === taskId
-        );
+  if (!task) return;
 
-    if (!task) return;
+  selectedTaskId = task.id;
 
-    selectedTaskId = task.id;
+  detailTaskTitle.textContent = task.title;
 
-    detailTaskTitle.textContent =
-        task.title;
+  detailTaskDescription.textContent =
+    task.description || 'No description available';
 
-    detailTaskDescription.textContent =
-        task.description ||
-        "No description available";
+  const progress = calculateProgress(task);
 
-    const progress =
-        calculateProgress(task);
+  detailProgressPercent.textContent = progress + '%';
 
-    detailProgressPercent.textContent =
-        progress + "%";
+  detailProgressFill.style.width = progress + '%';
 
-    detailProgressFill.style.width =
-        progress + "%";
+  detailSubtaskList.innerHTML = '';
 
-    detailSubtaskList.innerHTML =
-        "";
-
-    if (
-        !task.subtasks ||
-        task.subtasks.length === 0
-    ) {
-
-        detailSubtaskList.innerHTML =
-            `
+  if (!task.subtasks || task.subtasks.length === 0) {
+    detailSubtaskList.innerHTML = `
             <div class="empty-column">
                 No subtasks available
             </div>
             `;
+  } else {
+    task.subtasks.forEach((subtask) => {
+      const item = document.createElement('div');
 
-    } else {
+      item.className = 'detail-subtask';
 
-        task.subtasks.forEach(
-            subtask => {
+      if (subtask.completed) {
+        item.classList.add('completed');
+      }
 
-                const item =
-                    document.createElement(
-                        "div"
-                    );
-
-                item.className =
-                    "detail-subtask";
-
-                if (
-                    subtask.completed
-                ) {
-                    item.classList.add(
-                        "completed"
-                    );
-                }
-
-                item.innerHTML = `
+      item.innerHTML = `
                     <input
                         type="checkbox"
-                        ${
-                            subtask.completed
-                                ? "checked"
-                                : ""
-                        }
+                        ${subtask.completed ? 'checked' : ''}
                     />
 
                     <span>
@@ -764,252 +486,134 @@ function openTaskDetails(
                     </span>
                 `;
 
-                const checkbox =
-                    item.querySelector(
-                        "input"
-                    );
+      const checkbox = item.querySelector('input');
 
-                checkbox.addEventListener(
-                    "change",
-                    () => {
+      checkbox.addEventListener('change', () => {
+        subtask.completed = checkbox.checked;
 
-                        subtask.completed =
-                            checkbox.checked;
+        saveData();
 
-                        saveData();
+        renderTasks();
 
-                        renderTasks();
+        updateDashboard();
 
-                        updateDashboard();
+        openTaskDetails(task.id);
+      });
 
-                        openTaskDetails(
-                            task.id
-                        );
-                    }
-                );
+      detailSubtaskList.appendChild(item);
+    });
+  }
 
-                detailSubtaskList.appendChild(
-                    item
-                );
-            }
-        );
-    }
-
-    taskDetailsModal.classList.add(
-        "show"
-    );
+  taskDetailsModal.classList.add('show');
 }
 
 /* =====================================
    CLOSE DETAILS MODAL
 ===================================== */
 
-document
-    .querySelector(
-        ".close-details"
-    )
-    .addEventListener(
-        "click",
-        () => {
-
-            taskDetailsModal.classList.remove(
-                "show"
-            );
-        }
-    );
+document.querySelector('.close-details').addEventListener('click', () => {
+  taskDetailsModal.classList.remove('show');
+});
 
 /* =====================================
    DELETE TASK
 ===================================== */
 
-deleteTaskBtn.addEventListener(
-    "click",
-    () => {
+deleteTaskBtn.addEventListener('click', () => {
+  if (selectedTaskId === null) return;
 
-        if (
-            selectedTaskId === null
-        )
-            return;
+  const confirmed = confirm('Delete this task?');
 
-        const confirmed =
-            confirm(
-                "Delete this task?"
-            );
+  if (!confirmed) return;
 
-        if (!confirmed)
-            return;
+  const board = getActiveBoard();
 
-        const board =
-            getActiveBoard();
+  board.tasks = board.tasks.filter((task) => task.id !== selectedTaskId);
 
-        board.tasks =
-            board.tasks.filter(
-                task =>
-                    task.id !==
-                    selectedTaskId
-            );
+  saveData();
 
-        saveData();
+  taskDetailsModal.classList.remove('show');
 
-        taskDetailsModal.classList.remove(
-            "show"
-        );
+  renderTasks();
 
-        renderTasks();
-
-        updateDashboard();
-    }
-);
+  updateDashboard();
+});
 
 /* =====================================
    DRAG & DROP
 ===================================== */
 
-document
-    .querySelectorAll(
-        ".task-container"
-    )
-    .forEach(container => {
+document.querySelectorAll('.task-container').forEach((container) => {
+  container.addEventListener('dragover', (e) => {
+    e.preventDefault();
+  });
 
-        container.addEventListener(
-            "dragover",
-            e => {
-                e.preventDefault();
-            }
-        );
+  container.addEventListener('drop', () => {
+    const dragged = document.querySelector('.dragging');
 
-        container.addEventListener(
-            "drop",
-            () => {
+    if (!dragged) return;
 
-                const dragged =
-                    document.querySelector(
-                        ".dragging"
-                    );
+    const taskId = Number(dragged.dataset.id);
 
-                if (!dragged)
-                    return;
+    const board = getActiveBoard();
 
-                const taskId =
-                    Number(
-                        dragged.dataset.id
-                    );
+    const task = board.tasks.find((t) => t.id === taskId);
 
-                const board =
-                    getActiveBoard();
+    if (!task) return;
 
-                const task =
-                    board.tasks.find(
-                        t =>
-                            t.id ===
-                            taskId
-                    );
+    task.status = container.id;
 
-                if (!task)
-                    return;
+    saveData();
 
-                task.status =
-                    container.id;
+    renderTasks();
 
-                saveData();
-
-                renderTasks();
-
-                updateDashboard();
-            }
-        );
-    });
+    updateDashboard();
+  });
+});
 
 /* =====================================
    THEME TOGGLE
 ===================================== */
 
-const themeToggle =
-    document.getElementById(
-        "themeToggle"
-    );
+const themeToggle = document.getElementById('themeToggle');
 
-const savedTheme =
-    localStorage.getItem(
-        "kanbanTheme"
-    );
+const savedTheme = localStorage.getItem('kanbanTheme');
 
-if (
-    savedTheme === "dark"
-) {
+if (savedTheme === 'dark') {
+  document.body.classList.add('dark');
 
-    document.body.classList.add(
-        "dark"
-    );
-
-    themeToggle.textContent =
-        "☀️ Light Mode";
+  themeToggle.textContent = '☀️ Light Mode';
 }
 
-themeToggle.addEventListener(
-    "click",
-    () => {
+themeToggle.addEventListener('click', () => {
+  document.body.classList.toggle('dark');
 
-        document.body.classList.toggle(
-            "dark"
-        );
+  const isDark = document.body.classList.contains('dark');
 
-        const isDark =
-            document.body.classList.contains(
-                "dark"
-            );
+  if (isDark) {
+    localStorage.setItem('kanbanTheme', 'dark');
 
-        if (isDark) {
+    themeToggle.textContent = '☀️ Light Mode';
+  } else {
+    localStorage.setItem('kanbanTheme', 'light');
 
-            localStorage.setItem(
-                "kanbanTheme",
-                "dark"
-            );
-
-            themeToggle.textContent =
-                "☀️ Light Mode";
-
-        } else {
-
-            localStorage.setItem(
-                "kanbanTheme",
-                "light"
-            );
-
-            themeToggle.textContent =
-                "🌙 Dark Mode";
-        }
-    }
-);
+    themeToggle.textContent = '🌙 Dark Mode';
+  }
+});
 
 /* =====================================
    CLOSE MODALS ON OUTSIDE CLICK
 ===================================== */
 
-window.addEventListener(
-    "click",
-    e => {
+window.addEventListener('click', (e) => {
+  if (e.target === taskModal) {
+    taskModal.classList.remove('show');
+  }
 
-        if (
-            e.target === taskModal
-        ) {
-
-            taskModal.classList.remove(
-                "show"
-            );
-        }
-
-        if (
-            e.target ===
-            taskDetailsModal
-        ) {
-
-            taskDetailsModal.classList.remove(
-                "show"
-            );
-        }
-    }
-);
+  if (e.target === taskDetailsModal) {
+    taskDetailsModal.classList.remove('show');
+  }
+});
 
 /* =====================================
    INITIALIZE APP

--- a/public/Kanban_Board/style.css
+++ b/public/Kanban_Board/style.css
@@ -3,43 +3,45 @@
 ========================= */
 
 * {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 :root {
-    --primary: #4f46e5;
-    --primary-dark: #3730a3;
+  --primary: #4f46e5;
+  --primary-dark: #3730a3;
 
-    --success: #22c55e;
-    --warning: #f59e0b;
-    --danger: #ef4444;
+  --success: #22c55e;
+  --warning: #f59e0b;
+  --danger: #ef4444;
 
-    --bg: #f3f4f6;
-    --card: #ffffff;
-    --text: #111827;
-    --border: #e5e7eb;
+  --bg: #f3f4f6;
+  --card: #ffffff;
+  --text: #111827;
+  --border: #e5e7eb;
 
-    --shadow:
-        0 10px 25px rgba(0,0,0,0.08);
+  --shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
 
-    --radius: 16px;
+  --radius: 16px;
 }
 
 body.dark {
-    --bg: #0f172a;
-    --card: #1e293b;
-    --text: #f8fafc;
-    --border: #334155;
+  --bg: #0f172a;
+  --card: #1e293b;
+  --text: #f8fafc;
+  --border: #334155;
 }
 
 body {
-    background: var(--bg);
-    color: var(--text);
-    min-height: 100vh;
-    font-family: Inter, Segoe UI, sans-serif;
-    transition: .3s ease;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  font-family:
+    Inter,
+    Segoe UI,
+    sans-serif;
+  transition: 0.3s ease;
 }
 
 /* =========================
@@ -47,43 +49,43 @@ body {
 ========================= */
 
 header {
-    height: 80px;
+  height: 80px;
 
-    background: var(--card);
+  background: var(--card);
 
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 
-    padding: 0 30px;
+  padding: 0 30px;
 
-    border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
 
-    box-shadow: var(--shadow);
+  box-shadow: var(--shadow);
 }
 
 .header-left h1 {
-    font-size: 1.8rem;
-    font-weight: 700;
+  font-size: 1.8rem;
+  font-weight: 700;
 }
 
 .header-left p {
-    opacity: .7;
-    margin-top: 4px;
+  opacity: 0.7;
+  margin-top: 4px;
 }
 
 #themeToggle {
-    border: none;
-    background: var(--primary);
-    color: white;
-    padding: 12px 18px;
-    border-radius: 10px;
-    cursor: pointer;
-    transition: .3s;
+  border: none;
+  background: var(--primary);
+  color: white;
+  padding: 12px 18px;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: 0.3s;
 }
 
 #themeToggle:hover {
-    background: var(--primary-dark);
+  background: var(--primary-dark);
 }
 
 /* =========================
@@ -91,8 +93,8 @@ header {
 ========================= */
 
 .app-container {
-    display: flex;
-    min-height: calc(100vh - 80px);
+  display: flex;
+  min-height: calc(100vh - 80px);
 }
 
 /* =========================
@@ -100,68 +102,68 @@ header {
 ========================= */
 
 .sidebar {
-    width: 280px;
+  width: 280px;
 
-    background: var(--card);
+  background: var(--card);
 
-    border-right: 1px solid var(--border);
+  border-right: 1px solid var(--border);
 
-    padding: 25px;
+  padding: 25px;
 
-    overflow-y: auto;
+  overflow-y: auto;
 }
 
 .sidebar-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 
-    margin-bottom: 25px;
+  margin-bottom: 25px;
 }
 
 .sidebar-header h2 {
-    font-size: 1.4rem;
+  font-size: 1.4rem;
 }
 
 #addBoardBtn {
-    width: 40px;
-    height: 40px;
+  width: 40px;
+  height: 40px;
 
-    border: none;
-    border-radius: 50%;
+  border: none;
+  border-radius: 50%;
 
-    background: var(--primary);
-    color: white;
+  background: var(--primary);
+  color: white;
 
-    font-size: 22px;
-    cursor: pointer;
+  font-size: 22px;
+  cursor: pointer;
 }
 
 .board-list {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .board-item {
-    padding: 14px;
+  padding: 14px;
 
-    border-radius: 12px;
+  border-radius: 12px;
 
-    background: var(--bg);
+  background: var(--bg);
 
-    cursor: pointer;
+  cursor: pointer;
 
-    transition: .25s ease;
+  transition: 0.25s ease;
 }
 
 .board-item:hover {
-    transform: translateY(-2px);
+  transform: translateY(-2px);
 }
 
 .board-item.active {
-    background: var(--primary);
-    color: white;
+  background: var(--primary);
+  color: white;
 }
 
 /* =========================
@@ -169,9 +171,9 @@ header {
 ========================= */
 
 .content-area {
-    flex: 1;
-    padding: 25px;
-    overflow-y: auto;
+  flex: 1;
+  padding: 25px;
+  overflow-y: auto;
 }
 
 /* =========================
@@ -179,37 +181,36 @@ header {
 ========================= */
 
 .dashboard {
-    display: grid;
+  display: grid;
 
-    grid-template-columns:
-        repeat(auto-fit,minmax(180px,1fr));
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
 
-    gap: 20px;
+  gap: 20px;
 
-    margin-bottom: 25px;
+  margin-bottom: 25px;
 }
 
 .stat-card {
-    background: var(--card);
+  background: var(--card);
 
-    border-radius: var(--radius);
+  border-radius: var(--radius);
 
-    padding: 20px;
+  padding: 20px;
 
-    box-shadow: var(--shadow);
+  box-shadow: var(--shadow);
 
-    text-align: center;
+  text-align: center;
 }
 
 .stat-card h3 {
-    font-size: .95rem;
-    opacity: .8;
-    margin-bottom: 12px;
+  font-size: 0.95rem;
+  opacity: 0.8;
+  margin-bottom: 12px;
 }
 
 .stat-card span {
-    font-size: 2rem;
-    font-weight: 700;
+  font-size: 2rem;
+  font-weight: 700;
 }
 
 /* =========================
@@ -217,28 +218,28 @@ header {
 ========================= */
 
 .current-board-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 
-    margin-bottom: 25px;
+  margin-bottom: 25px;
 }
 
 #currentBoardTitle {
-    font-size: 2rem;
+  font-size: 2rem;
 }
 
 #renameBoardBtn {
-    border: none;
+  border: none;
 
-    background: var(--warning);
-    color: white;
+  background: var(--warning);
+  color: white;
 
-    padding: 12px 18px;
+  padding: 12px 18px;
 
-    border-radius: 10px;
+  border-radius: 10px;
 
-    cursor: pointer;
+  cursor: pointer;
 }
 
 /* =========================
@@ -246,56 +247,55 @@ header {
 ========================= */
 
 .board {
-    display: grid;
+  display: grid;
 
-    grid-template-columns:
-        repeat(4,1fr);
+  grid-template-columns: repeat(4, 1fr);
 
-    gap: 20px;
+  gap: 20px;
 }
 
 .column {
-    background: var(--card);
+  background: var(--card);
 
-    border-radius: var(--radius);
+  border-radius: var(--radius);
 
-    min-height: 600px;
+  min-height: 600px;
 
-    padding: 18px;
+  padding: 18px;
 
-    box-shadow: var(--shadow);
+  box-shadow: var(--shadow);
 }
 
 .column-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 
-    margin-bottom: 20px;
+  margin-bottom: 20px;
 }
 
 .column-header h3 {
-    font-size: 1rem;
+  font-size: 1rem;
 }
 
 .add-column-task {
-    width: 38px;
-    height: 38px;
+  width: 38px;
+  height: 38px;
 
-    border: none;
-    border-radius: 50%;
+  border: none;
+  border-radius: 50%;
 
-    background: var(--primary);
+  background: var(--primary);
 
-    color: white;
+  color: white;
 
-    font-size: 22px;
+  font-size: 22px;
 
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .task-container {
-    min-height: 450px;
+  min-height: 450px;
 }
 
 /* =========================
@@ -303,97 +303,93 @@ header {
 ========================= */
 
 .task {
-    background: var(--bg);
+  background: var(--bg);
 
-    border-radius: 14px;
+  border-radius: 14px;
 
-    padding: 15px;
+  padding: 15px;
 
-    margin-bottom: 15px;
+  margin-bottom: 15px;
 
-    cursor: grab;
+  cursor: grab;
 
-    transition: .25s ease;
+  transition: 0.25s ease;
 
-    border-left: 5px solid var(--primary);
+  border-left: 5px solid var(--primary);
 }
 
 .task:hover {
-    transform: translateY(-3px);
-    box-shadow: 0 10px 20px rgba(0,0,0,.08);
+  transform: translateY(-3px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.08);
 }
 
 .task.dragging {
-    opacity: .5;
+  opacity: 0.5;
 }
 
 .task-title {
-    font-size: 1rem;
-    font-weight: 700;
-    margin-bottom: 8px;
+  font-size: 1rem;
+  font-weight: 700;
+  margin-bottom: 8px;
 }
 
 .task-description {
-    font-size: .9rem;
-    opacity: .8;
-    margin-bottom: 12px;
+  font-size: 0.9rem;
+  opacity: 0.8;
+  margin-bottom: 12px;
 
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    line-clamp: 2;
-    -webkit-box-orient: vertical;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
 
-    overflow: hidden;
+  overflow: hidden;
 }
 
 .task-footer {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .progress-label {
-    font-size: .8rem;
-    font-weight: 600;
+  font-size: 0.8rem;
+  font-weight: 600;
 }
 
 .task-progress {
-    margin-top: 12px;
+  margin-top: 12px;
 }
 
 .progress-bar {
-    width: 100%;
-    height: 10px;
+  width: 100%;
+  height: 10px;
 
-    background: rgba(0,0,0,.08);
+  background: rgba(0, 0, 0, 0.08);
 
-    border-radius: 999px;
+  border-radius: 999px;
 
-    overflow: hidden;
+  overflow: hidden;
 }
 
 .progress-fill {
-    height: 100%;
+  height: 100%;
 
-    width: 0;
+  width: 0;
 
-    background: linear-gradient(
-        90deg,
-        #22c55e,
-        #16a34a
-    );
+  background: linear-gradient(90deg, #22c55e, #16a34a);
 
-    transition: width .3s ease;
+  transition: width 0.3s ease;
 }
 
 .progress-info {
-    display: flex;
-    justify-content: space-between;
+  display: flex;
+  justify-content: space-between;
 
-    margin-bottom: 8px;
+  margin-bottom: 8px;
 
-    font-size: .85rem;
-    font-weight: 600;
+  font-size: 0.85rem;
+  font-weight: 600;
 }
 
 /* =========================
@@ -401,86 +397,85 @@ header {
 ========================= */
 
 .modal {
-    position: fixed;
+  position: fixed;
 
-    inset: 0;
+  inset: 0;
 
-    background: rgba(0,0,0,.55);
+  background: rgba(0, 0, 0, 0.55);
 
-    display: none;
+  display: none;
 
-    justify-content: center;
-    align-items: center;
+  justify-content: center;
+  align-items: center;
 
-    z-index: 1000;
+  z-index: 1000;
 
-    padding: 20px;
+  padding: 20px;
 }
 
 .modal.show {
-    display: flex;
+  display: flex;
 }
 
 .modal-content {
-    width: 100%;
-    max-width: 700px;
+  width: 100%;
+  max-width: 700px;
 
-    background: var(--card);
+  background: var(--card);
 
-    border-radius: 20px;
+  border-radius: 20px;
 
-    overflow: hidden;
+  overflow: hidden;
 
-    box-shadow:
-        0 25px 50px rgba(0,0,0,.25);
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.25);
 
-    animation: modalOpen .25s ease;
+  animation: modalOpen 0.25s ease;
 }
 
 @keyframes modalOpen {
-    from {
-        opacity: 0;
-        transform: translateY(25px);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(25px);
+  }
 
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .modal-header {
-    padding: 20px 25px;
+  padding: 20px 25px;
 
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 
-    border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
 }
 
 .modal-header h2 {
-    font-size: 1.4rem;
+  font-size: 1.4rem;
 }
 
 .close-modal,
 .close-details {
-    font-size: 28px;
-    cursor: pointer;
-    font-weight: bold;
+  font-size: 28px;
+  cursor: pointer;
+  font-weight: bold;
 }
 
 .modal-body {
-    padding: 25px;
+  padding: 25px;
 }
 
 .modal-footer {
-    padding: 20px 25px;
+  padding: 20px 25px;
 
-    border-top: 1px solid var(--border);
+  border-top: 1px solid var(--border);
 
-    display: flex;
-    justify-content: flex-end;
+  display: flex;
+  justify-content: flex-end;
 }
 
 /* =========================
@@ -489,44 +484,44 @@ header {
 
 input,
 textarea {
-    width: 100%;
+  width: 100%;
 
-    padding: 14px;
+  padding: 14px;
 
-    border-radius: 12px;
+  border-radius: 12px;
 
-    border: 1px solid var(--border);
+  border: 1px solid var(--border);
 
-    background: var(--bg);
+  background: var(--bg);
 
-    color: var(--text);
+  color: var(--text);
 
-    margin-bottom: 15px;
+  margin-bottom: 15px;
 
-    outline: none;
+  outline: none;
 }
 
 textarea {
-    resize: vertical;
-    min-height: 120px;
+  resize: vertical;
+  min-height: 120px;
 }
 
 #saveTaskBtn {
-    border: none;
+  border: none;
 
-    background: var(--primary);
+  background: var(--primary);
 
-    color: white;
+  color: white;
 
-    padding: 12px 22px;
+  padding: 12px 22px;
 
-    border-radius: 10px;
+  border-radius: 10px;
 
-    cursor: pointer;
+  cursor: pointer;
 }
 
 #saveTaskBtn:hover {
-    background: var(--primary-dark);
+  background: var(--primary-dark);
 }
 
 /* =========================
@@ -534,58 +529,58 @@ textarea {
 ========================= */
 
 .subtask-section {
-    margin-top: 20px;
+  margin-top: 20px;
 }
 
 .subtask-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 
-    margin-bottom: 15px;
+  margin-bottom: 15px;
 }
 
 .subtask-header h4 {
-    font-size: 1rem;
+  font-size: 1rem;
 }
 
 #addSubtaskBtn {
-    border: none;
+  border: none;
 
-    background: var(--success);
+  background: var(--success);
 
-    color: white;
+  color: white;
 
-    padding: 10px 16px;
+  padding: 10px 16px;
 
-    border-radius: 10px;
+  border-radius: 10px;
 
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .subtask-item {
-    display: flex;
-    gap: 10px;
+  display: flex;
+  gap: 10px;
 
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 
 .subtask-item input {
-    margin-bottom: 0;
+  margin-bottom: 0;
 }
 
 .remove-subtask {
-    width: 45px;
+  width: 45px;
 
-    border: none;
+  border: none;
 
-    background: var(--danger);
+  background: var(--danger);
 
-    color: white;
+  color: white;
 
-    border-radius: 10px;
+  border-radius: 10px;
 
-    cursor: pointer;
+  cursor: pointer;
 }
 
 /* =========================
@@ -593,59 +588,59 @@ textarea {
 ========================= */
 
 .task-details {
-    max-width: 800px;
+  max-width: 800px;
 }
 
 .detail-subtasks {
-    margin-top: 20px;
+  margin-top: 20px;
 }
 
 .detail-subtask {
-    display: flex;
-    align-items: center;
+  display: flex;
+  align-items: center;
 
-    gap: 12px;
+  gap: 12px;
 
-    padding: 12px;
+  padding: 12px;
 
-    border-radius: 10px;
+  border-radius: 10px;
 
-    background: var(--bg);
+  background: var(--bg);
 
-    margin-bottom: 10px;
+  margin-bottom: 10px;
 }
 
-.detail-subtask input[type="checkbox"] {
-    width: 18px;
-    height: 18px;
+.detail-subtask input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
 
-    margin: 0;
+  margin: 0;
 }
 
 .detail-subtask.completed span {
-    text-decoration: line-through;
-    opacity: .6;
+  text-decoration: line-through;
+  opacity: 0.6;
 }
 
 .task-actions {
-    margin-top: 25px;
+  margin-top: 25px;
 
-    display: flex;
-    justify-content: flex-end;
+  display: flex;
+  justify-content: flex-end;
 }
 
 #deleteTaskBtn {
-    border: none;
+  border: none;
 
-    background: var(--danger);
+  background: var(--danger);
 
-    color: white;
+  color: white;
 
-    padding: 12px 20px;
+  padding: 12px 20px;
 
-    border-radius: 10px;
+  border-radius: 10px;
 
-    cursor: pointer;
+  cursor: pointer;
 }
 
 /* =========================
@@ -653,13 +648,13 @@ textarea {
 ========================= */
 
 .empty-column {
-    text-align: center;
+  text-align: center;
 
-    padding: 40px 20px;
+  padding: 40px 20px;
 
-    opacity: .6;
+  opacity: 0.6;
 
-    font-size: .9rem;
+  font-size: 0.9rem;
 }
 
 /* =========================
@@ -667,21 +662,21 @@ textarea {
 ========================= */
 
 body.dark .task {
-    background: rgba(255,255,255,.03);
+  background: rgba(255, 255, 255, 0.03);
 }
 
 body.dark input,
 body.dark textarea {
-    background: #0f172a;
-    border-color: #334155;
+  background: #0f172a;
+  border-color: #334155;
 }
 
 body.dark .detail-subtask {
-    background: #0f172a;
+  background: #0f172a;
 }
 
 body.dark .progress-bar {
-    background: rgba(255,255,255,.08);
+  background: rgba(255, 255, 255, 0.08);
 }
 
 /* =========================
@@ -689,66 +684,61 @@ body.dark .progress-bar {
 ========================= */
 
 @media (max-width: 1200px) {
-
-    .board {
-        grid-template-columns: repeat(2,1fr);
-    }
+  .board {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 @media (max-width: 900px) {
+  .app-container {
+    flex-direction: column;
+  }
 
-    .app-container {
-        flex-direction: column;
-    }
+  .sidebar {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
 
-    .sidebar {
-        width: 100%;
-        border-right: none;
-        border-bottom: 1px solid var(--border);
-    }
-
-    .dashboard {
-        grid-template-columns:
-        repeat(2,1fr);
-    }
+  .dashboard {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 @media (max-width: 768px) {
+  header {
+    flex-direction: column;
+    gap: 12px;
+    height: auto;
+    padding: 20px;
+  }
 
-    header {
-        flex-direction: column;
-        gap: 12px;
-        height: auto;
-        padding: 20px;
-    }
+  .board {
+    grid-template-columns: 1fr;
+  }
 
-    .board {
-        grid-template-columns: 1fr;
-    }
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
 
-    .dashboard {
-        grid-template-columns: 1fr;
-    }
-
-    .current-board-container {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 15px;
-    }
+  .current-board-container {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 15px;
+  }
 }
 
 @media (max-width: 500px) {
+  .modal-content {
+    max-height: 90vh;
+    overflow-y: auto;
+  }
 
-    .modal-content {
-        max-height: 90vh;
-        overflow-y: auto;
-    }
+  .stat-card span {
+    font-size: 1.6rem;
+  }
 
-    .stat-card span {
-        font-size: 1.6rem;
-    }
-
-    #currentBoardTitle {
-        font-size: 1.5rem;
-    }
+  #currentBoardTitle {
+    font-size: 1.5rem;
+  }
 }


### PR DESCRIPTION
## Description

### Fixes #9615

### Summary

This PR prevents users from creating or renaming boards with duplicate names in the Advanced Kanban Board. Board names are now validated before creation and renaming to ensure uniqueness, improving board management and preventing user confusion.

### Changes Made

* Added duplicate name validation before creating a new board.
* Added duplicate name validation when renaming an existing board.
* Performed case-insensitive comparison to prevent duplicates such as `Project Alpha` and `project alpha`.
* Trimmed leading and trailing whitespace before validation.
* Displayed a user-friendly alert when a duplicate board name is detected.

### Before

* Multiple boards could have identical names.
* Users could rename a board to an existing board name.
* Sidebar displayed duplicate board names, making navigation confusing.

### After

* Board names must be unique.
* Duplicate board creation is prevented.
* Duplicate board renaming is prevented.
* Users receive clear feedback when a duplicate name is entered.

### Testing

* Created a board with a unique name.
* Attempted to create a duplicate board (case-insensitive).
* Attempted to rename a board to an existing board name.
* Verified unique board creation and renaming continue to work correctly.
* Confirmed no regressions in board switching or task management.
