### PR TITLE
refactor: improve HTML structure and move inline styles to CSS in HSL Color Picker

### DIFF
--- a/public/HCL Color Generator/index.html
+++ b/public/HCL Color Generator/index.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>HSL Color Picker</title>
   <link rel="stylesheet" href="./style.css">
-  <link rel="icon" href="../favv.png" type="image/x-icon" />
+  <link rel="icon" href="../favv.png" type="image/x-icon">
 </head>
 <body>
-<a href="/" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 16px;border-radius:8px;background:#1e293b;color:#3b82f6;border:1px solid #3b82f6;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;transition:all 0.2s ease;" onmouseover="this.style.background='#3b82f6';this.style.color='#fff'" onmouseout="this.style.background='#1e293b';this.style.color='#3b82f6'">← Back to Home</a>
+<a href="/" class="project-back-button" onmouseover="this.style.background='#3b82f6';this.style.color='#fff'" onmouseout="this.style.background='#1e293b';this.style.color='#3b82f6'">← Back to Home</a>
 
 
   <div class="bg-orbs">
@@ -47,7 +47,7 @@
       <div class="palette-grid" id="quickPalette"></div>
     </div>
 
-    <button id="copyBtn">Copy Color</button>
+    <button type="button" id="copyBtn">Copy Color</button>
   </div>
 
   <script src="script.js"></script>

--- a/public/HCL Color Generator/style.css
+++ b/public/HCL Color Generator/style.css
@@ -34,6 +34,21 @@ body {
 .orb3 { width: 350px; height: 350px; top: 50%;     left: 50%;
         transform: translate(-50%, -50%); }
 
+.project-back-button{
+  position:fixed;
+  left:18px;
+  top:18px;
+  padding:8px 16px;
+  border-radius:8px;
+  background:#1e293b;
+  color:#3b82f6;
+  border:1px solid #3b82f6;
+  text-decoration:none;
+  z-index:9999;
+  font-weight:700;
+  font-family:Inter, system-ui, sans-serif;
+  transition:all 0.2s ease;
+}
 
 .container {
   position: relative;


### PR DESCRIPTION
## Description

### Related Issue
Closes #9783 

### Summary
Refactored the HSL Color Picker HTML to improve maintainability and HTML standards compliance. Moved inline styling into the external stylesheet, added explicit button types, and cleaned up minor HTML syntax without affecting existing functionality.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [x] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made

- Moved inline CSS from the "Back to Home" button into the external stylesheet.
- Added `type="button"` to the Copy Color button.
- Updated HTML to follow modern HTML5 syntax by removing unnecessary self-closing slashes.
- Improved separation of structure and presentation.
- Preserved existing functionality and UI behavior.

---

## 🧪 Testing and Verification

### Local Validation
- [x] HTML reviewed after refactoring.
- [x] No structural or validation issues introduced.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [x] Tested and verified in **Mozilla Firefox**
- [x] Tested and verified in **Microsoft Edge**

### Functionality Checks
- [x] Copy Color button continues to work correctly.
- [x] Navigation button appearance remains unchanged.
- [x] Styles load correctly from the external stylesheet.
- [x] No visual regressions observed.

---

## 📷 Screenshots / Video Recording

N/A (HTML refactoring and CSS cleanup only)

---

## 🤝 Contributor Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.