### PR TITLE
fix: reset streak on app load after missed days

### DIFF
--- a/public/Productivity-Dashboard/script.js
+++ b/public/Productivity-Dashboard/script.js
@@ -215,6 +215,7 @@ if (
 
 updateDarkButton();
 
+
 function render() {
 
     renderList("today");
@@ -222,6 +223,18 @@ function render() {
 
     updateTracker();
     loadNotes();
+}
+
+
+if(data.lastCompletedDate){
+    const today = new Date().toDateString();
+    const last = new Date(data.lastCompletedDate);
+    const diff = Math.floor((new Date(today) - last) / (1000 * 60 * 60 * 24));
+
+    if(diff > 1){
+        data.streak = 0;
+        saveData();
+    }
 }
 
 render();


### PR DESCRIPTION
## 📝 Pull Request Description
### Related Issue
Closes #9897

### Summary
The streak counter was not resetting when the app was reopened after missing one or more days. Added a check on app load that compares today's date with the last completed date and resets the streak to 0 if more than 1 day has passed.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---
## 🛠️ Changes Made
- Added a date gap check in `public/Productivity-Dashboard/script.js` before `render()` that resets `data.streak` to 0 if more than 1 day has passed since `lastCompletedDate`

---
## 🧪 Testing and Verification
### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---
## 📷 Screenshots / Video Recording
No visual changes — logic-only fix.

---
## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.