### PR TITLE
fix: preserve selected difficulty after each score

### DIFF
--- a/public/ping/index.html
+++ b/public/ping/index.html
@@ -1,65 +1,127 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
- <meta charset="UTF-8">
- <meta http-equiv="X-UA-Compatible" content="IE=edge">
- <meta name="viewport" content="width=device-width, initial-scale=1.0">
- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css" integrity="sha512-2SwdPD6INVrV/lHTZbO2nodKhrnDdJK9/kg2XD1r9uGqPo1cUbujc+IYdlYdEErWNu69gVcYgdxlmVmzTWnetw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
- <link rel="stylesheet" href="style.css">
- <script src="script.js" defer></script>
- <title>Ping Pong Game</title>
-</head>
-<body>
-<a href="/" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 16px;border-radius:8px;background:#1e293b;color:#3b82f6;border:1px solid #3b82f6;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;transition:all 0.2s ease;" onmouseover="this.style.background='#3b82f6';this.style.color='#fff'" onmouseout="this.style.background='#1e293b';this.style.color='#3b82f6'">← Back to Home</a>
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/7.0.1/css/all.min.css"
+      integrity="sha512-2SwdPD6INVrV/lHTZbO2nodKhrnDdJK9/kg2XD1r9uGqPo1cUbujc+IYdlYdEErWNu69gVcYgdxlmVmzTWnetw=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <link rel="stylesheet" href="style.css" />
+    <script src="script.js" defer></script>
+    <title>Ping Pong Game</title>
+  </head>
+  <body>
+    <a
+      href="/"
+      class="project-back-button"
+      style="
+        position: fixed;
+        left: 18px;
+        top: 18px;
+        padding: 8px 16px;
+        border-radius: 8px;
+        background: #1e293b;
+        color: #3b82f6;
+        border: 1px solid #3b82f6;
+        text-decoration: none;
+        z-index: 9999;
+        font-weight: 700;
+        font-family: Inter, system-ui, sans-serif;
+        transition: all 0.2s ease;
+      "
+      onmouseover="
+        this.style.background = '#3b82f6';
+        this.style.color = '#fff';
+      "
+      onmouseout="
+        this.style.background = '#1e293b';
+        this.style.color = '#3b82f6';
+      "
+      >← Back to Home</a
+    >
 
- <div class="header">
-  <i aria-hidden="true" class="fa-solid fa-table-tennis-paddle-ball" style="color: rgb(250, 248, 244);"></i>
-  <h1> THE PING PONG CHALLENGE </h1>
-  <i aria-hidden="true" class="fa-solid fa-table-tennis-paddle-ball" style="color: rgb(250, 248, 244);"></i>
-</div>
+    <div class="header">
+      <i
+        aria-hidden="true"
+        class="fa-solid fa-table-tennis-paddle-ball"
+        style="color: rgb(250, 248, 244)"
+      ></i>
+      <h1>THE PING PONG CHALLENGE</h1>
+      <i
+        aria-hidden="true"
+        class="fa-solid fa-table-tennis-paddle-ball"
+        style="color: rgb(250, 248, 244)"
+      ></i>
+    </div>
 
-<div class="theme-panel">
-  <span class="theme-label">Theme</span>
-  <div class="theme-selector" role="radiogroup" aria-label="Select game theme">
-    <button class="theme-btn" type="button" data-theme="classic" aria-pressed="false">Classic</button>
-    <button class="theme-btn" type="button" data-theme="neon" aria-pressed="false">Neon</button>
-    <button class="theme-btn" type="button" data-theme="retro" aria-pressed="false">Retro Arcade</button>
-  </div>
-</div>
+    <div class="theme-panel">
+      <span class="theme-label">Theme</span>
+      <div
+        class="theme-selector"
+        role="radiogroup"
+        aria-label="Select game theme"
+      >
+        <button
+          class="theme-btn"
+          type="button"
+          data-theme="classic"
+          aria-pressed="false"
+        >
+          Classic
+        </button>
+        <button
+          class="theme-btn"
+          type="button"
+          data-theme="neon"
+          aria-pressed="false"
+        >
+          Neon
+        </button>
+        <button
+          class="theme-btn"
+          type="button"
+          data-theme="retro"
+          aria-pressed="false"
+        >
+          Retro Arcade
+        </button>
+      </div>
+    </div>
 
-<h2> SELECT DIFFICULTY </h2>
+    <h2>SELECT DIFFICULTY</h2>
     <div class="buttons">
-    <button class ="easy" onclick="setDifficulty('easy')">
-        Easy
-    </button>
-    <button class ="medium" onclick="setDifficulty('medium')">
-        Medium
-    </button>
-    <button class="hard" onclick="setDifficulty('hard')">
-        Hard
-    </button>
+      <button class="easy" onclick="setDifficulty('easy')">Easy</button>
+      <button class="medium" onclick="setDifficulty('medium')">Medium</button>
+      <button class="hard" onclick="setDifficulty('hard')">Hard</button>
     </div>
 
-    <div class ="score">
-        <h2>Score</h2>
-        <div id="user-score">0</div><div> - </div><div id="computer-score">0</div>
+    <div class="score">
+      <h2>Score</h2>
+      <div id="user-score">0</div>
+      <div>-</div>
+      <div id="computer-score">0</div>
     </div>
- <div class="pong-wrapper">
-  <canvas id="ping-pong" width="600px" height="400px"></canvas>
- </div>
- <div class ="result" id ="result"> 
-    <div class ="result-inner">
+    <div class="pong-wrapper">
+      <canvas id="ping-pong" width="600px" height="400px"></canvas>
+    </div>
+    <div class="result" id="result">
+      <div class="result-inner">
         <h2 id="msg1">winner</h2>
-        <p id="msg"> WINNER</p>
+        <p id="msg">WINNER</p>
         <div class="buttons">
-        <button class ="new-btn">NEW GAME</button>
+          <button class="new-btn">NEW GAME</button>
         </div>
-    </div>    
-</div>
- <div class="buttons">
-   <button class="start-btn">Start</button>
-   <button class="pause-btn">Pause</button>
-   <button class="restart-btn">Restart</button>
-  </div>
-</body>
+      </div>
+    </div>
+    <div class="buttons">
+      <button class="start-btn">Start</button>
+      <button class="pause-btn">Pause</button>
+      <button class="restart-btn">Restart</button>
+    </div>
+  </body>
 </html>

--- a/public/ping/script.js
+++ b/public/ping/script.js
@@ -1,45 +1,47 @@
-const canvas = document.querySelector("#ping-pong");
-const context = canvas.getContext("2d");
+const canvas = document.querySelector('#ping-pong');
+const context = canvas.getContext('2d');
 
-const startBtn = document.querySelector(".start-btn");
-const pauseBtn = document.querySelector(".pause-btn");
-const restartBtn = document.querySelector(".restart-btn");
-const newBtn = document.querySelector(".new-btn");
-const themeButtons = document.querySelectorAll(".theme-btn");
+const startBtn = document.querySelector('.start-btn');
+const pauseBtn = document.querySelector('.pause-btn');
+const restartBtn = document.querySelector('.restart-btn');
+const newBtn = document.querySelector('.new-btn');
+const themeButtons = document.querySelectorAll('.theme-btn');
 
-const userscore = document.querySelector("#user-score");
-const computerscore = document.querySelector("#computer-score");
+const userscore = document.querySelector('#user-score');
+const computerscore = document.querySelector('#computer-score');
 
-const result = document.querySelector(".result");
-const msg = document.querySelector("#msg");
-const msg1 = document.querySelector("#msg1");
+const result = document.querySelector('.result');
+const msg = document.querySelector('#msg');
+const msg1 = document.querySelector('#msg1');
 
 let gameRunning = false;
 let animationId;
 const easy = 5;
 const medium = 9;
 const hard = 13;
-const STORAGE_KEY = "ping-pong-theme";
+
+let selectedSpeed = medium;
+const STORAGE_KEY = 'ping-pong-theme';
 
 const themeConfig = {
   classic: {
-    paddleColor: "#ffffff",
-    computerPaddleColor: "#ffffff",
-    ballColor: "#ffffff",
-    netColor: "#ffffff"
+    paddleColor: '#ffffff',
+    computerPaddleColor: '#ffffff',
+    ballColor: '#ffffff',
+    netColor: '#ffffff',
   },
   neon: {
-    paddleColor: "#00d9ff",
-    computerPaddleColor: "#00d9ff",
-    ballColor: "#ff3db9",
-    netColor: "#00d9ff"
+    paddleColor: '#00d9ff',
+    computerPaddleColor: '#00d9ff',
+    ballColor: '#ff3db9',
+    netColor: '#00d9ff',
   },
   retro: {
-    paddleColor: "#93ff4d",
-    computerPaddleColor: "#93ff4d",
-    ballColor: "#f5ff61",
-    netColor: "#d6ff8a"
-  }
+    paddleColor: '#93ff4d',
+    computerPaddleColor: '#93ff4d',
+    ballColor: '#f5ff61',
+    netColor: '#d6ff8a',
+  },
 };
 
 // CREATE USER PADDLE
@@ -49,7 +51,7 @@ const user = {
   width: 10,
   height: 100,
   color: themeConfig.classic.paddleColor,
-  score: 0
+  score: 0,
 };
 
 // CREATE COMPUTER PADDLE
@@ -59,7 +61,7 @@ const computer = {
   width: 10,
   height: 100,
   color: themeConfig.classic.computerPaddleColor,
-  score: 0
+  score: 0,
 };
 
 // CREATE THE BALL
@@ -70,7 +72,7 @@ const ball = {
   speed: 5,
   velocityX: 5,
   velocityY: 5,
-  color: themeConfig.classic.ballColor
+  color: themeConfig.classic.ballColor,
 };
 
 // CREATE THE NET
@@ -79,11 +81,11 @@ const net = {
   y: 0,
   width: 2,
   height: 10,
-  color: themeConfig.classic.netColor
+  color: themeConfig.classic.netColor,
 };
 
 function applyTheme(themeName) {
-  const selectedTheme = themeConfig[themeName] ? themeName : "classic";
+  const selectedTheme = themeConfig[themeName] ? themeName : 'classic';
   document.body.dataset.theme = selectedTheme;
 
   const settings = themeConfig[selectedTheme];
@@ -94,30 +96,30 @@ function applyTheme(themeName) {
 
   themeButtons.forEach((button) => {
     const isActive = button.dataset.theme === selectedTheme;
-    button.classList.toggle("active", isActive);
-    button.setAttribute("aria-pressed", String(isActive));
+    button.classList.toggle('active', isActive);
+    button.setAttribute('aria-pressed', String(isActive));
   });
 
   localStorage.setItem(STORAGE_KEY, selectedTheme);
 }
 
-restartBtn.addEventListener("click", () => {
+restartBtn.addEventListener('click', () => {
   document.location.reload();
 });
 
-newBtn.addEventListener("click", () => {
+newBtn.addEventListener('click', () => {
   document.location.reload();
 });
 
 themeButtons.forEach((button) => {
-  button.addEventListener("click", () => {
+  button.addEventListener('click', () => {
     applyTheme(button.dataset.theme);
   });
 });
 
-window.addEventListener("load", () => {
+window.addEventListener('load', () => {
   const savedTheme = localStorage.getItem(STORAGE_KEY);
-  applyTheme(savedTheme || "classic");
+  applyTheme(savedTheme || 'classic');
   render();
 });
 
@@ -127,7 +129,13 @@ function drawNet() {
   const netSpacing = 15;
 
   for (let i = 0; i <= canvas.height; i += netSpacing) {
-    drawRectangle(net.x - netWidth / 2, net.y + i, netWidth, net.height, net.color);
+    drawRectangle(
+      net.x - netWidth / 2,
+      net.y + i,
+      netWidth,
+      net.height,
+      net.color
+    );
   }
 }
 
@@ -149,38 +157,48 @@ function drawCircle(x, y, r, color) {
 // DRAW TEXT FUNCTION
 function drawText(text, x, y, color) {
   context.fillStyle = color;
-  context.font = "45px fantasy";
+  context.font = '45px fantasy';
   context.fillText(text, x, y);
 }
 
-// SET DIFFICULTY FUNCTION 
+// SET DIFFICULTY FUNCTION
 function setDifficulty(level) {
-  if (level === "easy") {
-    ball.speed = easy;
-    ball.velocityX = easy;
-    ball.velocityY = easy;
-  } else if (level === "medium") {
-    ball.speed = medium;
-    ball.velocityX = medium;
-    ball.velocityY = medium;
-  } else if (level === "hard") {
-    ball.speed = hard;
-    ball.velocityX = hard;
-    ball.velocityY = hard;
+  if (level === 'easy') {
+    selectedSpeed = easy;
+  } else if (level === 'medium') {
+    selectedSpeed = medium;
+  } else if (level === 'hard') {
+    selectedSpeed = hard;
   }
+
+  ball.speed = selectedSpeed;
+  ball.velocityX = ball.velocityX >= 0 ? selectedSpeed : -selectedSpeed;
+  ball.velocityY = ball.velocityY >= 0 ? selectedSpeed : -selectedSpeed;
 }
 
 // RENDER GAME FUNCTION
 function render() {
   // CLEAR THE CANVAS
-  drawRectangle(0, 0, canvas.width, canvas.height, getComputedStyle(document.body).getPropertyValue("--canvas-bg").trim());
+  drawRectangle(
+    0,
+    0,
+    canvas.width,
+    canvas.height,
+    getComputedStyle(document.body).getPropertyValue('--canvas-bg').trim()
+  );
 
   // DRAW THE NET
   drawNet();
 
   // DRAW THE USER AND COMPUTER PADDLES
   drawRectangle(user.x, user.y, user.width, user.height, user.color);
-  drawRectangle(computer.x, computer.y, computer.width, computer.height, computer.color);
+  drawRectangle(
+    computer.x,
+    computer.y,
+    computer.width,
+    computer.height,
+    computer.color
+  );
 
   // DRAW THE BALL
   drawCircle(ball.x, ball.y, ball.radius, ball.color);
@@ -190,7 +208,7 @@ function render() {
 }
 
 // CONTROL USERS PADDLE
-canvas.addEventListener("mousemove", movePaddle);
+canvas.addEventListener('mousemove', movePaddle);
 
 function movePaddle(evt) {
   let rectangle = canvas.getBoundingClientRect();
@@ -209,16 +227,21 @@ function collision(b, p) {
   p.left = p.x;
   p.right = p.x + p.width;
 
-  return b.right > p.left && b.bottom > p.top && b.left < p.right && b.top < p.bottom;
+  return (
+    b.right > p.left && b.bottom > p.top && b.left < p.right && b.top < p.bottom
+  );
 }
 
 // RESET BALL FUNCTION
 function resetBall() {
   ball.x = canvas.width / 2;
   ball.y = canvas.height / 2;
-  ball.speed = 9;
-  ball.velocityX = 9;
-  ball.velocityY = 9;
+
+  ball.speed = selectedSpeed;
+
+  // Serve towards the player who lost the previous point
+  ball.velocityX = -ball.velocityX > 0 ? selectedSpeed : -selectedSpeed;
+  ball.velocityY = selectedSpeed;
 }
 
 // UPDATE FUNCTION
@@ -236,7 +259,7 @@ function update() {
   }
 
   // PADDLE COLLISION
-  let player = (ball.x < canvas.width / 2) ? user : computer;
+  let player = ball.x < canvas.width / 2 ? user : computer;
 
   if (collision(ball, player)) {
     // WHERE THE BALL HIT THE PLAYER
@@ -246,10 +269,10 @@ function update() {
     collidePoint = collidePoint / (player.height / 2);
 
     // CALCULATE THE ANGLE IN RADIAN
-    let angleRad = collidePoint * Math.PI / 4;
+    let angleRad = (collidePoint * Math.PI) / 4;
 
     // X DIRECTION OF THE BALL WHEN IT'S HIT
-    let direction = (ball.x < canvas.width / 2) ? 1 : -1;
+    let direction = ball.x < canvas.width / 2 ? 1 : -1;
 
     // CHANGE VELOCITY OF X AND Y
     ball.velocityX = direction * ball.speed * Math.cos(angleRad);
@@ -283,25 +306,25 @@ function animate() {
   animationId = requestAnimationFrame(animate);
 }
 
-startBtn.addEventListener("click", () => {
+startBtn.addEventListener('click', () => {
   if (!gameRunning) {
     gameRunning = true;
     animate();
   }
 });
 
-pauseBtn.addEventListener("click", () => {
+pauseBtn.addEventListener('click', () => {
   gameRunning = false;
   cancelAnimationFrame(animationId);
 });
 
-// CHECK THE WINNER 
+// CHECK THE WINNER
 function checkWinner() {
   if (computer.score >= 6 || user.score >= 6) {
     if (computer.score >= 6 && user.score < 6) {
-      showWinner("computer");
+      showWinner('computer');
     } else if (computer.score < 6 && user.score >= 6) {
-      showWinner("user");
+      showWinner('user');
     } else {
       showdraw();
     }
@@ -312,19 +335,19 @@ function checkWinner() {
 
 //SHOW THE WINNER
 function showWinner(winner) {
-  result.classList.add("open");
-  if (winner === "user") {
-    msg1.innerText = "Congratulations !!!! ";
-    msg.innerText = "YOU ARE THE WINNER .\n🥳 🥳 🥳 🥳  ";
+  result.classList.add('open');
+  if (winner === 'user') {
+    msg1.innerText = 'Congratulations !!!! ';
+    msg.innerText = 'YOU ARE THE WINNER .\n🥳 🥳 🥳 🥳  ';
   } else {
-    msg1.innerText = "YOU LOSE ";
-    msg.innerText = "COMPUTER IS THE WINNER .\n 😔😔😔😔";
+    msg1.innerText = 'YOU LOSE ';
+    msg.innerText = 'COMPUTER IS THE WINNER .\n 😔😔😔😔';
   }
 }
 
 // SHOW THERE IS A DRAW
 function showdraw() {
-  result.classList.add("open");
-  msg1.innerText = "The MATCH is a DRAW.";
-  msg.innerText = "🤝 🤝 🤝 🤝";
+  result.classList.add('open');
+  msg1.innerText = 'The MATCH is a DRAW.';
+  msg.innerText = '🤝 🤝 🤝 🤝';
 }

--- a/public/ping/style.css
+++ b/public/ping/style.css
@@ -25,7 +25,7 @@
   --theme-btn-shadow: 0 0 0 transparent;
 }
 
-body[data-theme="classic"] {
+body[data-theme='classic'] {
   --bg-color: #05001a;
   --text-color: #ecf0f1;
   --header-bg: #05001a;
@@ -52,7 +52,7 @@ body[data-theme="classic"] {
   --theme-btn-shadow: 0 0 10px rgba(59, 130, 246, 0.4);
 }
 
-body[data-theme="neon"] {
+body[data-theme='neon'] {
   --bg-color: #010611;
   --text-color: #e6fbff;
   --header-bg: #020b1f;
@@ -79,7 +79,7 @@ body[data-theme="neon"] {
   --theme-btn-shadow: 0 0 10px rgba(0, 217, 255, 0.45);
 }
 
-body[data-theme="retro"] {
+body[data-theme='retro'] {
   --bg-color: #140220;
   --text-color: #f7f3c7;
   --header-bg: #1d0f38;
@@ -120,7 +120,9 @@ body {
   color: var(--text-color);
   text-align: center;
   padding: 20px;
-  transition: background 0.3s ease, color 0.3s ease;
+  transition:
+    background 0.3s ease,
+    color 0.3s ease;
 }
 
 .header {
@@ -196,7 +198,11 @@ h2 {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   cursor: pointer;
-  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    background 0.2s ease,
+    color 0.2s ease,
+    box-shadow 0.2s ease;
   box-shadow: var(--theme-btn-shadow);
 }
 
@@ -245,7 +251,9 @@ h2 {
   font-size: 28px;
   font-weight: bold;
   cursor: pointer;
-  transition: transform 0.3s ease, background-color 0.3s ease;
+  transition:
+    transform 0.3s ease,
+    background-color 0.3s ease;
 }
 
 .easy {
@@ -436,4 +444,3 @@ h2 {
     min-width: 100%;
   }
 }
-  


### PR DESCRIPTION
## Related Issue

Fixes #9816

## Description

This PR fixes an issue where the selected difficulty level was not preserved after a player scored a point.

Previously, the `resetBall()` function always reset the ball speed to the default medium speed (`9`), causing the game to ignore the user's selected difficulty after every serve.

## Changes Made

- Added a `selectedSpeed` variable to store the currently selected difficulty.
- Updated `setDifficulty()` to:
  - Save the selected difficulty.
  - Apply the selected speed to the ball while preserving its movement direction.
- Modified `resetBall()` to:
  - Restore the ball using the selected difficulty instead of hardcoded medium speed.
  - Continue serving with the correct speed after every point.

## Before

- Easy → First serve at speed **5**, subsequent serves at **9**
- Medium → Always **9**
- Hard → First serve at speed **13**, subsequent serves at **9**

## After

- Easy → Always **5**
- Medium → Always **9**
- Hard → Always **13**

The selected difficulty now remains active until the player changes it or restarts the game.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Breaking change

## Testing

- Selected **Easy**, scored multiple points → Ball speed remained **5**.
- Selected **Medium**, scored multiple points → Ball speed remained **9**.
- Selected **Hard**, scored multiple points → Ball speed remained **13**.
- Verified that gameplay continues normally after each serve.