### PR TITLE
fix: add fallback image when plant stage assets are missing

### DIFF
--- a/public/Plant/main.html
+++ b/public/Plant/main.html
@@ -1,158 +1,246 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Plant Growth Simulation — Grow Your Plant</title>
-    <meta name="description" content="Interactive plant growth simulation. Add water and sunlight to nurture your plant through 5 stages from seed to tree.">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@600;700;800&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="style.css">
-    <link rel="icon" href="image.png">
-</head>
-<body>
-
+    <meta
+      name="description"
+      content="Interactive plant growth simulation. Add water and sunlight to nurture your plant through 5 stages from seed to tree."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Outfit:wght@600;700;800&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+    <link rel="icon" href="image.png" />
+  </head>
+  <body>
     <!-- Back Navigation -->
-    <a href="/" class="back-button" id="back-button" aria-label="Navigate back to homepage">
-        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <path d="M19 12H5"></path>
-            <path d="M12 19l-7-7 7-7"></path>
-        </svg>
-        <span>Back</span>
+    <a
+      href="/"
+      class="back-button"
+      id="back-button"
+      aria-label="Navigate back to homepage"
+    >
+      <svg
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M19 12H5"></path>
+        <path d="M12 19l-7-7 7-7"></path>
+      </svg>
+      <span>Back</span>
     </a>
 
     <!-- Header -->
     <header class="page-header" role="banner">
-        <h1 id="page-title">
-            <span class="title-icon" aria-hidden="true">🌱</span>
-            Plant Growth Simulation
-        </h1>
-        <p class="subtitle">Nurture your plant from a tiny seed into a mighty tree</p>
+      <h1 id="page-title">
+        <span class="title-icon" aria-hidden="true">🌱</span>
+        Plant Growth Simulation
+      </h1>
+      <p class="subtitle">
+        Nurture your plant from a tiny seed into a mighty tree
+      </p>
     </header>
 
     <main id="main-content" role="main">
-
-        <!-- Dashboard Metrics -->
-        <section class="dashboard" id="dashboard" aria-label="Growth Metrics">
-            <div class="metric-card" id="water-metric-card">
-                <div class="metric-icon-wrap water-icon-wrap">
-                    <span class="metric-icon" aria-hidden="true">💧</span>
-                </div>
-                <div class="metric-info">
-                    <span class="metric-label" id="water-label">Water Level</span>
-                    <div class="meter" role="progressbar" aria-labelledby="water-label" aria-valuenow="0" aria-valuemin="0" aria-valuemax="4" id="water-meter-wrap">
-                        <div class="meter-fill meter-water" id="water-meter"></div>
-                    </div>
-                    <span class="metric-value" id="water-value">0 / 4</span>
-                </div>
+      <!-- Dashboard Metrics -->
+      <section class="dashboard" id="dashboard" aria-label="Growth Metrics">
+        <div class="metric-card" id="water-metric-card">
+          <div class="metric-icon-wrap water-icon-wrap">
+            <span class="metric-icon" aria-hidden="true">💧</span>
+          </div>
+          <div class="metric-info">
+            <span class="metric-label" id="water-label">Water Level</span>
+            <div
+              class="meter"
+              role="progressbar"
+              aria-labelledby="water-label"
+              aria-valuenow="0"
+              aria-valuemin="0"
+              aria-valuemax="4"
+              id="water-meter-wrap"
+            >
+              <div class="meter-fill meter-water" id="water-meter"></div>
             </div>
+            <span class="metric-value" id="water-value">0 / 4</span>
+          </div>
+        </div>
 
-            <div class="metric-card stage-metric-card" id="stage-metric-card">
-                <div class="metric-icon-wrap stage-icon-wrap">
-                    <span class="metric-icon" aria-hidden="true" id="stage-emoji">🌱</span>
-                </div>
-                <div class="metric-info">
-                    <span class="metric-label">Current Stage</span>
-                    <span class="stage-badge" id="stage-badge">Seeds</span>
-                </div>
+        <div class="metric-card stage-metric-card" id="stage-metric-card">
+          <div class="metric-icon-wrap stage-icon-wrap">
+            <span class="metric-icon" aria-hidden="true" id="stage-emoji"
+              >🌱</span
+            >
+          </div>
+          <div class="metric-info">
+            <span class="metric-label">Current Stage</span>
+            <span class="stage-badge" id="stage-badge">Seeds</span>
+          </div>
+        </div>
+
+        <div class="metric-card" id="sun-metric-card">
+          <div class="metric-icon-wrap sun-icon-wrap">
+            <span class="metric-icon" aria-hidden="true">☀️</span>
+          </div>
+          <div class="metric-info">
+            <span class="metric-label" id="sun-label">Sunlight Level</span>
+            <div
+              class="meter"
+              role="progressbar"
+              aria-labelledby="sun-label"
+              aria-valuenow="0"
+              aria-valuemin="0"
+              aria-valuemax="4"
+              id="sun-meter-wrap"
+            >
+              <div class="meter-fill meter-sun" id="sun-meter"></div>
             </div>
+            <span class="metric-value" id="sun-value">0 / 4</span>
+          </div>
+        </div>
+      </section>
 
-            <div class="metric-card" id="sun-metric-card">
-                <div class="metric-icon-wrap sun-icon-wrap">
-                    <span class="metric-icon" aria-hidden="true">☀️</span>
-                </div>
-                <div class="metric-info">
-                    <span class="metric-label" id="sun-label">Sunlight Level</span>
-                    <div class="meter" role="progressbar" aria-labelledby="sun-label" aria-valuenow="0" aria-valuemin="0" aria-valuemax="4" id="sun-meter-wrap">
-                        <div class="meter-fill meter-sun" id="sun-meter"></div>
-                    </div>
-                    <span class="metric-value" id="sun-value">0 / 4</span>
-                </div>
-            </div>
-        </section>
+      <!-- Plant Visualization -->
+      <section
+        class="plant-stage"
+        id="plant-stage"
+        aria-label="Plant Visualization"
+      >
+        <div class="plant-glow" id="plant-glow" aria-hidden="true"></div>
+        <div class="plant-image-container" id="plant-image-container">
+          <img
+            id="plant-image"
+            src="images/seeds.webp"
+            alt="Current plant stage: Seeds"
+            class="plant-image"
+            draggable="false"
+          />
+        </div>
+        <p class="stage-description" id="stage-description">
+          Every great tree starts as a tiny seed. Add water and sunlight to
+          begin growing!
+        </p>
+      </section>
 
-        <!-- Plant Visualization -->
-        <section class="plant-stage" id="plant-stage" aria-label="Plant Visualization">
-            <div class="plant-glow" id="plant-glow" aria-hidden="true"></div>
-            <div class="plant-image-container" id="plant-image-container">
-                <img
-                    id="plant-image"
-                    src="images/seeds.webp"
-                    alt="Current plant stage: Seeds"
-                    class="plant-image"
-                    draggable="false"
-                >
-            </div>
-            <p class="stage-description" id="stage-description">
-                Every great tree starts as a tiny seed. Add water and sunlight to begin growing!
-            </p>
-        </section>
+      <!-- Progress Timeline -->
+      <nav
+        class="progress-timeline"
+        id="progress-timeline"
+        aria-label="Growth Progress"
+      >
+        <ol class="timeline-list">
+          <li class="timeline-step active" data-step="0" aria-current="step">
+            <div class="step-dot" aria-hidden="true"></div>
+            <span class="step-label">Seeds</span>
+          </li>
+          <li class="timeline-connector" aria-hidden="true">
+            <div class="connector-fill" data-connector="0"></div>
+          </li>
+          <li class="timeline-step" data-step="1">
+            <div class="step-dot" aria-hidden="true"></div>
+            <span class="step-label">Sapling</span>
+          </li>
+          <li class="timeline-connector" aria-hidden="true">
+            <div class="connector-fill" data-connector="1"></div>
+          </li>
+          <li class="timeline-step" data-step="2">
+            <div class="step-dot" aria-hidden="true"></div>
+            <span class="step-label">Young Plant</span>
+          </li>
+          <li class="timeline-connector" aria-hidden="true">
+            <div class="connector-fill" data-connector="2"></div>
+          </li>
+          <li class="timeline-step" data-step="3">
+            <div class="step-dot" aria-hidden="true"></div>
+            <span class="step-label">Flowering</span>
+          </li>
+          <li class="timeline-connector" aria-hidden="true">
+            <div class="connector-fill" data-connector="3"></div>
+          </li>
+          <li class="timeline-step" data-step="4">
+            <div class="step-dot" aria-hidden="true"></div>
+            <span class="step-label">Tree</span>
+          </li>
+        </ol>
+      </nav>
 
-        <!-- Progress Timeline -->
-        <nav class="progress-timeline" id="progress-timeline" aria-label="Growth Progress">
-            <ol class="timeline-list">
-                <li class="timeline-step active" data-step="0" aria-current="step">
-                    <div class="step-dot" aria-hidden="true"></div>
-                    <span class="step-label">Seeds</span>
-                </li>
-                <li class="timeline-connector" aria-hidden="true"><div class="connector-fill" data-connector="0"></div></li>
-                <li class="timeline-step" data-step="1">
-                    <div class="step-dot" aria-hidden="true"></div>
-                    <span class="step-label">Sapling</span>
-                </li>
-                <li class="timeline-connector" aria-hidden="true"><div class="connector-fill" data-connector="1"></div></li>
-                <li class="timeline-step" data-step="2">
-                    <div class="step-dot" aria-hidden="true"></div>
-                    <span class="step-label">Young Plant</span>
-                </li>
-                <li class="timeline-connector" aria-hidden="true"><div class="connector-fill" data-connector="2"></div></li>
-                <li class="timeline-step" data-step="3">
-                    <div class="step-dot" aria-hidden="true"></div>
-                    <span class="step-label">Flowering</span>
-                </li>
-                <li class="timeline-connector" aria-hidden="true"><div class="connector-fill" data-connector="3"></div></li>
-                <li class="timeline-step" data-step="4">
-                    <div class="step-dot" aria-hidden="true"></div>
-                    <span class="step-label">Tree</span>
-                </li>
-            </ol>
-        </nav>
+      <!-- Controls -->
+      <section class="controls" id="controls" aria-label="Plant Controls">
+        <button
+          class="control-btn water-btn"
+          id="water-btn"
+          type="button"
+          aria-label="Add water to your plant"
+        >
+          <span class="btn-icon" aria-hidden="true">💧</span>
+          <span class="btn-text">Add Water</span>
+        </button>
 
-        <!-- Controls -->
-        <section class="controls" id="controls" aria-label="Plant Controls">
-            <button class="control-btn water-btn" id="water-btn" type="button" aria-label="Add water to your plant">
-                <span class="btn-icon" aria-hidden="true">💧</span>
-                <span class="btn-text">Add Water</span>
-            </button>
+        <button
+          class="control-btn reset-btn"
+          id="reset-btn"
+          type="button"
+          aria-label="Reset simulation and start over"
+        >
+          <span class="btn-icon" aria-hidden="true">
+            <svg
+              width="20"
+              height="20"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M1 4v6h6"></path>
+              <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
+            </svg>
+          </span>
+          <span class="btn-text">Start Over</span>
+        </button>
 
-            <button class="control-btn reset-btn" id="reset-btn" type="button" aria-label="Reset simulation and start over">
-                <span class="btn-icon" aria-hidden="true">
-                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M1 4v6h6"></path>
-                        <path d="M3.51 15a9 9 0 1 0 2.13-9.36L1 10"></path>
-                    </svg>
-                </span>
-                <span class="btn-text">Start Over</span>
-            </button>
+        <button
+          class="control-btn sun-btn"
+          id="sun-btn"
+          type="button"
+          aria-label="Add sunlight to your plant"
+        >
+          <span class="btn-icon" aria-hidden="true">☀️</span>
+          <span class="btn-text">Add Sunlight</span>
+        </button>
+      </section>
 
-            <button class="control-btn sun-btn" id="sun-btn" type="button" aria-label="Add sunlight to your plant">
-                <span class="btn-icon" aria-hidden="true">☀️</span>
-                <span class="btn-text">Add Sunlight</span>
-            </button>
-        </section>
-
-        <!-- Info Card -->
-        <aside class="info-card" id="info-card" aria-label="Helpful tips">
-            <div class="info-icon" aria-hidden="true">💡</div>
-            <p class="info-text">Add <strong>water</strong> and <strong>sunlight</strong> once each per step to advance to the next growth stage. Both are needed equally for healthy growth!</p>
-        </aside>
-
+      <!-- Info Card -->
+      <aside class="info-card" id="info-card" aria-label="Helpful tips">
+        <div class="info-icon" aria-hidden="true">💡</div>
+        <p class="info-text">
+          Add <strong>water</strong> and <strong>sunlight</strong> once each per
+          step to advance to the next growth stage. Both are needed equally for
+          healthy growth!
+        </p>
+      </aside>
     </main>
 
     <!-- Celebration Overlay (hidden by default) -->
-    <div class="celebration-overlay" id="celebration-overlay" aria-hidden="true" role="presentation"></div>
+    <div
+      class="celebration-overlay"
+      id="celebration-overlay"
+      aria-hidden="true"
+      role="presentation"
+    ></div>
 
     <script src="script.js"></script>
-</body>
+  </body>
 </html>

--- a/public/Plant/script.js
+++ b/public/Plant/script.js
@@ -2,291 +2,313 @@
    Plant Growth Simulation — Enhanced Interactive Logic
    ========================================================================== */
 (function () {
-    'use strict';
+  'use strict';
 
-    // ---- Stage Data ----
-    const STAGES = [
-        {
-            name: 'Seeds',
-            image: 'images/seeds.webp',
-            emoji: '🌱',
-            description: 'Every great tree starts as a tiny seed. Add water and sunlight to begin growing!'
-        },
-        {
-            name: 'Sapling',
-            image: 'images/sap3.webp',
-            emoji: '🌿',
-            description: 'A tender sapling has emerged! Keep nurturing it with care.'
-        },
-        {
-            name: 'Young Plant',
-            image: 'images/stage-2-veretation.png',
-            emoji: '🪴',
-            description: 'Your plant is growing strong with lush green vegetation.'
-        },
-        {
-            name: 'Flowering Plant',
-            image: 'images/flowering.png',
-            emoji: '🌸',
-            description: 'Beautiful flowers have bloomed! Your plant is thriving.'
-        },
-        {
-            name: 'Tree',
-            image: 'images/R.png',
-            emoji: '🌳',
-            description: 'A magnificent tree stands tall! You\'ve completed the journey. 🎉'
-        }
+  // ---- Stage Data ----
+  const STAGES = [
+    {
+      name: 'Seeds',
+      image: 'images/seeds.webp',
+      emoji: '🌱',
+      description:
+        'Every great tree starts as a tiny seed. Add water and sunlight to begin growing!',
+    },
+    {
+      name: 'Sapling',
+      image: 'images/sap3.webp',
+      emoji: '🌿',
+      description: 'A tender sapling has emerged! Keep nurturing it with care.',
+    },
+    {
+      name: 'Young Plant',
+      image: 'images/stage-2-veretation.png',
+      emoji: '🪴',
+      description: 'Your plant is growing strong with lush green vegetation.',
+    },
+    {
+      name: 'Flowering Plant',
+      image: 'images/flowering.png',
+      emoji: '🌸',
+      description: 'Beautiful flowers have bloomed! Your plant is thriving.',
+    },
+    {
+      name: 'Tree',
+      image: 'images/R.png',
+      emoji: '🌳',
+      description:
+        "A magnificent tree stands tall! You've completed the journey. 🎉",
+    },
+  ];
+
+  const FALLBACK_IMAGE = 'images/back.webp';
+
+  const MAX_LEVEL = 4;
+
+  // ---- State ----
+  let state = {
+    water: 0,
+    sunlight: 0,
+    stage: 0,
+  };
+
+  // ---- DOM Elements ----
+  const el = {
+    plantImage: document.getElementById('plant-image'),
+    plantStage: document.getElementById('plant-stage'),
+    plantGlow: document.getElementById('plant-glow'),
+    stageDescription: document.getElementById('stage-description'),
+    stageBadge: document.getElementById('stage-badge'),
+    stageEmoji: document.getElementById('stage-emoji'),
+    waterMeter: document.getElementById('water-meter'),
+    waterMeterWrap: document.getElementById('water-meter-wrap'),
+    waterValue: document.getElementById('water-value'),
+    sunMeter: document.getElementById('sun-meter'),
+    sunMeterWrap: document.getElementById('sun-meter-wrap'),
+    sunValue: document.getElementById('sun-value'),
+    waterBtn: document.getElementById('water-btn'),
+    sunBtn: document.getElementById('sun-btn'),
+    resetBtn: document.getElementById('reset-btn'),
+    timeline: document.getElementById('progress-timeline'),
+    celebrationOverlay: document.getElementById('celebration-overlay'),
+    plantImageContainer: document.getElementById('plant-image-container'),
+  };
+
+  el.plantImage.addEventListener('error', function () {
+    console.warn('Missing plant stage image:', this.src);
+
+    this.onerror = null;
+    this.classList.add('fallback');
+    this.src = FALLBACK_IMAGE;
+    this.alt = 'Plant image unavailable';
+  });
+  // ---- Initialize ----
+  function init() {
+    bindEvents();
+    render();
+  }
+
+  // ---- Event Binding ----
+  function bindEvents() {
+    el.waterBtn.addEventListener('click', handleWater);
+    el.sunBtn.addEventListener('click', handleSunlight);
+    el.resetBtn.addEventListener('click', handleReset);
+
+    // Ripple effect on buttons
+    document.querySelectorAll('.control-btn').forEach(function (btn) {
+      btn.addEventListener('click', createRipple);
+    });
+  }
+
+  // ---- Handlers ----
+  function handleWater() {
+    if (state.water >= MAX_LEVEL || state.water > state.sunlight) return;
+    state.water++;
+    onResourceAdded();
+  }
+
+  function handleSunlight() {
+    if (state.sunlight >= MAX_LEVEL || state.sunlight > state.water) return;
+    state.sunlight++;
+    onResourceAdded();
+  }
+
+  function onResourceAdded() {
+    checkStageAdvance();
+    render();
+  }
+
+  function handleReset() {
+    state = { water: 0, sunlight: 0, stage: 0 };
+    el.plantStage.classList.remove('completed');
+    el.celebrationOverlay.classList.remove('active');
+    el.celebrationOverlay.innerHTML = '';
+
+    // Animate plant image reset
+    el.plantImage.classList.add('growing');
+    el.plantImage.addEventListener('animationend', function onEnd() {
+      el.plantImage.classList.remove('growing');
+      el.plantImage.removeEventListener('animationend', onEnd);
+    });
+
+    render();
+  }
+
+  // ---- Stage Logic ----
+  function checkStageAdvance() {
+    var newStage = Math.min(state.water, state.sunlight);
+    if (newStage !== state.stage && newStage <= STAGES.length - 1) {
+      state.stage = newStage;
+      animatePlantTransition();
+
+      if (state.stage === STAGES.length - 1) {
+        triggerCelebration();
+      }
+    }
+  }
+
+  // ---- Rendering ----
+  function render() {
+    renderMeters();
+    renderStage();
+    renderTimeline();
+    renderButtons();
+  }
+
+  function renderMeters() {
+    var waterPercent = (state.water / MAX_LEVEL) * 100;
+    var sunPercent = (state.sunlight / MAX_LEVEL) * 100;
+
+    el.waterMeter.style.width = waterPercent + '%';
+    el.sunMeter.style.width = sunPercent + '%';
+
+    el.waterMeterWrap.setAttribute('aria-valuenow', state.water);
+    el.sunMeterWrap.setAttribute('aria-valuenow', state.sunlight);
+
+    el.waterValue.textContent = state.water + ' / ' + MAX_LEVEL;
+    el.sunValue.textContent = state.sunlight + ' / ' + MAX_LEVEL;
+  }
+
+  function renderStage() {
+    var stage = STAGES[state.stage];
+
+    el.plantImage.onerror = function () {
+      console.warn('Missing plant stage image:', stage.image);
+
+      this.onerror = null;
+      this.src = FALLBACK_IMAGE;
+      this.alt = 'Plant image unavailable';
+    };
+
+    el.plantImage.src = stage.image;
+    el.plantImage.alt = 'Current plant stage: ' + stage.name;
+    el.stageDescription.textContent = stage.description;
+    el.stageBadge.textContent = stage.name;
+    el.stageEmoji.textContent = stage.emoji;
+    el.plantStage.setAttribute('data-stage', state.stage);
+  }
+
+  function renderTimeline() {
+    var steps = el.timeline.querySelectorAll('.timeline-step');
+    var connectors = el.timeline.querySelectorAll('.connector-fill');
+
+    steps.forEach(function (step, index) {
+      step.classList.remove('active', 'completed');
+      step.removeAttribute('aria-current');
+
+      if (index < state.stage) {
+        step.classList.add('completed');
+      } else if (index === state.stage) {
+        step.classList.add('active');
+        step.setAttribute('aria-current', 'step');
+      }
+    });
+
+    connectors.forEach(function (connector, index) {
+      if (index < state.stage) {
+        connector.classList.add('filled');
+      } else {
+        connector.classList.remove('filled');
+      }
+    });
+  }
+
+  function renderButtons() {
+    var isComplete = state.stage >= STAGES.length - 1;
+
+    // Water button: disable if at max or if water is already ahead of sunlight
+    el.waterBtn.disabled =
+      isComplete || state.water >= MAX_LEVEL || state.water > state.sunlight;
+    el.sunBtn.disabled =
+      isComplete || state.sunlight >= MAX_LEVEL || state.sunlight > state.water;
+
+    // Update button text for completed state
+    if (isComplete) {
+      el.waterBtn.querySelector('.btn-text').textContent = 'Max Level';
+      el.sunBtn.querySelector('.btn-text').textContent = 'Max Level';
+    } else {
+      el.waterBtn.querySelector('.btn-text').textContent = 'Add Water';
+      el.sunBtn.querySelector('.btn-text').textContent = 'Add Sunlight';
+    }
+  }
+
+  // ---- Animations ----
+  function animatePlantTransition() {
+    el.plantImage.classList.add('growing');
+    el.plantImage.addEventListener('animationend', function onEnd() {
+      el.plantImage.classList.remove('growing');
+      el.plantImage.removeEventListener('animationend', onEnd);
+    });
+  }
+
+  function createRipple(e) {
+    var btn = e.currentTarget;
+    var rect = btn.getBoundingClientRect();
+    var size = Math.max(rect.width, rect.height);
+    var x = e.clientX - rect.left - size / 2;
+    var y = e.clientY - rect.top - size / 2;
+
+    // Remove existing ripples
+    var existingRipple = btn.querySelector('.ripple');
+    if (existingRipple) existingRipple.remove();
+
+    var ripple = document.createElement('span');
+    ripple.classList.add('ripple');
+    ripple.style.width = ripple.style.height = size + 'px';
+    ripple.style.left = x + 'px';
+    ripple.style.top = y + 'px';
+
+    btn.appendChild(ripple);
+
+    ripple.addEventListener('animationend', function () {
+      ripple.remove();
+    });
+  }
+
+  // ---- Celebration ----
+  function triggerCelebration() {
+    el.plantStage.classList.add('completed');
+
+    // Generate confetti
+    var overlay = el.celebrationOverlay;
+    overlay.innerHTML = '';
+    overlay.classList.add('active');
+
+    var colors = [
+      'hsl(145, 65%, 48%)', // green
+      'hsl(42, 95%, 55%)', // gold
+      'hsl(200, 85%, 55%)', // blue
+      'hsl(330, 70%, 55%)', // pink
+      'hsl(48, 100%, 60%)', // yellow
+      'hsl(280, 55%, 58%)', // purple
     ];
 
-    const MAX_LEVEL = 4;
-
-    // ---- State ----
-    let state = {
-        water: 0,
-        sunlight: 0,
-        stage: 0
-    };
-
-    // ---- DOM Elements ----
-    const el = {
-        plantImage: document.getElementById('plant-image'),
-        plantStage: document.getElementById('plant-stage'),
-        plantGlow: document.getElementById('plant-glow'),
-        stageDescription: document.getElementById('stage-description'),
-        stageBadge: document.getElementById('stage-badge'),
-        stageEmoji: document.getElementById('stage-emoji'),
-        waterMeter: document.getElementById('water-meter'),
-        waterMeterWrap: document.getElementById('water-meter-wrap'),
-        waterValue: document.getElementById('water-value'),
-        sunMeter: document.getElementById('sun-meter'),
-        sunMeterWrap: document.getElementById('sun-meter-wrap'),
-        sunValue: document.getElementById('sun-value'),
-        waterBtn: document.getElementById('water-btn'),
-        sunBtn: document.getElementById('sun-btn'),
-        resetBtn: document.getElementById('reset-btn'),
-        timeline: document.getElementById('progress-timeline'),
-        celebrationOverlay: document.getElementById('celebration-overlay'),
-        plantImageContainer: document.getElementById('plant-image-container')
-    };
-
-    // ---- Initialize ----
-    function init() {
-        bindEvents();
-        render();
+    for (var i = 0; i < 60; i++) {
+      var piece = document.createElement('div');
+      piece.classList.add('confetti-piece');
+      piece.style.backgroundColor =
+        colors[Math.floor(Math.random() * colors.length)];
+      piece.style.left = Math.random() * 100 + 'vw';
+      piece.style.animationDuration = Math.random() * 2 + 2 + 's';
+      piece.style.animationDelay = Math.random() * 1.5 + 's';
+      piece.style.width = Math.random() * 8 + 6 + 'px';
+      piece.style.height = Math.random() * 8 + 6 + 'px';
+      piece.style.borderRadius = Math.random() > 0.5 ? '50%' : '2px';
+      overlay.appendChild(piece);
     }
 
-    // ---- Event Binding ----
-    function bindEvents() {
-        el.waterBtn.addEventListener('click', handleWater);
-        el.sunBtn.addEventListener('click', handleSunlight);
-        el.resetBtn.addEventListener('click', handleReset);
-
-        // Ripple effect on buttons
-        document.querySelectorAll('.control-btn').forEach(function (btn) {
-            btn.addEventListener('click', createRipple);
-        });
-    }
-
-    // ---- Handlers ----
-    function handleWater() {
-        if (state.water >= MAX_LEVEL || state.water > state.sunlight) return;
-        state.water++;
-        onResourceAdded();
-    }
-
-    function handleSunlight() {
-        if (state.sunlight >= MAX_LEVEL || state.sunlight > state.water) return;
-        state.sunlight++;
-        onResourceAdded();
-    }
-
-    function onResourceAdded() {
-        checkStageAdvance();
-        render();
-    }
-
-    function handleReset() {
-        state = { water: 0, sunlight: 0, stage: 0 };
-        el.plantStage.classList.remove('completed');
-        el.celebrationOverlay.classList.remove('active');
-        el.celebrationOverlay.innerHTML = '';
-
-        // Animate plant image reset
-        el.plantImage.classList.add('growing');
-        el.plantImage.addEventListener('animationend', function onEnd() {
-            el.plantImage.classList.remove('growing');
-            el.plantImage.removeEventListener('animationend', onEnd);
-        });
-
-        render();
-    }
-
-    // ---- Stage Logic ----
-    function checkStageAdvance() {
-        var newStage = Math.min(state.water, state.sunlight);
-        if (newStage !== state.stage && newStage <= STAGES.length - 1) {
-            state.stage = newStage;
-            animatePlantTransition();
-
-            if (state.stage === STAGES.length - 1) {
-                triggerCelebration();
-            }
-        }
-    }
-
-    // ---- Rendering ----
-    function render() {
-        renderMeters();
-        renderStage();
-        renderTimeline();
-        renderButtons();
-    }
-
-    function renderMeters() {
-        var waterPercent = (state.water / MAX_LEVEL) * 100;
-        var sunPercent = (state.sunlight / MAX_LEVEL) * 100;
-
-        el.waterMeter.style.width = waterPercent + '%';
-        el.sunMeter.style.width = sunPercent + '%';
-
-        el.waterMeterWrap.setAttribute('aria-valuenow', state.water);
-        el.sunMeterWrap.setAttribute('aria-valuenow', state.sunlight);
-
-        el.waterValue.textContent = state.water + ' / ' + MAX_LEVEL;
-        el.sunValue.textContent = state.sunlight + ' / ' + MAX_LEVEL;
-    }
-
-    function renderStage() {
-        var stage = STAGES[state.stage];
-
-        el.plantImage.src = stage.image;
-        el.plantImage.alt = 'Current plant stage: ' + stage.name;
-        el.stageDescription.textContent = stage.description;
-        el.stageBadge.textContent = stage.name;
-        el.stageEmoji.textContent = stage.emoji;
-        el.plantStage.setAttribute('data-stage', state.stage);
-    }
-
-    function renderTimeline() {
-        var steps = el.timeline.querySelectorAll('.timeline-step');
-        var connectors = el.timeline.querySelectorAll('.connector-fill');
-
-        steps.forEach(function (step, index) {
-            step.classList.remove('active', 'completed');
-            step.removeAttribute('aria-current');
-
-            if (index < state.stage) {
-                step.classList.add('completed');
-            } else if (index === state.stage) {
-                step.classList.add('active');
-                step.setAttribute('aria-current', 'step');
-            }
-        });
-
-        connectors.forEach(function (connector, index) {
-            if (index < state.stage) {
-                connector.classList.add('filled');
-            } else {
-                connector.classList.remove('filled');
-            }
-        });
-    }
-
-    function renderButtons() {
-        var isComplete = state.stage >= STAGES.length - 1;
-
-        // Water button: disable if at max or if water is already ahead of sunlight
-        el.waterBtn.disabled = isComplete || state.water >= MAX_LEVEL || state.water > state.sunlight;
-        el.sunBtn.disabled = isComplete || state.sunlight >= MAX_LEVEL || state.sunlight > state.water;
-
-        // Update button text for completed state
-        if (isComplete) {
-            el.waterBtn.querySelector('.btn-text').textContent = 'Max Level';
-            el.sunBtn.querySelector('.btn-text').textContent = 'Max Level';
-        } else {
-            el.waterBtn.querySelector('.btn-text').textContent = 'Add Water';
-            el.sunBtn.querySelector('.btn-text').textContent = 'Add Sunlight';
-        }
-    }
-
-    // ---- Animations ----
-    function animatePlantTransition() {
-        el.plantImage.classList.add('growing');
-        el.plantImage.addEventListener('animationend', function onEnd() {
-            el.plantImage.classList.remove('growing');
-            el.plantImage.removeEventListener('animationend', onEnd);
-        });
-    }
-
-    function createRipple(e) {
-        var btn = e.currentTarget;
-        var rect = btn.getBoundingClientRect();
-        var size = Math.max(rect.width, rect.height);
-        var x = e.clientX - rect.left - size / 2;
-        var y = e.clientY - rect.top - size / 2;
-
-        // Remove existing ripples
-        var existingRipple = btn.querySelector('.ripple');
-        if (existingRipple) existingRipple.remove();
-
-        var ripple = document.createElement('span');
-        ripple.classList.add('ripple');
-        ripple.style.width = ripple.style.height = size + 'px';
-        ripple.style.left = x + 'px';
-        ripple.style.top = y + 'px';
-
-        btn.appendChild(ripple);
-
-        ripple.addEventListener('animationend', function () {
-            ripple.remove();
-        });
-    }
-
-    // ---- Celebration ----
-    function triggerCelebration() {
-        el.plantStage.classList.add('completed');
-
-        // Generate confetti
-        var overlay = el.celebrationOverlay;
+    // Clean up after animation
+    setTimeout(function () {
+      overlay.classList.remove('active');
+      setTimeout(function () {
         overlay.innerHTML = '';
-        overlay.classList.add('active');
+      }, 500);
+    }, 4500);
+  }
 
-        var colors = [
-            'hsl(145, 65%, 48%)',   // green
-            'hsl(42, 95%, 55%)',    // gold
-            'hsl(200, 85%, 55%)',   // blue
-            'hsl(330, 70%, 55%)',   // pink
-            'hsl(48, 100%, 60%)',   // yellow
-            'hsl(280, 55%, 58%)'   // purple
-        ];
-
-        for (var i = 0; i < 60; i++) {
-            var piece = document.createElement('div');
-            piece.classList.add('confetti-piece');
-            piece.style.backgroundColor = colors[Math.floor(Math.random() * colors.length)];
-            piece.style.left = Math.random() * 100 + 'vw';
-            piece.style.animationDuration = (Math.random() * 2 + 2) + 's';
-            piece.style.animationDelay = Math.random() * 1.5 + 's';
-            piece.style.width = (Math.random() * 8 + 6) + 'px';
-            piece.style.height = (Math.random() * 8 + 6) + 'px';
-            piece.style.borderRadius = Math.random() > 0.5 ? '50%' : '2px';
-            overlay.appendChild(piece);
-        }
-
-        // Clean up after animation
-        setTimeout(function () {
-            overlay.classList.remove('active');
-            setTimeout(function () {
-                overlay.innerHTML = '';
-            }, 500);
-        }, 4500);
-    }
-
-    // ---- Start ----
-    if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', init);
-    } else {
-        init();
-    }
-
+  // ---- Start ----
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
 })();

--- a/public/Plant/style.css
+++ b/public/Plant/style.css
@@ -5,1042 +5,1123 @@
 
 /* ---------- Design Tokens ---------- */
 :root {
-    /* Background */
-    --bg-primary: hsl(225, 28%, 6%);
-    --bg-secondary: hsl(225, 25%, 10%);
-    --bg-card: hsla(225, 30%, 14%, 0.55);
-    --bg-card-hover: hsla(225, 30%, 18%, 0.65);
-    --bg-card-border: hsla(225, 40%, 35%, 0.2);
+  /* Background */
+  --bg-primary: hsl(225, 28%, 6%);
+  --bg-secondary: hsl(225, 25%, 10%);
+  --bg-card: hsla(225, 30%, 14%, 0.55);
+  --bg-card-hover: hsla(225, 30%, 18%, 0.65);
+  --bg-card-border: hsla(225, 40%, 35%, 0.2);
 
-    /* Accent Colors */
-    --accent-water: hsl(200, 85%, 55%);
-    --accent-water-light: hsl(200, 90%, 72%);
-    --accent-water-dark: hsl(200, 80%, 35%);
-    --accent-sun: hsl(42, 95%, 55%);
-    --accent-sun-light: hsl(42, 95%, 72%);
-    --accent-sun-dark: hsl(42, 85%, 38%);
-    --accent-grow: hsl(145, 65%, 48%);
-    --accent-grow-light: hsl(145, 65%, 65%);
-    --accent-grow-dark: hsl(145, 60%, 30%);
-    --accent-reset: hsl(280, 55%, 58%);
-    --accent-reset-light: hsl(280, 55%, 72%);
-    --accent-danger: hsl(0, 75%, 58%);
-    --accent-celebration: hsl(48, 100%, 60%);
+  /* Accent Colors */
+  --accent-water: hsl(200, 85%, 55%);
+  --accent-water-light: hsl(200, 90%, 72%);
+  --accent-water-dark: hsl(200, 80%, 35%);
+  --accent-sun: hsl(42, 95%, 55%);
+  --accent-sun-light: hsl(42, 95%, 72%);
+  --accent-sun-dark: hsl(42, 85%, 38%);
+  --accent-grow: hsl(145, 65%, 48%);
+  --accent-grow-light: hsl(145, 65%, 65%);
+  --accent-grow-dark: hsl(145, 60%, 30%);
+  --accent-reset: hsl(280, 55%, 58%);
+  --accent-reset-light: hsl(280, 55%, 72%);
+  --accent-danger: hsl(0, 75%, 58%);
+  --accent-celebration: hsl(48, 100%, 60%);
 
-    /* Text */
-    --text-primary: hsl(220, 20%, 94%);
-    --text-secondary: hsl(220, 15%, 62%);
-    --text-muted: hsl(220, 12%, 45%);
-    --text-on-accent: hsl(0, 0%, 100%);
+  /* Text */
+  --text-primary: hsl(220, 20%, 94%);
+  --text-secondary: hsl(220, 15%, 62%);
+  --text-muted: hsl(220, 12%, 45%);
+  --text-on-accent: hsl(0, 0%, 100%);
 
-    /* Typography */
-    --font-body: 'Inter', system-ui, -apple-system, sans-serif;
-    --font-display: 'Outfit', 'Inter', system-ui, sans-serif;
-    --fs-xs: clamp(0.7rem, 0.65rem + 0.25vw, 0.8rem);
-    --fs-sm: clamp(0.8rem, 0.75rem + 0.3vw, 0.9rem);
-    --fs-base: clamp(0.9rem, 0.85rem + 0.35vw, 1rem);
-    --fs-md: clamp(1rem, 0.9rem + 0.5vw, 1.15rem);
-    --fs-lg: clamp(1.15rem, 1rem + 0.7vw, 1.4rem);
-    --fs-xl: clamp(1.4rem, 1.1rem + 1.2vw, 2rem);
-    --fs-2xl: clamp(1.8rem, 1.3rem + 2vw, 2.8rem);
+  /* Typography */
+  --font-body: 'Inter', system-ui, -apple-system, sans-serif;
+  --font-display: 'Outfit', 'Inter', system-ui, sans-serif;
+  --fs-xs: clamp(0.7rem, 0.65rem + 0.25vw, 0.8rem);
+  --fs-sm: clamp(0.8rem, 0.75rem + 0.3vw, 0.9rem);
+  --fs-base: clamp(0.9rem, 0.85rem + 0.35vw, 1rem);
+  --fs-md: clamp(1rem, 0.9rem + 0.5vw, 1.15rem);
+  --fs-lg: clamp(1.15rem, 1rem + 0.7vw, 1.4rem);
+  --fs-xl: clamp(1.4rem, 1.1rem + 1.2vw, 2rem);
+  --fs-2xl: clamp(1.8rem, 1.3rem + 2vw, 2.8rem);
 
-    /* Spacing */
-    --space-xs: 0.35rem;
-    --space-sm: 0.6rem;
-    --space-md: 1rem;
-    --space-lg: 1.5rem;
-    --space-xl: 2.25rem;
-    --space-2xl: 3.5rem;
+  /* Spacing */
+  --space-xs: 0.35rem;
+  --space-sm: 0.6rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2.25rem;
+  --space-2xl: 3.5rem;
 
-    /* Borders */
-    --radius-sm: 8px;
-    --radius-md: 12px;
-    --radius-lg: 16px;
-    --radius-xl: 24px;
-    --radius-full: 9999px;
+  /* Borders */
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 16px;
+  --radius-xl: 24px;
+  --radius-full: 9999px;
 
-    /* Shadows */
-    --shadow-card: 0 4px 24px hsla(225, 50%, 4%, 0.5),
-                   0 1px 4px hsla(225, 50%, 4%, 0.3);
-    --shadow-card-hover: 0 8px 40px hsla(225, 50%, 4%, 0.6),
-                         0 2px 8px hsla(225, 50%, 4%, 0.4);
-    --shadow-glow-water: 0 0 20px hsla(200, 85%, 55%, 0.3),
-                         0 0 60px hsla(200, 85%, 55%, 0.1);
-    --shadow-glow-sun: 0 0 20px hsla(42, 95%, 55%, 0.3),
-                       0 0 60px hsla(42, 95%, 55%, 0.1);
-    --shadow-glow-grow: 0 0 30px hsla(145, 65%, 48%, 0.25),
-                        0 0 80px hsla(145, 65%, 48%, 0.08);
-    --shadow-glow-celebration: 0 0 40px hsla(48, 100%, 60%, 0.4),
-                               0 0 100px hsla(48, 100%, 60%, 0.15);
+  /* Shadows */
+  --shadow-card:
+    0 4px 24px hsla(225, 50%, 4%, 0.5), 0 1px 4px hsla(225, 50%, 4%, 0.3);
+  --shadow-card-hover:
+    0 8px 40px hsla(225, 50%, 4%, 0.6), 0 2px 8px hsla(225, 50%, 4%, 0.4);
+  --shadow-glow-water:
+    0 0 20px hsla(200, 85%, 55%, 0.3), 0 0 60px hsla(200, 85%, 55%, 0.1);
+  --shadow-glow-sun:
+    0 0 20px hsla(42, 95%, 55%, 0.3), 0 0 60px hsla(42, 95%, 55%, 0.1);
+  --shadow-glow-grow:
+    0 0 30px hsla(145, 65%, 48%, 0.25), 0 0 80px hsla(145, 65%, 48%, 0.08);
+  --shadow-glow-celebration:
+    0 0 40px hsla(48, 100%, 60%, 0.4), 0 0 100px hsla(48, 100%, 60%, 0.15);
 
-    /* Transitions */
-    --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
-    --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
-    --duration-fast: 200ms;
-    --duration-normal: 350ms;
-    --duration-slow: 600ms;
+  /* Transitions */
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
+  --duration-fast: 200ms;
+  --duration-normal: 350ms;
+  --duration-slow: 600ms;
 
-    /* Glass */
-    --glass-blur: 16px;
-    --glass-border: 1px solid var(--bg-card-border);
+  /* Glass */
+  --glass-blur: 16px;
+  --glass-border: 1px solid var(--bg-card-border);
 }
 
 /* ---------- Reset & Base ---------- */
 *,
 *::before,
 *::after {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 }
 
 html {
-    scroll-behavior: smooth;
-    -webkit-text-size-adjust: 100%;
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
 }
 
 body {
-    font-family: var(--font-body);
-    font-size: var(--fs-base);
-    color: var(--text-primary);
-    background: var(--bg-primary);
-    background-image:
-        radial-gradient(ellipse 80% 60% at 50% -10%, hsla(200, 60%, 20%, 0.25) 0%, transparent 60%),
-        radial-gradient(ellipse 60% 50% at 80% 50%, hsla(280, 40%, 15%, 0.15) 0%, transparent 55%),
-        radial-gradient(ellipse 60% 50% at 20% 80%, hsla(145, 50%, 15%, 0.12) 0%, transparent 55%);
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    line-height: 1.6;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-    overflow-x: hidden;
-    padding: var(--space-lg) var(--space-md);
-    padding-top: calc(var(--space-2xl) + 20px);
+  font-family: var(--font-body);
+  font-size: var(--fs-base);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  background-image:
+    radial-gradient(
+      ellipse 80% 60% at 50% -10%,
+      hsla(200, 60%, 20%, 0.25) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse 60% 50% at 80% 50%,
+      hsla(280, 40%, 15%, 0.15) 0%,
+      transparent 55%
+    ),
+    radial-gradient(
+      ellipse 60% 50% at 20% 80%,
+      hsla(145, 50%, 15%, 0.12) 0%,
+      transparent 55%
+    );
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
+  padding: var(--space-lg) var(--space-md);
+  padding-top: calc(var(--space-2xl) + 20px);
 }
 
 img {
-    max-width: 100%;
-    height: auto;
-    display: block;
+  max-width: 100%;
+  height: auto;
+  display: block;
 }
 
-ol, ul {
-    list-style: none;
+ol,
+ul {
+  list-style: none;
 }
 
 button {
-    font-family: inherit;
-    cursor: pointer;
-    border: none;
-    outline: none;
-    background: none;
-    color: inherit;
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  outline: none;
+  background: none;
+  color: inherit;
 }
 
 a {
-    color: inherit;
-    text-decoration: none;
+  color: inherit;
+  text-decoration: none;
 }
 
 /* ---------- Back Button ---------- */
 .back-button {
-    position: fixed;
-    top: var(--space-md);
-    left: var(--space-md);
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-xs);
-    padding: var(--space-sm) var(--space-md);
-    background: var(--bg-card);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-    border: var(--glass-border);
-    border-radius: var(--radius-full);
-    font-size: var(--fs-sm);
-    font-weight: 600;
-    color: var(--text-secondary);
-    z-index: 100;
-    transition: all var(--duration-fast) var(--ease-out);
-    box-shadow: var(--shadow-card);
+  position: fixed;
+  top: var(--space-md);
+  left: var(--space-md);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-card);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: var(--glass-border);
+  border-radius: var(--radius-full);
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--text-secondary);
+  z-index: 100;
+  transition: all var(--duration-fast) var(--ease-out);
+  box-shadow: var(--shadow-card);
 }
 
 .back-button:hover {
-    color: var(--text-primary);
-    background: var(--bg-card-hover);
-    transform: translateX(-2px);
-    box-shadow: var(--shadow-card-hover);
+  color: var(--text-primary);
+  background: var(--bg-card-hover);
+  transform: translateX(-2px);
+  box-shadow: var(--shadow-card-hover);
 }
 
 .back-button:focus-visible {
-    outline: 2px solid var(--accent-grow);
-    outline-offset: 2px;
+  outline: 2px solid var(--accent-grow);
+  outline-offset: 2px;
 }
 
 .back-button svg {
-    flex-shrink: 0;
+  flex-shrink: 0;
 }
 
 /* ---------- Header ---------- */
 .page-header {
-    text-align: center;
-    margin-bottom: var(--space-xl);
-    animation: fadeSlideDown var(--duration-slow) var(--ease-out) both;
+  text-align: center;
+  margin-bottom: var(--space-xl);
+  animation: fadeSlideDown var(--duration-slow) var(--ease-out) both;
 }
 
 .page-header h1 {
-    font-family: var(--font-display);
-    font-size: var(--fs-2xl);
-    font-weight: 800;
-    letter-spacing: -0.02em;
-    background: linear-gradient(135deg, var(--accent-grow-light) 0%, var(--accent-water-light) 50%, var(--accent-sun-light) 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--space-sm);
-    line-height: 1.2;
+  font-family: var(--font-display);
+  font-size: var(--fs-2xl);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  background: linear-gradient(
+    135deg,
+    var(--accent-grow-light) 0%,
+    var(--accent-water-light) 50%,
+    var(--accent-sun-light) 100%
+  );
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-sm);
+  line-height: 1.2;
 }
 
 .title-icon {
-    -webkit-text-fill-color: initial;
-    font-size: 1.1em;
-    filter: drop-shadow(0 2px 8px hsla(145, 65%, 48%, 0.35));
+  -webkit-text-fill-color: initial;
+  font-size: 1.1em;
+  filter: drop-shadow(0 2px 8px hsla(145, 65%, 48%, 0.35));
 }
 
 .subtitle {
-    color: var(--text-secondary);
-    font-size: var(--fs-md);
-    margin-top: var(--space-xs);
-    font-weight: 400;
+  color: var(--text-secondary);
+  font-size: var(--fs-md);
+  margin-top: var(--space-xs);
+  font-weight: 400;
 }
 
 /* ---------- Main Content ---------- */
 main {
-    width: 100%;
-    max-width: 780px;
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-xl);
-    animation: fadeSlideUp var(--duration-slow) var(--ease-out) 0.1s both;
+  width: 100%;
+  max-width: 780px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
+  animation: fadeSlideUp var(--duration-slow) var(--ease-out) 0.1s both;
 }
 
 /* ---------- Dashboard ---------- */
 .dashboard {
-    display: grid;
-    grid-template-columns: 1fr auto 1fr;
-    gap: var(--space-md);
-    align-items: stretch;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: var(--space-md);
+  align-items: stretch;
 }
 
 .metric-card {
-    background: var(--bg-card);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-    border: var(--glass-border);
-    border-radius: var(--radius-lg);
-    padding: var(--space-lg);
-    display: flex;
-    align-items: center;
-    gap: var(--space-md);
-    box-shadow: var(--shadow-card);
-    transition: all var(--duration-normal) var(--ease-out);
+  background: var(--bg-card);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: var(--glass-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  box-shadow: var(--shadow-card);
+  transition: all var(--duration-normal) var(--ease-out);
 }
 
 .metric-card:hover {
-    background: var(--bg-card-hover);
-    box-shadow: var(--shadow-card-hover);
-    transform: translateY(-2px);
+  background: var(--bg-card-hover);
+  box-shadow: var(--shadow-card-hover);
+  transform: translateY(-2px);
 }
 
 .metric-icon-wrap {
-    width: 48px;
-    height: 48px;
-    border-radius: var(--radius-md);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 1.5rem;
-    flex-shrink: 0;
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.5rem;
+  flex-shrink: 0;
 }
 
 .water-icon-wrap {
-    background: hsla(200, 85%, 55%, 0.12);
-    box-shadow: inset 0 0 12px hsla(200, 85%, 55%, 0.08);
+  background: hsla(200, 85%, 55%, 0.12);
+  box-shadow: inset 0 0 12px hsla(200, 85%, 55%, 0.08);
 }
 
 .sun-icon-wrap {
-    background: hsla(42, 95%, 55%, 0.12);
-    box-shadow: inset 0 0 12px hsla(42, 95%, 55%, 0.08);
+  background: hsla(42, 95%, 55%, 0.12);
+  box-shadow: inset 0 0 12px hsla(42, 95%, 55%, 0.08);
 }
 
 .stage-icon-wrap {
-    background: hsla(145, 65%, 48%, 0.12);
-    box-shadow: inset 0 0 12px hsla(145, 65%, 48%, 0.08);
+  background: hsla(145, 65%, 48%, 0.12);
+  box-shadow: inset 0 0 12px hsla(145, 65%, 48%, 0.08);
 }
 
 .metric-info {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-xs);
-    min-width: 0;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  min-width: 0;
 }
 
 .metric-label {
-    font-size: var(--fs-xs);
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    font-weight: 600;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
 }
 
 .metric-value {
-    font-size: var(--fs-sm);
-    font-weight: 600;
-    color: var(--text-secondary);
-    font-variant-numeric: tabular-nums;
+  font-size: var(--fs-sm);
+  font-weight: 600;
+  color: var(--text-secondary);
+  font-variant-numeric: tabular-nums;
 }
 
 /* Meters */
 .meter {
-    width: 100%;
-    height: 8px;
-    background: hsla(225, 20%, 20%, 0.6);
-    border-radius: var(--radius-full);
-    overflow: hidden;
-    position: relative;
+  width: 100%;
+  height: 8px;
+  background: hsla(225, 20%, 20%, 0.6);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+  position: relative;
 }
 
 .meter-fill {
-    height: 100%;
-    width: 0%;
-    border-radius: var(--radius-full);
-    transition: width var(--duration-slow) var(--ease-spring);
-    position: relative;
+  height: 100%;
+  width: 0%;
+  border-radius: var(--radius-full);
+  transition: width var(--duration-slow) var(--ease-spring);
+  position: relative;
 }
 
 .meter-water {
-    background: linear-gradient(90deg, var(--accent-water-dark), var(--accent-water), var(--accent-water-light));
-    box-shadow: 0 0 10px hsla(200, 85%, 55%, 0.3);
+  background: linear-gradient(
+    90deg,
+    var(--accent-water-dark),
+    var(--accent-water),
+    var(--accent-water-light)
+  );
+  box-shadow: 0 0 10px hsla(200, 85%, 55%, 0.3);
 }
 
 .meter-sun {
-    background: linear-gradient(90deg, var(--accent-sun-dark), var(--accent-sun), var(--accent-sun-light));
-    box-shadow: 0 0 10px hsla(42, 95%, 55%, 0.3);
+  background: linear-gradient(
+    90deg,
+    var(--accent-sun-dark),
+    var(--accent-sun),
+    var(--accent-sun-light)
+  );
+  box-shadow: 0 0 10px hsla(42, 95%, 55%, 0.3);
 }
 
 /* Stage Badge */
 .stage-metric-card {
-    flex-direction: column;
-    text-align: center;
-    justify-content: center;
+  flex-direction: column;
+  text-align: center;
+  justify-content: center;
 }
 
 .stage-metric-card .metric-info {
-    align-items: center;
+  align-items: center;
 }
 
 .stage-badge {
-    font-family: var(--font-display);
-    font-size: var(--fs-lg);
-    font-weight: 700;
-    color: var(--accent-grow-light);
-    white-space: nowrap;
+  font-family: var(--font-display);
+  font-size: var(--fs-lg);
+  font-weight: 700;
+  color: var(--accent-grow-light);
+  white-space: nowrap;
 }
 
 /* ---------- Plant Visualization ---------- */
 .plant-stage {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    position: relative;
-    padding: var(--space-xl) 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  padding: var(--space-xl) 0;
 }
 
 .plant-glow {
-    position: absolute;
-    width: 260px;
-    height: 260px;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -55%);
-    border-radius: 50%;
-    background: radial-gradient(circle, hsla(145, 65%, 48%, 0.1) 0%, transparent 70%);
-    animation: pulseGlow 3s ease-in-out infinite;
-    pointer-events: none;
-    z-index: 0;
+  position: absolute;
+  width: 260px;
+  height: 260px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -55%);
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    hsla(145, 65%, 48%, 0.1) 0%,
+    transparent 70%
+  );
+  animation: pulseGlow 3s ease-in-out infinite;
+  pointer-events: none;
+  z-index: 0;
 }
 
 .plant-image-container {
-    position: relative;
-    z-index: 1;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 220px;
-    height: 220px;
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 220px;
+  height: 220px;
 }
 
 .plant-image {
-    max-width: 200px;
-    max-height: 200px;
-    object-fit: contain;
-    filter: drop-shadow(0 8px 24px hsla(0, 0%, 0%, 0.5));
-    transition: all var(--duration-slow) var(--ease-spring);
+  max-width: 200px;
+  max-height: 200px;
+  object-fit: contain;
+  filter: drop-shadow(0 8px 24px hsla(0, 0%, 0%, 0.5));
+  transition: all var(--duration-slow) var(--ease-spring);
 }
 
 .plant-image.growing {
-    animation: plantGrow var(--duration-slow) var(--ease-spring);
+  animation: plantGrow var(--duration-slow) var(--ease-spring);
 }
 
 .stage-description {
-    text-align: center;
-    color: var(--text-secondary);
-    font-size: var(--fs-sm);
-    max-width: 400px;
-    margin-top: var(--space-lg);
-    line-height: 1.6;
-    z-index: 1;
+  text-align: center;
+  color: var(--text-secondary);
+  font-size: var(--fs-sm);
+  max-width: 400px;
+  margin-top: var(--space-lg);
+  line-height: 1.6;
+  z-index: 1;
 }
 
 /* ---------- Progress Timeline ---------- */
 .progress-timeline {
-    padding: var(--space-sm) 0;
+  padding: var(--space-sm) 0;
 }
 
 .timeline-list {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
 }
 
 .timeline-step {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--space-xs);
-    position: relative;
-    flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
+  position: relative;
+  flex-shrink: 0;
 }
 
 .step-dot {
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background: hsla(225, 20%, 25%, 0.8);
-    border: 2px solid hsla(225, 20%, 35%, 0.5);
-    transition: all var(--duration-normal) var(--ease-spring);
-    position: relative;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: hsla(225, 20%, 25%, 0.8);
+  border: 2px solid hsla(225, 20%, 35%, 0.5);
+  transition: all var(--duration-normal) var(--ease-spring);
+  position: relative;
 }
 
 .step-dot::after {
-    content: '';
-    position: absolute;
-    inset: 2px;
-    border-radius: 50%;
-    background: transparent;
-    transition: background var(--duration-normal) var(--ease-out);
+  content: '';
+  position: absolute;
+  inset: 2px;
+  border-radius: 50%;
+  background: transparent;
+  transition: background var(--duration-normal) var(--ease-out);
 }
 
 .timeline-step.active .step-dot {
-    background: var(--accent-grow);
-    border-color: var(--accent-grow);
-    box-shadow: 0 0 12px hsla(145, 65%, 48%, 0.4);
-    transform: scale(1.2);
+  background: var(--accent-grow);
+  border-color: var(--accent-grow);
+  box-shadow: 0 0 12px hsla(145, 65%, 48%, 0.4);
+  transform: scale(1.2);
 }
 
 .timeline-step.active .step-dot::after {
-    background: hsla(145, 65%, 80%, 0.4);
+  background: hsla(145, 65%, 80%, 0.4);
 }
 
 .timeline-step.completed .step-dot {
-    background: var(--accent-grow-dark);
-    border-color: var(--accent-grow);
+  background: var(--accent-grow-dark);
+  border-color: var(--accent-grow);
 }
 
 .step-label {
-    font-size: var(--fs-xs);
-    color: var(--text-muted);
-    font-weight: 500;
-    transition: color var(--duration-normal) var(--ease-out);
-    white-space: nowrap;
+  font-size: var(--fs-xs);
+  color: var(--text-muted);
+  font-weight: 500;
+  transition: color var(--duration-normal) var(--ease-out);
+  white-space: nowrap;
 }
 
 .timeline-step.active .step-label {
-    color: var(--accent-grow-light);
-    font-weight: 700;
+  color: var(--accent-grow-light);
+  font-weight: 700;
 }
 
 .timeline-step.completed .step-label {
-    color: var(--text-secondary);
+  color: var(--text-secondary);
 }
 
 .timeline-connector {
-    width: 40px;
-    height: 3px;
-    background: hsla(225, 20%, 25%, 0.6);
-    border-radius: var(--radius-full);
-    overflow: hidden;
-    flex-shrink: 0;
-    align-self: flex-start;
-    margin-top: 7px;
+  width: 40px;
+  height: 3px;
+  background: hsla(225, 20%, 25%, 0.6);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-top: 7px;
 }
 
 .connector-fill {
-    height: 100%;
-    width: 0%;
-    background: linear-gradient(90deg, var(--accent-grow-dark), var(--accent-grow));
-    border-radius: var(--radius-full);
-    transition: width var(--duration-slow) var(--ease-out);
+  height: 100%;
+  width: 0%;
+  background: linear-gradient(
+    90deg,
+    var(--accent-grow-dark),
+    var(--accent-grow)
+  );
+  border-radius: var(--radius-full);
+  transition: width var(--duration-slow) var(--ease-out);
 }
 
 .connector-fill.filled {
-    width: 100%;
+  width: 100%;
 }
 
 /* ---------- Controls ---------- */
 .controls {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: var(--space-md);
-    flex-wrap: wrap;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: var(--space-md);
+  flex-wrap: wrap;
 }
 
 .control-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-sm);
-    padding: var(--space-md) var(--space-xl);
-    border-radius: var(--radius-xl);
-    font-size: var(--fs-md);
-    font-weight: 700;
-    font-family: var(--font-display);
-    letter-spacing: 0.01em;
-    transition: all var(--duration-fast) var(--ease-out);
-    position: relative;
-    overflow: hidden;
-    min-height: 52px;
-    min-width: 150px;
-    justify-content: center;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-xl);
+  border-radius: var(--radius-xl);
+  font-size: var(--fs-md);
+  font-weight: 700;
+  font-family: var(--font-display);
+  letter-spacing: 0.01em;
+  transition: all var(--duration-fast) var(--ease-out);
+  position: relative;
+  overflow: hidden;
+  min-height: 52px;
+  min-width: 150px;
+  justify-content: center;
 }
 
 .control-btn::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    opacity: 0;
-    transition: opacity var(--duration-fast) var(--ease-out);
-    pointer-events: none;
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity var(--duration-fast) var(--ease-out);
+  pointer-events: none;
 }
 
 .control-btn:active {
-    transform: scale(0.96);
+  transform: scale(0.96);
 }
 
 .control-btn:focus-visible {
-    outline: 2px solid var(--accent-grow);
-    outline-offset: 3px;
+  outline: 2px solid var(--accent-grow);
+  outline-offset: 3px;
 }
 
 /* Water Button */
 .water-btn {
-    background: linear-gradient(135deg, var(--accent-water-dark), var(--accent-water));
-    color: var(--text-on-accent);
-    box-shadow: 0 4px 16px hsla(200, 85%, 55%, 0.25),
-                inset 0 1px 0 hsla(200, 90%, 80%, 0.2);
+  background: linear-gradient(
+    135deg,
+    var(--accent-water-dark),
+    var(--accent-water)
+  );
+  color: var(--text-on-accent);
+  box-shadow:
+    0 4px 16px hsla(200, 85%, 55%, 0.25),
+    inset 0 1px 0 hsla(200, 90%, 80%, 0.2);
 }
 
 .water-btn:hover {
-    box-shadow: var(--shadow-glow-water),
-                inset 0 1px 0 hsla(200, 90%, 80%, 0.3);
-    transform: translateY(-2px);
-    filter: brightness(1.1);
+  box-shadow:
+    var(--shadow-glow-water),
+    inset 0 1px 0 hsla(200, 90%, 80%, 0.3);
+  transform: translateY(-2px);
+  filter: brightness(1.1);
 }
 
 .water-btn:disabled {
-    background: hsla(200, 30%, 35%, 0.4);
-    color: hsla(200, 30%, 70%, 0.5);
-    box-shadow: none;
-    cursor: not-allowed;
-    transform: none;
-    filter: none;
+  background: hsla(200, 30%, 35%, 0.4);
+  color: hsla(200, 30%, 70%, 0.5);
+  box-shadow: none;
+  cursor: not-allowed;
+  transform: none;
+  filter: none;
 }
 
 /* Sun Button */
 .sun-btn {
-    background: linear-gradient(135deg, var(--accent-sun-dark), var(--accent-sun));
-    color: hsl(30, 40%, 15%);
-    box-shadow: 0 4px 16px hsla(42, 95%, 55%, 0.25),
-                inset 0 1px 0 hsla(42, 100%, 80%, 0.25);
+  background: linear-gradient(
+    135deg,
+    var(--accent-sun-dark),
+    var(--accent-sun)
+  );
+  color: hsl(30, 40%, 15%);
+  box-shadow:
+    0 4px 16px hsla(42, 95%, 55%, 0.25),
+    inset 0 1px 0 hsla(42, 100%, 80%, 0.25);
 }
 
 .sun-btn:hover {
-    box-shadow: var(--shadow-glow-sun),
-                inset 0 1px 0 hsla(42, 100%, 80%, 0.35);
-    transform: translateY(-2px);
-    filter: brightness(1.1);
+  box-shadow:
+    var(--shadow-glow-sun),
+    inset 0 1px 0 hsla(42, 100%, 80%, 0.35);
+  transform: translateY(-2px);
+  filter: brightness(1.1);
 }
 
 .sun-btn:disabled {
-    background: hsla(42, 30%, 35%, 0.4);
-    color: hsla(42, 30%, 70%, 0.5);
-    box-shadow: none;
-    cursor: not-allowed;
-    transform: none;
-    filter: none;
+  background: hsla(42, 30%, 35%, 0.4);
+  color: hsla(42, 30%, 70%, 0.5);
+  box-shadow: none;
+  cursor: not-allowed;
+  transform: none;
+  filter: none;
 }
 
 /* Reset Button */
 .reset-btn {
-    background: var(--bg-card);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-    border: var(--glass-border);
-    color: var(--text-secondary);
-    box-shadow: var(--shadow-card);
-    padding: var(--space-md) var(--space-lg);
-    min-width: auto;
+  background: var(--bg-card);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: var(--glass-border);
+  color: var(--text-secondary);
+  box-shadow: var(--shadow-card);
+  padding: var(--space-md) var(--space-lg);
+  min-width: auto;
 }
 
 .reset-btn:hover {
-    color: var(--accent-reset-light);
-    background: var(--bg-card-hover);
-    border-color: hsla(280, 55%, 58%, 0.3);
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-card-hover);
+  color: var(--accent-reset-light);
+  background: var(--bg-card-hover);
+  border-color: hsla(280, 55%, 58%, 0.3);
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-card-hover);
 }
 
 .reset-btn .btn-icon svg {
-    transition: transform var(--duration-normal) var(--ease-out);
+  transition: transform var(--duration-normal) var(--ease-out);
 }
 
 .reset-btn:hover .btn-icon svg {
-    transform: rotate(-180deg);
+  transform: rotate(-180deg);
 }
 
 /* Button Ripple */
 .control-btn .ripple {
-    position: absolute;
-    border-radius: 50%;
-    background: hsla(0, 0%, 100%, 0.25);
-    transform: scale(0);
-    animation: rippleAnim var(--duration-slow) ease-out forwards;
-    pointer-events: none;
+  position: absolute;
+  border-radius: 50%;
+  background: hsla(0, 0%, 100%, 0.25);
+  transform: scale(0);
+  animation: rippleAnim var(--duration-slow) ease-out forwards;
+  pointer-events: none;
 }
 
 /* ---------- Info Card ---------- */
 .info-card {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--space-md);
-    padding: var(--space-lg);
-    background: var(--bg-card);
-    backdrop-filter: blur(var(--glass-blur));
-    -webkit-backdrop-filter: blur(var(--glass-blur));
-    border: var(--glass-border);
-    border-radius: var(--radius-lg);
-    box-shadow: var(--shadow-card);
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-md);
+  padding: var(--space-lg);
+  background: var(--bg-card);
+  backdrop-filter: blur(var(--glass-blur));
+  -webkit-backdrop-filter: blur(var(--glass-blur));
+  border: var(--glass-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-card);
 }
 
 .info-icon {
-    font-size: 1.3rem;
-    flex-shrink: 0;
-    margin-top: 1px;
+  font-size: 1.3rem;
+  flex-shrink: 0;
+  margin-top: 1px;
 }
 
 .info-text {
-    font-size: var(--fs-sm);
-    color: var(--text-secondary);
-    line-height: 1.7;
+  font-size: var(--fs-sm);
+  color: var(--text-secondary);
+  line-height: 1.7;
 }
 
 .info-text strong {
-    color: var(--text-primary);
-    font-weight: 600;
+  color: var(--text-primary);
+  font-weight: 600;
 }
 
 /* ---------- Celebration Overlay ---------- */
 .celebration-overlay {
-    position: fixed;
-    inset: 0;
-    z-index: 200;
-    pointer-events: none;
-    opacity: 0;
-    transition: opacity 0.5s ease;
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.5s ease;
 }
 
 .celebration-overlay.active {
-    opacity: 1;
+  opacity: 1;
 }
 
 .confetti-piece {
-    position: absolute;
-    width: 10px;
-    height: 10px;
-    border-radius: 2px;
-    animation: confettiFall linear forwards;
-    opacity: 0.9;
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  animation: confettiFall linear forwards;
+  opacity: 0.9;
 }
 
 /* ---------- Animations ---------- */
 @keyframes fadeSlideUp {
-    from {
-        opacity: 0;
-        transform: translateY(24px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes fadeSlideDown {
-    from {
-        opacity: 0;
-        transform: translateY(-16px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateY(-16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes plantGrow {
-    0% {
-        transform: scale(0.7);
-        opacity: 0.3;
-        filter: drop-shadow(0 8px 24px hsla(0, 0%, 0%, 0.5)) blur(4px);
-    }
-    50% {
-        transform: scale(1.08);
-        filter: drop-shadow(0 8px 24px hsla(0, 0%, 0%, 0.5)) blur(0px);
-    }
-    100% {
-        transform: scale(1);
-        opacity: 1;
-        filter: drop-shadow(0 8px 24px hsla(0, 0%, 0%, 0.5)) blur(0px);
-    }
+  0% {
+    transform: scale(0.7);
+    opacity: 0.3;
+    filter: drop-shadow(0 8px 24px hsla(0, 0%, 0%, 0.5)) blur(4px);
+  }
+  50% {
+    transform: scale(1.08);
+    filter: drop-shadow(0 8px 24px hsla(0, 0%, 0%, 0.5)) blur(0px);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+    filter: drop-shadow(0 8px 24px hsla(0, 0%, 0%, 0.5)) blur(0px);
+  }
 }
 
 @keyframes pulseGlow {
-    0%, 100% {
-        opacity: 0.5;
-        transform: translate(-50%, -55%) scale(1);
-    }
-    50% {
-        opacity: 1;
-        transform: translate(-50%, -55%) scale(1.15);
-    }
+  0%,
+  100% {
+    opacity: 0.5;
+    transform: translate(-50%, -55%) scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: translate(-50%, -55%) scale(1.15);
+  }
 }
 
 @keyframes rippleAnim {
-    to {
-        transform: scale(4);
-        opacity: 0;
-    }
+  to {
+    transform: scale(4);
+    opacity: 0;
+  }
 }
 
 @keyframes confettiFall {
-    0% {
-        transform: translateY(-20vh) rotate(0deg);
-        opacity: 1;
-    }
-    100% {
-        transform: translateY(110vh) rotate(720deg);
-        opacity: 0;
-    }
+  0% {
+    transform: translateY(-20vh) rotate(0deg);
+    opacity: 1;
+  }
+  100% {
+    transform: translateY(110vh) rotate(720deg);
+    opacity: 0;
+  }
 }
 
 @keyframes celebrationPulse {
-    0% { box-shadow: var(--shadow-glow-grow); }
-    50% { box-shadow: var(--shadow-glow-celebration); }
-    100% { box-shadow: var(--shadow-glow-grow); }
+  0% {
+    box-shadow: var(--shadow-glow-grow);
+  }
+  50% {
+    box-shadow: var(--shadow-glow-celebration);
+  }
+  100% {
+    box-shadow: var(--shadow-glow-grow);
+  }
 }
 
 @keyframes bounceIn {
-    0% {
-        transform: scale(0.3);
-        opacity: 0;
-    }
-    50% {
-        transform: scale(1.08);
-    }
-    70% {
-        transform: scale(0.95);
-    }
-    100% {
-        transform: scale(1);
-        opacity: 1;
-    }
+  0% {
+    transform: scale(0.3);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(1.08);
+  }
+  70% {
+    transform: scale(0.95);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 /* Plant glow color per stage */
-.plant-stage[data-stage="0"] .plant-glow {
-    background: radial-gradient(circle, hsla(30, 40%, 40%, 0.1) 0%, transparent 70%);
+.plant-stage[data-stage='0'] .plant-glow {
+  background: radial-gradient(
+    circle,
+    hsla(30, 40%, 40%, 0.1) 0%,
+    transparent 70%
+  );
 }
-.plant-stage[data-stage="1"] .plant-glow {
-    background: radial-gradient(circle, hsla(120, 50%, 40%, 0.12) 0%, transparent 70%);
+.plant-stage[data-stage='1'] .plant-glow {
+  background: radial-gradient(
+    circle,
+    hsla(120, 50%, 40%, 0.12) 0%,
+    transparent 70%
+  );
 }
-.plant-stage[data-stage="2"] .plant-glow {
-    background: radial-gradient(circle, hsla(140, 60%, 45%, 0.15) 0%, transparent 70%);
+.plant-stage[data-stage='2'] .plant-glow {
+  background: radial-gradient(
+    circle,
+    hsla(140, 60%, 45%, 0.15) 0%,
+    transparent 70%
+  );
 }
-.plant-stage[data-stage="3"] .plant-glow {
-    background: radial-gradient(circle, hsla(330, 60%, 55%, 0.15) 0%, transparent 70%);
+.plant-stage[data-stage='3'] .plant-glow {
+  background: radial-gradient(
+    circle,
+    hsla(330, 60%, 55%, 0.15) 0%,
+    transparent 70%
+  );
 }
-.plant-stage[data-stage="4"] .plant-glow {
-    background: radial-gradient(circle, hsla(145, 65%, 48%, 0.2) 0%, transparent 70%);
-    width: 320px;
-    height: 320px;
+.plant-stage[data-stage='4'] .plant-glow {
+  background: radial-gradient(
+    circle,
+    hsla(145, 65%, 48%, 0.2) 0%,
+    transparent 70%
+  );
+  width: 320px;
+  height: 320px;
 }
 
 /* Completion state */
 .plant-stage.completed .plant-image {
-    filter: drop-shadow(0 8px 24px hsla(0, 0%, 0%, 0.5)) drop-shadow(0 0 20px hsla(48, 100%, 60%, 0.3));
+  filter: drop-shadow(0 8px 24px hsla(0, 0%, 0%, 0.5))
+    drop-shadow(0 0 20px hsla(48, 100%, 60%, 0.3));
 }
 
 .plant-stage.completed .plant-glow {
-    animation: pulseGlow 2s ease-in-out infinite;
+  animation: pulseGlow 2s ease-in-out infinite;
+}
+
+.plant-image.fallback {
+  opacity: 0.8;
+  object-fit: contain;
 }
 
 /* ---------- Responsive: Tablet ---------- */
 @media (max-width: 768px) {
-    body {
-        padding: var(--space-md) var(--space-sm);
-        padding-top: calc(var(--space-2xl) + 10px);
-    }
+  body {
+    padding: var(--space-md) var(--space-sm);
+    padding-top: calc(var(--space-2xl) + 10px);
+  }
 
-    .dashboard {
-        grid-template-columns: 1fr 1fr;
-        gap: var(--space-sm);
-    }
+  .dashboard {
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-sm);
+  }
 
-    .stage-metric-card {
-        grid-column: 1 / -1;
-        flex-direction: row;
-    }
+  .stage-metric-card {
+    grid-column: 1 / -1;
+    flex-direction: row;
+  }
 
-    .stage-metric-card .metric-info {
-        align-items: flex-start;
-    }
+  .stage-metric-card .metric-info {
+    align-items: flex-start;
+  }
 
-    .metric-card {
-        padding: var(--space-md);
-    }
+  .metric-card {
+    padding: var(--space-md);
+  }
 
-    .metric-icon-wrap {
-        width: 40px;
-        height: 40px;
-        font-size: 1.2rem;
-    }
+  .metric-icon-wrap {
+    width: 40px;
+    height: 40px;
+    font-size: 1.2rem;
+  }
 
-    .plant-image {
-        max-width: 170px;
-        max-height: 170px;
-    }
+  .plant-image {
+    max-width: 170px;
+    max-height: 170px;
+  }
 
-    .plant-image-container {
-        width: 180px;
-        height: 180px;
-    }
+  .plant-image-container {
+    width: 180px;
+    height: 180px;
+  }
 
-    .timeline-connector {
-        width: 24px;
-    }
+  .timeline-connector {
+    width: 24px;
+  }
 
-    .control-btn {
-        padding: var(--space-md) var(--space-lg);
-        font-size: var(--fs-base);
-        min-width: 130px;
-    }
+  .control-btn {
+    padding: var(--space-md) var(--space-lg);
+    font-size: var(--fs-base);
+    min-width: 130px;
+  }
 
-    .controls {
-        gap: var(--space-sm);
-    }
+  .controls {
+    gap: var(--space-sm);
+  }
 }
 
 /* ---------- Responsive: Mobile ---------- */
 @media (max-width: 480px) {
-    body {
-        padding: var(--space-sm);
-        padding-top: calc(var(--space-xl) + 16px);
-    }
+  body {
+    padding: var(--space-sm);
+    padding-top: calc(var(--space-xl) + 16px);
+  }
 
-    .back-button {
-        top: var(--space-sm);
-        left: var(--space-sm);
-        padding: var(--space-xs) var(--space-sm);
-        font-size: var(--fs-xs);
-    }
+  .back-button {
+    top: var(--space-sm);
+    left: var(--space-sm);
+    padding: var(--space-xs) var(--space-sm);
+    font-size: var(--fs-xs);
+  }
 
-    .page-header {
-        margin-bottom: var(--space-lg);
-    }
+  .page-header {
+    margin-bottom: var(--space-lg);
+  }
 
-    .page-header h1 {
-        flex-direction: column;
-        gap: var(--space-xs);
-    }
+  .page-header h1 {
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
 
-    main {
-        gap: var(--space-lg);
-    }
+  main {
+    gap: var(--space-lg);
+  }
 
-    .dashboard {
-        grid-template-columns: 1fr;
-    }
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
 
-    .stage-metric-card {
-        grid-column: auto;
-    }
+  .stage-metric-card {
+    grid-column: auto;
+  }
 
-    .metric-card {
-        padding: var(--space-md);
-    }
+  .metric-card {
+    padding: var(--space-md);
+  }
 
-    .plant-image {
-        max-width: 140px;
-        max-height: 140px;
-    }
+  .plant-image {
+    max-width: 140px;
+    max-height: 140px;
+  }
 
-    .plant-image-container {
-        width: 150px;
-        height: 150px;
-    }
+  .plant-image-container {
+    width: 150px;
+    height: 150px;
+  }
 
-    .plant-glow {
-        width: 180px;
-        height: 180px;
-    }
+  .plant-glow {
+    width: 180px;
+    height: 180px;
+  }
 
-    .plant-stage {
-        padding: var(--space-md) 0;
-    }
+  .plant-stage {
+    padding: var(--space-md) 0;
+  }
 
-    /* Timeline scrolls horizontally on very small screens */
-    .progress-timeline {
-        overflow-x: auto;
-        -webkit-overflow-scrolling: touch;
-        padding: var(--space-sm);
-        margin: 0 calc(-1 * var(--space-sm));
-    }
+  /* Timeline scrolls horizontally on very small screens */
+  .progress-timeline {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: var(--space-sm);
+    margin: 0 calc(-1 * var(--space-sm));
+  }
 
-    .timeline-list {
-        min-width: max-content;
-        padding: 0 var(--space-sm);
-    }
+  .timeline-list {
+    min-width: max-content;
+    padding: 0 var(--space-sm);
+  }
 
-    .timeline-connector {
-        width: 16px;
-    }
+  .timeline-connector {
+    width: 16px;
+  }
 
-    .step-label {
-        font-size: 0.65rem;
-    }
+  .step-label {
+    font-size: 0.65rem;
+  }
 
-    .controls {
-        flex-direction: column;
-        gap: var(--space-sm);
-    }
+  .controls {
+    flex-direction: column;
+    gap: var(--space-sm);
+  }
 
-    .control-btn {
-        width: 100%;
-        min-width: auto;
-        justify-content: center;
-    }
+  .control-btn {
+    width: 100%;
+    min-width: auto;
+    justify-content: center;
+  }
 
-    .controls .reset-btn {
-        order: 3;
-    }
+  .controls .reset-btn {
+    order: 3;
+  }
 
-    .info-card {
-        padding: var(--space-md);
-    }
+  .info-card {
+    padding: var(--space-md);
+  }
 
-    .stage-description {
-        font-size: var(--fs-xs);
-    }
+  .stage-description {
+    font-size: var(--fs-xs);
+  }
 }
 
 /* ---------- Large Desktop ---------- */
 @media (min-width: 1200px) {
-    main {
-        max-width: 860px;
-    }
+  main {
+    max-width: 860px;
+  }
 
-    .plant-image {
-        max-width: 240px;
-        max-height: 240px;
-    }
+  .plant-image {
+    max-width: 240px;
+    max-height: 240px;
+  }
 
-    .plant-image-container {
-        width: 260px;
-        height: 260px;
-    }
+  .plant-image-container {
+    width: 260px;
+    height: 260px;
+  }
 
-    .plant-glow {
-        width: 320px;
-        height: 320px;
-    }
+  .plant-glow {
+    width: 320px;
+    height: 320px;
+  }
 
-    .timeline-connector {
-        width: 56px;
-    }
+  .timeline-connector {
+    width: 56px;
+  }
 }
 
 /* ---------- Accessibility ---------- */
 @media (prefers-reduced-motion: reduce) {
-    *,
-    *::before,
-    *::after {
-        animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
-        transition-duration: 0.01ms !important;
-    }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
 
-    .plant-glow {
-        display: none;
-    }
+  .plant-glow {
+    display: none;
+  }
 
-    .celebration-overlay {
-        display: none;
-    }
+  .celebration-overlay {
+    display: none;
+  }
 }
 
 /* High contrast - ensure readability */
 @media (prefers-contrast: high) {
-    :root {
-        --bg-card: hsla(225, 30%, 14%, 0.9);
-        --bg-card-border: hsla(225, 40%, 50%, 0.5);
-        --text-secondary: hsl(220, 15%, 75%);
-        --text-muted: hsl(220, 12%, 60%);
-    }
+  :root {
+    --bg-card: hsla(225, 30%, 14%, 0.9);
+    --bg-card-border: hsla(225, 40%, 50%, 0.5);
+    --text-secondary: hsl(220, 15%, 75%);
+    --text-muted: hsl(220, 12%, 60%);
+  }
 
-    .meter {
-        border: 1px solid var(--text-muted);
-    }
+  .meter {
+    border: 1px solid var(--text-muted);
+  }
 }
 
 /* Focus visible for keyboard users */
 *:focus-visible {
-    outline: 2px solid var(--accent-grow);
-    outline-offset: 2px;
+  outline: 2px solid var(--accent-grow);
+  outline-offset: 2px;
 }
 
 /* Visually hidden utility (screen-reader only) */
 .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border-width: 0;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
 }


### PR DESCRIPTION
## Related Issue

Fixes #9825

## Description

This PR adds graceful handling for missing plant stage images.

### Changes Made

- Added a fallback placeholder image for missing assets.
- Added an `error` handler to the plant image.
- Prevented infinite error loops.
- Logged missing image warnings in the browser console.
- Preserved the growth simulation even when image files are unavailable.

### Before

- Missing or renamed stage images displayed a broken image icon.

### After

- Missing images automatically display a placeholder image.
- The simulation continues functioning normally.
- Developers receive a console warning identifying the missing asset.

## Testing

- ✅ Renamed `images/flowering.png`
- ✅ Placeholder image displayed correctly
- ✅ No broken image icon appeared
- ✅ Simulation continued through all stages