### PR TITLE
docs(#9744): fix CONTRIBUTING.md to reference projects.json instead o…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,7 +213,7 @@ Your Name
 ```
 
 ### Step 3: Update Main Project List
-Add your project to the main website by editing `index.js`:
+Add your project to the main website by editing `projects.json`. Do not modify `index.js` directly.
 
 ```javascript
 // Find the data array and add your project
@@ -223,13 +223,13 @@ Add your project to the main website by editing `index.js`:
 
 ## ➕ Adding Your Project to the Project List
 
-Welcome! This section will walk you through how to correctly add your project to the main project list in `index.js`. Following this format carefully ensures your project shows up on the website, works with filters, and links correctly. Don't worry — it's simpler than it looks!
+Welcome! This section will walk you through how to correctly add your project to the main project list in `projects.json`. Following this format carefully ensures your project shows up on the website, works with filters, and links correctly. Don't worry — it's simpler than it looks!
 
 ---
 
 ### 📋 The Project Entry Format
 
-Each project is stored as a single line inside the `PROJECTS` array in `index.js`. Every entry follows this structure:
+Each project is stored as a single line inside the `PROJECTS` array in `projects.json`. Every entry follows this structure:
 
 ```javascript
 ["Day Number", "Project Name", "./public/FolderName/index.html", ["tag1", "tag2"], "Difficulty"]
@@ -390,7 +390,7 @@ Before submitting your pull request, preview your changes locally and verify tha
 
 ---
 
-> **Still unsure?** Look at any existing entry in `index.js` as a reference, or open an issue and the maintainers will be happy to help.
+> **Still unsure?** Look at any existing entry in `projects.json` as a reference, or open an issue and the maintainers will be happy to help.
 
 ### Step 4: Add .gitignore (If needed)
 For projects with dependencies:


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #9744

### Summary
The CONTRIBUTING.md file incorrectly instructed contributors to add new projects in `index.js`.  
This PR updates the documentation to correctly reference `projects.json`, ensuring new contributors follow the proper workflow.  
I am a **GSSoC'26 contributor** and worked on fixing this documentation issue.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation update
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Corrected Step 3 in CONTRIBUTING.md to reference `projects.json` instead of `index.js`.
- Updated explanatory text in the "Adding Your Project to the Project List" section to match the actual workflow.

---

## 🧪 Testing and Verification

### Local Validation
- N/A — documentation-only change, no project entries modified.


### Browser Compatibility Check
N/A — documentation-only change.

### Responsive & Accessibility Checks
N/A — documentation-only change.

---

## 📷 Screenshots / Video Recording
N/A — documentation-only change.

---

## 🤝 Contributor Checklist
- [x] My changes follow the code style guidelines of this project.
- [x] I have performed a self-review of my own changes.
- [x] I have updated the documentation accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
