### PR TITLE
fix: enable clickable source link in pin details modal

### DIFF
--- a/public/pinspire/index.html
+++ b/public/pinspire/index.html
@@ -50,7 +50,12 @@
             <svg viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="5" r="3"/><circle cx="6" cy="12" r="3"/><circle cx="18" cy="19" r="3"/><line x1="8.59" y1="13.51" x2="15.42" y2="17.49"/><line x1="15.41" y1="6.51" x2="8.59" y2="10.49"/></svg>
           </button>
         </div>
-        <a class="modal-source" id="modalSource" href="#" onclick="return false;">
+        <a
+    class="modal-source"
+    id="modalSource"
+    href="#"
+    target="_blank"
+    rel="noopener noreferrer">
           <span class="modal-source-icon" id="modalSourceIcon"></span>
           <div>
             <div class="modal-source-text" id="modalSourceText">Visit source</div>

--- a/public/pinspire/pinspire.css
+++ b/public/pinspire/pinspire.css
@@ -1,11 +1,13 @@
-*, *::before, *::after {
+*,
+*::before,
+*::after {
   box-sizing: border-box;
   margin: 0;
   padding: 0;
 }
 
 :root {
-  --red: #E60023;
+  --red: #e60023;
   --red-dark: #ad081b;
   --bg: #f0ede8;
   --surface: #ffffff;
@@ -18,7 +20,8 @@
 }
 
 body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   background: var(--bg);
   color: var(--text);
   min-height: 100vh;
@@ -33,7 +36,7 @@ nav {
   z-index: 100;
   height: var(--nav-h);
   background: var(--surface);
-  border-bottom: 1px solid rgba(0,0,0,.08);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   display: flex;
   align-items: center;
   gap: 12px;
@@ -72,10 +75,13 @@ nav {
   border: none;
   background: none;
   color: var(--muted);
-  transition: background .15s, color .15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 
-.nav-link.active, .nav-link:hover {
+.nav-link.active,
+.nav-link:hover {
   background: var(--text);
   color: #fff;
 }
@@ -130,7 +136,7 @@ nav {
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background .15s;
+  transition: background 0.15s;
   position: relative;
 }
 
@@ -167,7 +173,7 @@ nav {
   font-size: 14px;
   color: #7a5230;
   border: 2px solid transparent;
-  transition: border-color .15s;
+  transition: border-color 0.15s;
 }
 
 .avatar:hover {
@@ -182,7 +188,7 @@ nav {
   right: 0;
   z-index: 90;
   background: var(--surface);
-  border-bottom: 1px solid rgba(0,0,0,.06);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
   display: flex;
   gap: 8px;
   padding: 10px 16px;
@@ -204,7 +210,9 @@ nav {
   cursor: pointer;
   background: var(--bg);
   color: var(--text);
-  transition: background .15s, color .15s;
+  transition:
+    background 0.15s,
+    color 0.15s;
 }
 
 .pill.active {
@@ -244,7 +252,7 @@ nav {
   display: block;
   width: 100%;
   height: auto;
-  transition: transform .35s ease;
+  transition: transform 0.35s ease;
 }
 
 .pin:hover .pin-img-wrap img {
@@ -254,9 +262,13 @@ nav {
 .pin-overlay {
   position: absolute;
   inset: 0;
-  background: linear-gradient(to bottom, rgba(0,0,0,0) 40%, rgba(0,0,0,.45) 100%);
+  background: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0) 40%,
+    rgba(0, 0, 0, 0.45) 100%
+  );
   opacity: 0;
-  transition: opacity .2s;
+  transition: opacity 0.2s;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -287,7 +299,9 @@ nav {
   font-size: 14px;
   font-weight: 700;
   cursor: pointer;
-  transition: background .15s, transform .1s;
+  transition:
+    background 0.15s,
+    transform 0.1s;
 }
 
 .save-btn:hover {
@@ -299,14 +313,14 @@ nav {
 }
 
 .save-btn:active {
-  transform: scale(.96);
+  transform: scale(0.96);
 }
 
 .more-btn {
   width: 32px;
   height: 32px;
   border-radius: 50%;
-  background: rgba(255,255,255,.85);
+  background: rgba(255, 255, 255, 0.85);
   border: none;
   cursor: pointer;
   display: flex;
@@ -314,7 +328,7 @@ nav {
   justify-content: center;
   font-size: 18px;
   color: var(--text);
-  transition: background .15s;
+  transition: background 0.15s;
 }
 
 .more-btn:hover {
@@ -322,7 +336,7 @@ nav {
 }
 
 .source-link {
-  background: rgba(255,255,255,.85);
+  background: rgba(255, 255, 255, 0.85);
   border-radius: 20px;
   padding: 5px 12px;
   font-size: 12px;
@@ -375,7 +389,7 @@ nav {
   position: fixed;
   inset: 0;
   z-index: 200;
-  background: rgba(0,0,0,.55);
+  background: rgba(0, 0, 0, 0.55);
   align-items: center;
   justify-content: center;
   padding: 24px;
@@ -405,13 +419,13 @@ nav {
   height: 38px;
   border-radius: 50%;
   border: none;
-  background: rgba(255,255,255,.85);
+  background: rgba(255, 255, 255, 0.85);
   cursor: pointer;
   font-size: 20px;
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: background .15s;
+  transition: background 0.15s;
 }
 
 .modal-close:hover {
@@ -462,7 +476,7 @@ nav {
   font-size: 15px;
   font-weight: 700;
   cursor: pointer;
-  transition: background .15s;
+  transition: background 0.15s;
 }
 
 .modal-save-btn:hover {
@@ -477,7 +491,7 @@ nav {
   width: 44px;
   height: 44px;
   border-radius: 50%;
-  border: 1px solid rgba(0,0,0,.1);
+  border: 1px solid rgba(0, 0, 0, 0.1);
   background: none;
   cursor: pointer;
   display: flex;
@@ -500,11 +514,11 @@ nav {
   gap: 10px;
   padding: 12px;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(0,0,0,.1);
+  border: 1px solid rgba(0, 0, 0, 0.1);
   margin-bottom: 20px;
   text-decoration: none;
   color: var(--text);
-  transition: background .15s;
+  transition: background 0.15s;
 }
 
 .modal-source:hover {
@@ -580,12 +594,12 @@ nav {
   margin-left: auto;
   padding: 9px 16px;
   border-radius: 24px;
-  border: 1px solid rgba(0,0,0,.15);
+  border: 1px solid rgba(0, 0, 0, 0.15);
   background: none;
   font-size: 14px;
   font-weight: 700;
   cursor: pointer;
-  transition: background .15s;
+  transition: background 0.15s;
 }
 
 .follow-btn:hover {
@@ -616,8 +630,8 @@ nav {
 }
 
 .comment-avatar {
-  background:#e9d7c1;
-  color:#7a5230;
+  background: #e9d7c1;
+  color: #7a5230;
   width: 34px;
   height: 34px;
   border-radius: 50%;
@@ -650,19 +664,19 @@ nav {
   gap: 10px;
   align-items: center;
   margin-top: 20px;
-  border-top: 1px solid rgba(0,0,0,.08);
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
   padding-top: 16px;
 }
 
 .comment-input {
   flex: 1;
-  border: 1px solid rgba(0,0,0,.12);
+  border: 1px solid rgba(0, 0, 0, 0.12);
   border-radius: 24px;
   padding: 10px 16px;
   font-size: 13px;
   outline: none;
   font-family: inherit;
-  transition: border-color .15s;
+  transition: border-color 0.15s;
 }
 
 .comment-input:focus {
@@ -682,7 +696,7 @@ nav {
   font-size: 14px;
   font-weight: 600;
   z-index: 999;
-  transition: transform .3s ease;
+  transition: transform 0.3s ease;
   white-space: nowrap;
 }
 
@@ -711,15 +725,32 @@ nav {
 }
 
 /* RESPONSIVE */
-@media(max-width:768px) {
-  .nav-links { display: none; }
-  .modal { flex-direction: column; max-height: 95vh; }
-  .modal-img-side { min-height: 260px; max-height: 40vh; }
-  .modal-info-side { width: 100%; max-height: 55vh; }
-  .grid-wrap { columns: 2 140px; }
+@media (max-width: 768px) {
+  .nav-links {
+    display: none;
+  }
+  .modal {
+    flex-direction: column;
+    max-height: 95vh;
+  }
+  .modal-img-side {
+    min-height: 260px;
+    max-height: 40vh;
+  }
+  .modal-info-side {
+    width: 100%;
+    max-height: 55vh;
+  }
+  .grid-wrap {
+    columns: 2 140px;
+  }
 }
 
-@media(max-width:480px) {
-  .nav-actions .icon-btn:not(:last-child) { display: none; }
-  .modal-info-side { padding: 16px; }
+@media (max-width: 480px) {
+  .nav-actions .icon-btn:not(:last-child) {
+    display: none;
+  }
+  .modal-info-side {
+    padding: 16px;
+  }
 }

--- a/public/pinspire/pinspire.js
+++ b/public/pinspire/pinspire.js
@@ -1,26 +1,462 @@
-const categories = ['All','Travel','Food','Architecture','Nature','Fashion','Interior','Art','Fitness','Technology','Books'];
+const categories = [
+  'All',
+  'Travel',
+  'Food',
+  'Architecture',
+  'Nature',
+  'Fashion',
+  'Interior',
+  'Art',
+  'Fitness',
+  'Technology',
+  'Books',
+];
 
 const PINS = [
-  {id:1,img:'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=500&q=80',title:'Swiss Alps at Sunset',author:'Maya Rivers',aI:'MR',aBg:'#c8b0d2',aC:'#4a2066',followers:'2.4k followers',desc:'Golden hour in the Swiss Alps is something that words can barely capture. The way the light falls over the jagged peaks and reflects off the pristine snowfields is pure magic.',tags:['Travel'],source:'natgeo.com',sIcon:'🏔️',comments:[{name:'Jade L.',i:'JL',bg:'#b0d2c8',c:'#205242',text:'This view is absolutely breathtaking!',t:'2h'},{name:'Tom K.',i:'TK',bg:'#d2c8b0',c:'#524220',text:'Adding this to my bucket list.',t:'45m'}]},
-  {id:2,img:'https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=500&q=80',title:'Modern Minimalist Living',author:'Archi Studio',aI:'AS',aBg:'#b0c8d2',aC:'#204252',followers:'18.3k followers',desc:'Clean lines, warm tones, and intentional negative space define this Scandinavian-inspired living room. The pendant light anchors the seating perfectly.',tags:['Interior'],source:'dezeen.com',sIcon:'🛋️',comments:[{name:'Cleo B.',i:'CB',bg:'#d2b0c8',c:'#521843',text:'This is my dream home vibe.',t:'1h'}]},
-  {id:3,img:'https://images.unsplash.com/photo-1565299585323-38d6b0865b47?w=500&q=80',title:'Avocado Toast Perfection',author:'Chef Nina',aI:'CN',aBg:'#c8d2b0',aC:'#425220',followers:'5.1k followers',desc:'Sourdough toasted to a deep golden crunch, fresh avocado with lemon, and everything bagel seasoning. Life-changing brunch.',tags:['Food'],source:'foodnetwork.com',sIcon:'🥑',comments:[{name:'Ravi P.',i:'RP',bg:'#d2c8b0',c:'#524820',text:'Made this yesterday, total game changer!',t:'3h'}]},
-  {id:4,img:'https://images.unsplash.com/photo-1441986300917-64674bd600d8?w=500&q=80',title:'Parisian Street Style',author:'Vogue Paris',aI:'VP',aBg:'#d2b0b8',aC:'#52202c',followers:'341k followers',desc:'Effortless chic is not a myth—it is a daily practice. Layer textures, invest in fit, and let one statement piece carry the whole look.',tags:['Fashion'],source:'vogue.com',sIcon:'👗',comments:[]},
-  {id:5,img:'https://images.unsplash.com/photo-1518770660439-4636190af475?w=500&q=80',title:'Circuit Board Macro',author:'TechVision',aI:'TV',aBg:'#b0d2b8',aC:'#204528',followers:'12k followers',desc:'The hidden beauty of electronics — every trace, pad, and component placed with purpose. A macro lens reveals the tiny city within.',tags:['Technology'],source:'hackster.io',sIcon:'💻',comments:[{name:'Ali J.',i:'AJ',bg:'#c8c8d2',c:'#303052',text:'This would make an amazing wallpaper.',t:'5h'}]},
-  {id:6,img:'https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?w=500&q=80',title:'Tokyo by Night',author:'Urban Wanderer',aI:'UW',aBg:'#c8b0d2',aC:'#4a2066',followers:'89k followers',desc:'Shinjuku at midnight is an overwhelming cascade of neon and humanity. Every alley hides a ramen shop or a jazz bar. Tokyo never sleeps.',tags:['Travel','Architecture'],source:'lonelyplanet.com',sIcon:'🌆',comments:[{name:'Hana S.',i:'HS',bg:'#d2c4b0',c:'#523c20',text:'My hometown! This photo nails it.',t:'30m'}]},
-  {id:7,img:'https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?w=500&q=80',title:'Polaroid Camera Revival',author:'Film Lovers',aI:'FL',aBg:'#b8c8d2',aC:'#244052',followers:'3.7k followers',desc:'There is something irreplaceable about holding a physical photo that developed right in your hands. Instant film is not a gimmick—it is an experience.',tags:['Art'],source:'lomography.com',sIcon:'📷',comments:[]},
-  {id:8,img:'https://images.unsplash.com/photo-1540189549336-e6e99c3679fe?w=500&q=80',title:'Buddha Bowl Bright',author:'Nourish Kitchen',aI:'NK',aBg:'#c8d4b0',aC:'#40521c',followers:'22k followers',desc:'Roasted sweet potato, crispy chickpeas, purple cabbage, microgreens, and a tahini lemon drizzle. Nutritious and genuinely beautiful.',tags:['Food'],source:'minimalistbaker.com',sIcon:'🥗',comments:[{name:'Priya V.',i:'PV',bg:'#d4b0c8',c:'#521c40',text:'The colors in this bowl are stunning!',t:'1d'}]},
-  {id:9,img:'https://images.unsplash.com/photo-1491555103944-7c647fd857e6?w=500&q=80',title:'Powder Day Colorado',author:'Fresh Tracks',aI:'FT',aBg:'#b0c4d4',aC:'#1c3c52',followers:'6.2k followers',desc:'Waist-deep powder on a bluebird day. Breckenridge delivered everything it promised this season.',tags:['Fitness','Travel'],source:'powder.com',sIcon:'⛷️',comments:[]},
-  {id:10,img:'https://images.unsplash.com/photo-1481627834876-b7833e8f5570?w=500&q=80',title:'Vintage Book Collection',author:'Bibliophile',aI:'BI',aBg:'#d4c4b0',aC:'#52381c',followers:'14.5k followers',desc:'Books arranged by spine color is controversial in librarian circles but aesthetically undeniable. These worn spines tell stories of their own.',tags:['Books','Art'],source:'bookriot.com',sIcon:'📚',comments:[{name:'Ellie W.',i:'EW',bg:'#c4b0d4',c:'#381c52',text:'The smell of old books is unbeatable.',t:'2d'}]},
-  {id:11,img:'https://images.unsplash.com/photo-1505118380757-91f5f5632de0?w=500&q=80',title:'Lavender Fields Provence',author:'Bloom Traveler',aI:'BT',aBg:'#c4b0d4',aC:'#381c52',followers:'31k followers',desc:'Every July, the Valensole plateau transforms into an endless purple carpet. The fragrance alone is worth the journey from Paris.',tags:['Travel','Nature'],source:'visitsouthfrance.com',sIcon:'💜',comments:[{name:'Lena G.',i:'LG',bg:'#b4d4b0',c:'#1c521c',text:'This is my screensaver now. Perfect.',t:'6h'}]},
-  {id:12,img:'https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?w=500&q=80',title:'Home Gym Essentials',author:'Strong & Simple',aI:'SS',aBg:'#b4d4b0',aC:'#1c521c',followers:'9.8k followers',desc:'You do not need a fancy membership. A barbell, a rack, and rings is all that stands between you and serious strength gains.',tags:['Fitness'],source:'strongerbyscience.com',sIcon:'💪',comments:[]},
-  {id:13,img:'https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?w=500&q=80',title:'Patagonia Peaks',author:'Wild Roamer',aI:'WR',aBg:'#b0c8d4',aC:'#1c4052',followers:'47k followers',desc:'The Torres del Paine circuit is as demanding as it is rewarding. Plan for rapidly changing weather and book refugios months ahead.',tags:['Travel','Nature'],source:'chile.travel',sIcon:'🏕️',comments:[{name:'Marco F.',i:'MF',bg:'#d4c8b0',c:'#523c1c',text:'Did this hike last year. Life-changing.',t:'4h'}]},
-  {id:14,img:'https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=500&q=80',title:'Code in the Dark',author:'Dev Aesthetic',aI:'DA',aBg:'#c8d4b0',aC:'#3c521c',followers:'55k followers',desc:'A dark terminal, a mechanical keyboard, and a problem worth solving. There is a particular clarity that comes at 2am.',tags:['Technology'],source:'dev.to',sIcon:'💡',comments:[{name:'Kim C.',i:'KC',bg:'#d4b0c8',c:'#521c3c',text:'This is my entire personality.',t:'8h'}]},
-  {id:15,img:'https://images.unsplash.com/photo-1563911302283-d2bc129e7570?w=500&q=80',title:'Japandi Bedroom',author:'Wabi Spaces',aI:'WS',aBg:'#d4b4b0',aC:'#521c18',followers:'28k followers',desc:'The Japanese-Scandinavian hybrid is not a trend — it is a philosophy. Simplicity, craftsmanship, and the conscious absence of clutter.',tags:['Interior','Art'],source:'architecturaldigest.com',sIcon:'🏡',comments:[{name:'Fiona T.',i:'FT',bg:'#b0d4c0',c:'#1c5230',text:'Those linen curtains are everything.',t:'1h'}]},
-  {id:16,img:'https://images.unsplash.com/photo-1548199973-03cce0bbc87b?w=500&q=80',title:'Golden Retrievers at Play',author:'Happy Tails',aI:'HT',aBg:'#d4c8b0',aC:'#52401c',followers:'112k followers',desc:'Joy, pure and uncomplicated. Two goldens experiencing the ocean for the very first time is the content the internet was made for.',tags:['Nature'],source:'akc.org',sIcon:'🐾',comments:[{name:'Julia R.',i:'JR',bg:'#c8b0d4',c:'#40205c',text:'I am now incapable of being sad.',t:'3h'}]},
-  {id:17,img:'https://images.unsplash.com/photo-1493976040374-85c8e12f0c0e?w=500&q=80',title:'Kyoto Temple Garden',author:'Zen Traveler',aI:'ZT',aBg:'#b0d4c8',aC:'#1c5244',followers:'19k followers',desc:'The Ryoan-ji rock garden embodies ma — negative space used intentionally. Fifteen stones arranged so only 14 are ever visible at once.',tags:['Travel','Architecture'],source:'japan-guide.com',sIcon:'⛩️',comments:[]},
-  {id:18,img:'https://images.unsplash.com/photo-1432821596592-e2c18b78144f?w=500&q=80',title:'Flat Lay Desk Setup',author:'Minimal Work',aI:'MW',aBg:'#d4d0b0',aC:'#524c1c',followers:'7.3k followers',desc:'A clean desk is a clean mind. This setup took three iterations to get the cable management right, but the result speaks for itself.',tags:['Technology','Interior'],source:'notion.so',sIcon:'🖥️',comments:[{name:'Sam D.',i:'SD',bg:'#b0c8d4',c:'#1c4052',text:'What keyboard is that? Stunning.',t:'12h'}]},
-  {id:19,img:'https://images.unsplash.com/photo-1504674900247-0877df9cc836?w=500&q=80',title:'Sushi Omakase',author:'Umami Table',aI:'UT',aBg:'#d4b0b4',aC:'#52181c',followers:'33k followers',desc:'Twelve courses, each a precisely controlled act of restraint. Omakase is not just a meal — it is a form of trust between chef and guest.',tags:['Food'],source:'seriouseats.com',sIcon:'🍱',comments:[{name:'Leo K.',i:'LK',bg:'#b4c8d4',c:'#1c3c52',text:'The uni course alone is worth it.',t:'2h'}]},
-  {id:20,img:'https://images.unsplash.com/photo-1446776877081-d282a0f896e2?w=500&q=80',title:'Northern Lights Iceland',author:'Aurora Chaser',aI:'AC',aBg:'#b0b4d4',aC:'#1c1c52',followers:'76k followers',desc:'Chasing the aurora means long cold nights, remote locations, and enormous patience. When it finally appears, every freezing hour feels worth it.',tags:['Travel','Nature'],source:'inspiredbyiceland.com',sIcon:'🌌',comments:[{name:'Ana V.',i:'AV',bg:'#d4c0b0',c:'#523010',text:'On my bucket list forever.',t:'1d'}]},
+  {
+    id: 1,
+    img: 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=500&q=80',
+    title: 'Swiss Alps at Sunset',
+    author: 'Maya Rivers',
+    aI: 'MR',
+    aBg: '#c8b0d2',
+    aC: '#4a2066',
+    followers: '2.4k followers',
+    desc: 'Golden hour in the Swiss Alps is something that words can barely capture. The way the light falls over the jagged peaks and reflects off the pristine snowfields is pure magic.',
+    tags: ['Travel'],
+    source: 'natgeo.com',
+    sourceUrl: 'https://natgeo.com',
+    sIcon: '🏔️',
+    comments: [
+      {
+        name: 'Jade L.',
+        i: 'JL',
+        bg: '#b0d2c8',
+        c: '#205242',
+        text: 'This view is absolutely breathtaking!',
+        t: '2h',
+      },
+      {
+        name: 'Tom K.',
+        i: 'TK',
+        bg: '#d2c8b0',
+        c: '#524220',
+        text: 'Adding this to my bucket list.',
+        t: '45m',
+      },
+    ],
+  },
+  {
+    id: 2,
+    img: 'https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=500&q=80',
+    title: 'Modern Minimalist Living',
+    author: 'Archi Studio',
+    aI: 'AS',
+    aBg: '#b0c8d2',
+    aC: '#204252',
+    followers: '18.3k followers',
+    desc: 'Clean lines, warm tones, and intentional negative space define this Scandinavian-inspired living room. The pendant light anchors the seating perfectly.',
+    tags: ['Interior'],
+    source: 'dezeen.com',
+    sIcon: '🛋️',
+    comments: [
+      {
+        name: 'Cleo B.',
+        i: 'CB',
+        bg: '#d2b0c8',
+        c: '#521843',
+        text: 'This is my dream home vibe.',
+        t: '1h',
+      },
+    ],
+  },
+  {
+    id: 3,
+    img: 'https://images.unsplash.com/photo-1565299585323-38d6b0865b47?w=500&q=80',
+    title: 'Avocado Toast Perfection',
+    author: 'Chef Nina',
+    aI: 'CN',
+    aBg: '#c8d2b0',
+    aC: '#425220',
+    followers: '5.1k followers',
+    desc: 'Sourdough toasted to a deep golden crunch, fresh avocado with lemon, and everything bagel seasoning. Life-changing brunch.',
+    tags: ['Food'],
+    source: 'foodnetwork.com',
+    sIcon: '🥑',
+    comments: [
+      {
+        name: 'Ravi P.',
+        i: 'RP',
+        bg: '#d2c8b0',
+        c: '#524820',
+        text: 'Made this yesterday, total game changer!',
+        t: '3h',
+      },
+    ],
+  },
+  {
+    id: 4,
+    img: 'https://images.unsplash.com/photo-1441986300917-64674bd600d8?w=500&q=80',
+    title: 'Parisian Street Style',
+    author: 'Vogue Paris',
+    aI: 'VP',
+    aBg: '#d2b0b8',
+    aC: '#52202c',
+    followers: '341k followers',
+    desc: 'Effortless chic is not a myth—it is a daily practice. Layer textures, invest in fit, and let one statement piece carry the whole look.',
+    tags: ['Fashion'],
+    source: 'vogue.com',
+    sIcon: '👗',
+    comments: [],
+  },
+  {
+    id: 5,
+    img: 'https://images.unsplash.com/photo-1518770660439-4636190af475?w=500&q=80',
+    title: 'Circuit Board Macro',
+    author: 'TechVision',
+    aI: 'TV',
+    aBg: '#b0d2b8',
+    aC: '#204528',
+    followers: '12k followers',
+    desc: 'The hidden beauty of electronics — every trace, pad, and component placed with purpose. A macro lens reveals the tiny city within.',
+    tags: ['Technology'],
+    source: 'hackster.io',
+    sIcon: '💻',
+    comments: [
+      {
+        name: 'Ali J.',
+        i: 'AJ',
+        bg: '#c8c8d2',
+        c: '#303052',
+        text: 'This would make an amazing wallpaper.',
+        t: '5h',
+      },
+    ],
+  },
+  {
+    id: 6,
+    img: 'https://images.unsplash.com/photo-1477959858617-67f85cf4f1df?w=500&q=80',
+    title: 'Tokyo by Night',
+    author: 'Urban Wanderer',
+    aI: 'UW',
+    aBg: '#c8b0d2',
+    aC: '#4a2066',
+    followers: '89k followers',
+    desc: 'Shinjuku at midnight is an overwhelming cascade of neon and humanity. Every alley hides a ramen shop or a jazz bar. Tokyo never sleeps.',
+    tags: ['Travel', 'Architecture'],
+    source: 'lonelyplanet.com',
+    sIcon: '🌆',
+    comments: [
+      {
+        name: 'Hana S.',
+        i: 'HS',
+        bg: '#d2c4b0',
+        c: '#523c20',
+        text: 'My hometown! This photo nails it.',
+        t: '30m',
+      },
+    ],
+  },
+  {
+    id: 7,
+    img: 'https://images.unsplash.com/photo-1526170375885-4d8ecf77b99f?w=500&q=80',
+    title: 'Polaroid Camera Revival',
+    author: 'Film Lovers',
+    aI: 'FL',
+    aBg: '#b8c8d2',
+    aC: '#244052',
+    followers: '3.7k followers',
+    desc: 'There is something irreplaceable about holding a physical photo that developed right in your hands. Instant film is not a gimmick—it is an experience.',
+    tags: ['Art'],
+    source: 'lomography.com',
+    sIcon: '📷',
+    comments: [],
+  },
+  {
+    id: 8,
+    img: 'https://images.unsplash.com/photo-1540189549336-e6e99c3679fe?w=500&q=80',
+    title: 'Buddha Bowl Bright',
+    author: 'Nourish Kitchen',
+    aI: 'NK',
+    aBg: '#c8d4b0',
+    aC: '#40521c',
+    followers: '22k followers',
+    desc: 'Roasted sweet potato, crispy chickpeas, purple cabbage, microgreens, and a tahini lemon drizzle. Nutritious and genuinely beautiful.',
+    tags: ['Food'],
+    source: 'minimalistbaker.com',
+    sIcon: '🥗',
+    comments: [
+      {
+        name: 'Priya V.',
+        i: 'PV',
+        bg: '#d4b0c8',
+        c: '#521c40',
+        text: 'The colors in this bowl are stunning!',
+        t: '1d',
+      },
+    ],
+  },
+  {
+    id: 9,
+    img: 'https://images.unsplash.com/photo-1491555103944-7c647fd857e6?w=500&q=80',
+    title: 'Powder Day Colorado',
+    author: 'Fresh Tracks',
+    aI: 'FT',
+    aBg: '#b0c4d4',
+    aC: '#1c3c52',
+    followers: '6.2k followers',
+    desc: 'Waist-deep powder on a bluebird day. Breckenridge delivered everything it promised this season.',
+    tags: ['Fitness', 'Travel'],
+    source: 'powder.com',
+    sIcon: '⛷️',
+    comments: [],
+  },
+  {
+    id: 10,
+    img: 'https://images.unsplash.com/photo-1481627834876-b7833e8f5570?w=500&q=80',
+    title: 'Vintage Book Collection',
+    author: 'Bibliophile',
+    aI: 'BI',
+    aBg: '#d4c4b0',
+    aC: '#52381c',
+    followers: '14.5k followers',
+    desc: 'Books arranged by spine color is controversial in librarian circles but aesthetically undeniable. These worn spines tell stories of their own.',
+    tags: ['Books', 'Art'],
+    source: 'bookriot.com',
+    sIcon: '📚',
+    comments: [
+      {
+        name: 'Ellie W.',
+        i: 'EW',
+        bg: '#c4b0d4',
+        c: '#381c52',
+        text: 'The smell of old books is unbeatable.',
+        t: '2d',
+      },
+    ],
+  },
+  {
+    id: 11,
+    img: 'https://images.unsplash.com/photo-1505118380757-91f5f5632de0?w=500&q=80',
+    title: 'Lavender Fields Provence',
+    author: 'Bloom Traveler',
+    aI: 'BT',
+    aBg: '#c4b0d4',
+    aC: '#381c52',
+    followers: '31k followers',
+    desc: 'Every July, the Valensole plateau transforms into an endless purple carpet. The fragrance alone is worth the journey from Paris.',
+    tags: ['Travel', 'Nature'],
+    source: 'visitsouthfrance.com',
+    sIcon: '💜',
+    comments: [
+      {
+        name: 'Lena G.',
+        i: 'LG',
+        bg: '#b4d4b0',
+        c: '#1c521c',
+        text: 'This is my screensaver now. Perfect.',
+        t: '6h',
+      },
+    ],
+  },
+  {
+    id: 12,
+    img: 'https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?w=500&q=80',
+    title: 'Home Gym Essentials',
+    author: 'Strong & Simple',
+    aI: 'SS',
+    aBg: '#b4d4b0',
+    aC: '#1c521c',
+    followers: '9.8k followers',
+    desc: 'You do not need a fancy membership. A barbell, a rack, and rings is all that stands between you and serious strength gains.',
+    tags: ['Fitness'],
+    source: 'strongerbyscience.com',
+    sIcon: '💪',
+    comments: [],
+  },
+  {
+    id: 13,
+    img: 'https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?w=500&q=80',
+    title: 'Patagonia Peaks',
+    author: 'Wild Roamer',
+    aI: 'WR',
+    aBg: '#b0c8d4',
+    aC: '#1c4052',
+    followers: '47k followers',
+    desc: 'The Torres del Paine circuit is as demanding as it is rewarding. Plan for rapidly changing weather and book refugios months ahead.',
+    tags: ['Travel', 'Nature'],
+    source: 'chile.travel',
+    sIcon: '🏕️',
+    comments: [
+      {
+        name: 'Marco F.',
+        i: 'MF',
+        bg: '#d4c8b0',
+        c: '#523c1c',
+        text: 'Did this hike last year. Life-changing.',
+        t: '4h',
+      },
+    ],
+  },
+  {
+    id: 14,
+    img: 'https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=500&q=80',
+    title: 'Code in the Dark',
+    author: 'Dev Aesthetic',
+    aI: 'DA',
+    aBg: '#c8d4b0',
+    aC: '#3c521c',
+    followers: '55k followers',
+    desc: 'A dark terminal, a mechanical keyboard, and a problem worth solving. There is a particular clarity that comes at 2am.',
+    tags: ['Technology'],
+    source: 'dev.to',
+    sIcon: '💡',
+    comments: [
+      {
+        name: 'Kim C.',
+        i: 'KC',
+        bg: '#d4b0c8',
+        c: '#521c3c',
+        text: 'This is my entire personality.',
+        t: '8h',
+      },
+    ],
+  },
+  {
+    id: 15,
+    img: 'https://images.unsplash.com/photo-1563911302283-d2bc129e7570?w=500&q=80',
+    title: 'Japandi Bedroom',
+    author: 'Wabi Spaces',
+    aI: 'WS',
+    aBg: '#d4b4b0',
+    aC: '#521c18',
+    followers: '28k followers',
+    desc: 'The Japanese-Scandinavian hybrid is not a trend — it is a philosophy. Simplicity, craftsmanship, and the conscious absence of clutter.',
+    tags: ['Interior', 'Art'],
+    source: 'architecturaldigest.com',
+    sIcon: '🏡',
+    comments: [
+      {
+        name: 'Fiona T.',
+        i: 'FT',
+        bg: '#b0d4c0',
+        c: '#1c5230',
+        text: 'Those linen curtains are everything.',
+        t: '1h',
+      },
+    ],
+  },
+  {
+    id: 16,
+    img: 'https://images.unsplash.com/photo-1548199973-03cce0bbc87b?w=500&q=80',
+    title: 'Golden Retrievers at Play',
+    author: 'Happy Tails',
+    aI: 'HT',
+    aBg: '#d4c8b0',
+    aC: '#52401c',
+    followers: '112k followers',
+    desc: 'Joy, pure and uncomplicated. Two goldens experiencing the ocean for the very first time is the content the internet was made for.',
+    tags: ['Nature'],
+    source: 'akc.org',
+    sIcon: '🐾',
+    comments: [
+      {
+        name: 'Julia R.',
+        i: 'JR',
+        bg: '#c8b0d4',
+        c: '#40205c',
+        text: 'I am now incapable of being sad.',
+        t: '3h',
+      },
+    ],
+  },
+  {
+    id: 17,
+    img: 'https://images.unsplash.com/photo-1493976040374-85c8e12f0c0e?w=500&q=80',
+    title: 'Kyoto Temple Garden',
+    author: 'Zen Traveler',
+    aI: 'ZT',
+    aBg: '#b0d4c8',
+    aC: '#1c5244',
+    followers: '19k followers',
+    desc: 'The Ryoan-ji rock garden embodies ma — negative space used intentionally. Fifteen stones arranged so only 14 are ever visible at once.',
+    tags: ['Travel', 'Architecture'],
+    source: 'japan-guide.com',
+    sIcon: '⛩️',
+    comments: [],
+  },
+  {
+    id: 18,
+    img: 'https://images.unsplash.com/photo-1432821596592-e2c18b78144f?w=500&q=80',
+    title: 'Flat Lay Desk Setup',
+    author: 'Minimal Work',
+    aI: 'MW',
+    aBg: '#d4d0b0',
+    aC: '#524c1c',
+    followers: '7.3k followers',
+    desc: 'A clean desk is a clean mind. This setup took three iterations to get the cable management right, but the result speaks for itself.',
+    tags: ['Technology', 'Interior'],
+    source: 'notion.so',
+    sIcon: '🖥️',
+    comments: [
+      {
+        name: 'Sam D.',
+        i: 'SD',
+        bg: '#b0c8d4',
+        c: '#1c4052',
+        text: 'What keyboard is that? Stunning.',
+        t: '12h',
+      },
+    ],
+  },
+  {
+    id: 19,
+    img: 'https://images.unsplash.com/photo-1504674900247-0877df9cc836?w=500&q=80',
+    title: 'Sushi Omakase',
+    author: 'Umami Table',
+    aI: 'UT',
+    aBg: '#d4b0b4',
+    aC: '#52181c',
+    followers: '33k followers',
+    desc: 'Twelve courses, each a precisely controlled act of restraint. Omakase is not just a meal — it is a form of trust between chef and guest.',
+    tags: ['Food'],
+    source: 'seriouseats.com',
+    sIcon: '🍱',
+    comments: [
+      {
+        name: 'Leo K.',
+        i: 'LK',
+        bg: '#b4c8d4',
+        c: '#1c3c52',
+        text: 'The uni course alone is worth it.',
+        t: '2h',
+      },
+    ],
+  },
+  {
+    id: 20,
+    img: 'https://images.unsplash.com/photo-1446776877081-d282a0f896e2?w=500&q=80',
+    title: 'Northern Lights Iceland',
+    author: 'Aurora Chaser',
+    aI: 'AC',
+    aBg: '#b0b4d4',
+    aC: '#1c1c52',
+    followers: '76k followers',
+    desc: 'Chasing the aurora means long cold nights, remote locations, and enormous patience. When it finally appears, every freezing hour feels worth it.',
+    tags: ['Travel', 'Nature'],
+    source: 'inspiredbyiceland.com',
+    sIcon: '🌌',
+    comments: [
+      {
+        name: 'Ana V.',
+        i: 'AV',
+        bg: '#d4c0b0',
+        c: '#523010',
+        text: 'On my bucket list forever.',
+        t: '1d',
+      },
+    ],
+  },
 ];
 
 // State
@@ -30,61 +466,70 @@ let searchTerm = '';
 let currentPin = null;
 let followingCreators = new Set();
 let allComments = {};
-PINS.forEach(p => { allComments[p.id] = p.comments.map(c=>({...c})); });
+PINS.forEach((p) => {
+  allComments[p.id] = p.comments.map((c) => ({ ...c }));
+});
 
 // Init
 renderPills();
 renderGrid();
 
-function renderPills(){
-  document.getElementById('pillsWrap').innerHTML = categories.map(c=>
-    `<button class="pill${c===activeCategory?' active':''}" onclick="selectCategory('${c}')">${c}</button>`
-  ).join('');
+function renderPills() {
+  document.getElementById('pillsWrap').innerHTML = categories
+    .map(
+      (c) =>
+        `<button class="pill${c === activeCategory ? ' active' : ''}" onclick="selectCategory('${c}')">${c}</button>`
+    )
+    .join('');
 }
 
-function selectCategory(cat){
+function selectCategory(cat) {
   activeCategory = cat;
   renderPills();
   renderGrid();
 }
 
-function setTab(el){
-  document.querySelectorAll('.nav-link').forEach(b=>b.classList.remove('active'));
+function setTab(el) {
+  document
+    .querySelectorAll('.nav-link')
+    .forEach((b) => b.classList.remove('active'));
   el.classList.add('active');
   showToast(el.textContent + ' tab selected');
 }
 
-function handleSearch(val){
+function handleSearch(val) {
   searchTerm = val.toLowerCase().trim();
   renderGrid();
 }
 
-function getFiltered(){
-  return PINS.filter(p=>{
-    const mCat = activeCategory==='All'||p.tags.includes(activeCategory);
-    const mSearch = !searchTerm||
-      p.title.toLowerCase().includes(searchTerm)||
-      p.author.toLowerCase().includes(searchTerm)||
-      p.tags.some(t=>t.toLowerCase().includes(searchTerm));
-    return mCat&&mSearch;
+function getFiltered() {
+  return PINS.filter((p) => {
+    const mCat = activeCategory === 'All' || p.tags.includes(activeCategory);
+    const mSearch =
+      !searchTerm ||
+      p.title.toLowerCase().includes(searchTerm) ||
+      p.author.toLowerCase().includes(searchTerm) ||
+      p.tags.some((t) => t.toLowerCase().includes(searchTerm));
+    return mCat && mSearch;
   });
 }
 
-function renderGrid(){
+function renderGrid() {
   const grid = document.getElementById('grid');
   const pins = getFiltered();
-  if(!pins.length){
+  if (!pins.length) {
     grid.innerHTML = `<div class="empty-state"><div class="emoji">🔍</div><h3>No pins found</h3><p>Try a different search or category.</p></div>`;
     return;
   }
-  grid.innerHTML = pins.map(pin=>{
-    const saved = savedPins.has(pin.id);
-    return `<div class="pin" onclick="openModal(${pin.id})">
+  grid.innerHTML = pins
+    .map((pin) => {
+      const saved = savedPins.has(pin.id);
+      return `<div class="pin" onclick="openModal(${pin.id})">
       <div class="pin-img-wrap">
         <img src="${pin.img}" alt="${pin.title}" loading="lazy" />
         <div class="pin-overlay">
           <div class="pin-top-row">
-            <button class="save-btn${saved?' saved':''}" onclick="toggleSave(event,${pin.id})">${saved?'Saved':'Save'}</button>
+            <button class="save-btn${saved ? ' saved' : ''}" onclick="toggleSave(event,${pin.id})">${saved ? 'Saved' : 'Save'}</button>
           </div>
           <div class="pin-bottom-row">
             <span class="source-link">
@@ -103,21 +548,27 @@ function renderGrid(){
         </div>
       </div>
     </div>`;
-  }).join('');
+    })
+    .join('');
 }
 
-function toggleSave(e,id){
+function toggleSave(e, id) {
   e.stopPropagation();
-  if(savedPins.has(id)){savedPins.delete(id);showToast('Removed from saved');}
-  else{savedPins.add(id);showToast('Saved to your board!');}
+  if (savedPins.has(id)) {
+    savedPins.delete(id);
+    showToast('Removed from saved');
+  } else {
+    savedPins.add(id);
+    showToast('Saved to your board!');
+  }
   renderGrid();
-  if(currentPin&&currentPin.id===id) updateModalSaveBtn();
+  if (currentPin && currentPin.id === id) updateModalSaveBtn();
 }
 
 // MODAL
-function openModal(id){
-  const pin = PINS.find(p=>p.id===id);
-  if(!pin) return;
+function openModal(id) {
+  const pin = PINS.find((p) => p.id === id);
+  if (!pin) return;
   currentPin = pin;
   document.getElementById('modalImg').src = pin.img;
   document.getElementById('modalImg').alt = pin.title;
@@ -126,98 +577,119 @@ function openModal(id){
   document.getElementById('modalSourceIcon').textContent = pin.sIcon;
   document.getElementById('modalSourceText').textContent = 'Visit source';
   document.getElementById('modalSourceUrl').textContent = pin.source;
+  const sourceLink = document.getElementById('modalSource');
+  sourceLink.href = pin.sourceUrl;
   document.getElementById('modalCreatorAvatar').textContent = pin.aI;
   document.getElementById('modalCreatorAvatar').style.background = pin.aBg;
   document.getElementById('modalCreatorAvatar').style.color = pin.aC;
   document.getElementById('modalCreatorName').textContent = pin.author;
   document.getElementById('modalCreatorFollows').textContent = pin.followers;
   const fb = document.getElementById('followBtn');
-  fb.textContent = followingCreators.has(pin.author)?'Following':'Follow';
-  fb.className = 'follow-btn'+(followingCreators.has(pin.author)?' following':'');
+  fb.textContent = followingCreators.has(pin.author) ? 'Following' : 'Follow';
+  fb.className =
+    'follow-btn' + (followingCreators.has(pin.author) ? ' following' : '');
   updateModalSaveBtn();
   renderComments(id);
   document.getElementById('commentInput').value = '';
-  document.getElementById('commentsTitle').textContent = `Comments (${allComments[id].length})`;
+  document.getElementById('commentsTitle').textContent =
+    `Comments (${allComments[id].length})`;
   document.getElementById('modalBackdrop').classList.add('open');
   document.body.style.overflow = 'hidden';
 }
 
-function updateModalSaveBtn(){
-  if(!currentPin) return;
+function updateModalSaveBtn() {
+  if (!currentPin) return;
   const btn = document.getElementById('modalSaveBtn');
   const saved = savedPins.has(currentPin.id);
   btn.textContent = saved ? 'Saved' : 'Save';
-  btn.className = 'modal-save-btn'+(saved?' saved':'');
+  btn.className = 'modal-save-btn' + (saved ? ' saved' : '');
 }
 
-function toggleModalSave(){
-  if(!currentPin) return;
-  toggleSave({stopPropagation:()=>{}}, currentPin.id);
+function toggleModalSave() {
+  if (!currentPin) return;
+  toggleSave({ stopPropagation: () => {} }, currentPin.id);
 }
 
-function toggleFollow(){
-  if(!currentPin) return;
+function toggleFollow() {
+  if (!currentPin) return;
   const name = currentPin.author;
   const fb = document.getElementById('followBtn');
-  if(followingCreators.has(name)){
+  if (followingCreators.has(name)) {
     followingCreators.delete(name);
-    fb.textContent='Follow'; fb.className='follow-btn';
-    showToast('Unfollowed '+name);
+    fb.textContent = 'Follow';
+    fb.className = 'follow-btn';
+    showToast('Unfollowed ' + name);
   } else {
     followingCreators.add(name);
-    fb.textContent='Following'; fb.className='follow-btn following';
-    showToast('Following '+name+'!');
+    fb.textContent = 'Following';
+    fb.className = 'follow-btn following';
+    showToast('Following ' + name + '!');
   }
 }
 
-function renderComments(id){
+function renderComments(id) {
   const list = document.getElementById('commentsList');
-  const comments = allComments[id]||[];
-  if(!comments.length){
-    list.innerHTML = '<div style="font-size:13px;color:var(--muted);text-align:center;padding:16px 0;">No comments yet. Be the first!</div>';
+  const comments = allComments[id] || [];
+  if (!comments.length) {
+    list.innerHTML =
+      '<div style="font-size:13px;color:var(--muted);text-align:center;padding:16px 0;">No comments yet. Be the first!</div>';
     return;
   }
-  list.innerHTML = comments.map(c=>`
+  list.innerHTML = comments
+    .map(
+      (c) => `
     <div class="comment">
-      <div class="comment-avatar" style="background:${c.bg||'#e0d8d0'};color:${c.c||'#444'}">${c.i||'?'}</div>
+      <div class="comment-avatar" style="background:${c.bg || '#e0d8d0'};color:${c.c || '#444'}">${c.i || '?'}</div>
       <div class="comment-body">
         <span class="comment-name">${c.name}</span>${c.text}
         <div class="comment-time">${c.t}</div>
       </div>
-    </div>`).join('');
+    </div>`
+    )
+    .join('');
 }
 
-function submitComment(e){
-  if(e.key!=='Enter'||!currentPin) return;
+function submitComment(e) {
+  if (e.key !== 'Enter' || !currentPin) return;
   const input = document.getElementById('commentInput');
   const text = input.value.trim();
-  if(!text) return;
-  allComments[currentPin.id].unshift({name:'You',i:'YO',bg:'#e9d7c1',c:'#7a5230',text,t:'Just now'});
+  if (!text) return;
+  allComments[currentPin.id].unshift({
+    name: 'You',
+    i: 'YO',
+    bg: '#e9d7c1',
+    c: '#7a5230',
+    text,
+    t: 'Just now',
+  });
   renderComments(currentPin.id);
-  document.getElementById('commentsTitle').textContent = `Comments (${allComments[currentPin.id].length})`;
+  document.getElementById('commentsTitle').textContent =
+    `Comments (${allComments[currentPin.id].length})`;
   input.value = '';
   showToast('Comment posted!');
 }
 
-function closeModal(){
+function closeModal() {
   document.getElementById('modalBackdrop').classList.remove('open');
   document.body.style.overflow = '';
   currentPin = null;
 }
 
-function closeModalBackdrop(e){
-  if(e.target===document.getElementById('modalBackdrop')) closeModal();
+function closeModalBackdrop(e) {
+  if (e.target === document.getElementById('modalBackdrop')) closeModal();
 }
 
 // keyboard close
-document.addEventListener('keydown',e=>{if(e.key==='Escape') closeModal();});
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') closeModal();
+});
 
 // TOAST
 let toastTimer;
-function showToast(msg){
+function showToast(msg) {
   const t = document.getElementById('toast');
   t.textContent = msg;
   t.classList.add('show');
   clearTimeout(toastTimer);
-  toastTimer = setTimeout(()=>t.classList.remove('show'), 2500);
+  toastTimer = setTimeout(() => t.classList.remove('show'), 2500);
 }


### PR DESCRIPTION
## Related Issue

Fixes #9817

## Summary

This PR fixes the non-functional "Visit source" link in the pin details modal.

### Changes Made

- Removed the `onclick="return false;"` that prevented navigation.
- Added `target="_blank"` and `rel="noopener noreferrer"` to open links securely in a new tab.
- Added a `sourceUrl` field for each pin.
- Updated `openModal()` to assign the correct URL to the modal source link.

### Result

Users can now click **Visit source** and navigate to the original website associated with the selected pin.