### PR TITLE
refactor: add explicit button types to calculator controls

### DIFF
--- a/public/simple_calculator/index.html
+++ b/public/simple_calculator/index.html
@@ -25,28 +25,28 @@
 
   <div class="buttons">
 
-    <button onclick="clearAll()" class="op">AC</button>
-    <button onclick="append('/')">÷</button>
-    <button onclick="append('*')">×</button>
-    <button onclick="deleteLast()">⌫</button>
+    <button type="button" onclick="clearAll()" class="op">AC</button>
+    <button type="button" onclick="append('/')">÷</button>
+    <button type="button" onclick="append('*')">×</button>
+    <button type="button" onclick="deleteLast()">⌫</button>
 
-    <button onclick="append('7')">7</button>
-    <button onclick="append('8')">8</button>
-    <button onclick="append('9')">9</button>
-    <button onclick="append('-')" class="op">−</button>
+    <button type="button" onclick="append('7')">7</button>
+    <button type="button" onclick="append('8')">8</button>
+    <button type="button" onclick="append('9')">9</button>
+    <button type="button" onclick="append('-')" class="op">−</button>
 
-    <button onclick="append('4')">4</button>
-    <button onclick="append('5')">5</button>
-    <button onclick="append('6')">6</button>
-    <button onclick="append('+')" class="op">+</button>
+    <button type="button" onclick="append('4')">4</button>
+    <button type="button" onclick="append('5')">5</button>
+    <button type="button" onclick="append('6')">6</button>
+    <button type="button" onclick="append('+')" class="op">+</button>
 
-    <button onclick="append('1')">1</button>
-    <button onclick="append('2')">2</button>
-    <button onclick="append('3')">3</button>
-    <button onclick="calculate()" class="eq">=</button>
+    <button type="button" onclick="append('1')">1</button>
+    <button type="button" onclick="append('2')">2</button>
+    <button type="button" onclick="append('3')">3</button>
+    <button type="button" onclick="calculate()" class="eq">=</button>
 
-    <button class="zero" onclick="append('0')">0</button>
-    <button onclick="append('.')">.</button>
+    <button type="button" class="zero" onclick="append('0')">0</button>
+    <button type="button" onclick="append('.')">.</button>
 
   </div>
 


### PR DESCRIPTION
## 📝 Description

### Related Issue

Closes #9919

### Summary

Refactored the Glass Calculator HTML by explicitly defining `type="button"` for all calculator controls. This improves HTML semantics, prevents unintended form submissions if the component is reused inside forms, and aligns the project with HTML best practices without affecting functionality.

### Type of Change

* [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New project addition
* [ ] 🚀 New feature or UI/UX enhancement
* [x] ♻️ Code refactoring / clean-up
* [ ] 📝 Documentation update
* [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made

* Added `type="button"` to every calculator button.
* Improved HTML semantics and maintainability.
* Prevented potential unintended form submission behavior when the component is embedded inside a form.
* Kept existing calculator functionality unchanged.

---

## 🧪 Testing and Verification

### Local Validation

* [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check

* [x] Tested and verified in **Google Chrome**
* [ ] Tested and verified in **Mozilla Firefox**
* [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks

* [x] Verified responsive layout on Mobile viewports (using DevTools)
* [x] Verified responsive layout on Tablet viewports
* [x] Keyboard navigation and focus outlines checked
* [x] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording

No visual changes. This PR only improves HTML semantics and maintainability.

---

## 🤝 Contributor Checklist

* [x] My code follows the code style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have updated the documentation / README files accordingly.
* [x] My changes generate no new warnings or console errors.
* [x] There are no unrelated changes or formatter noise in this PR.
