### PR TITLE
Fix duplicate Quick Actions on Patient Dashboard (#9924)

### DIFF
--- a/public/Medical_App/index.html
+++ b/public/Medical_App/index.html
@@ -524,17 +524,7 @@
                         <div id="healthTip" class="health-tip-content"><p>Loading health tip...</p></div>
                     </section>
 
-                    <section class="card">
-                        <div class="card-header">
-                            <div class="card-icon primary"><i class="ph ph-lightning-bolt"></i></div>
-                            <h2>Quick Actions</h2>
-                        </div>
-                        <div class="quick-actions">
-                            <a href="feedback.html" class="quick-action-btn"><i class="ph ph-chat-circle-text"></i><span>Give Feedback</span></a>
-                            <button class="quick-action-btn"><i class="ph ph-download"></i><span>Download Records</span></button>
-                            <button class="quick-action-btn"><i class="ph ph-calendar"></i><span>Reschedule</span></button>
-                        </div>
-                    </section>
+
 
 
 


### PR DESCRIPTION
Fix: Removed duplicate "Quick Actions" from Patient Dashboard
Closes #9924

Description:
The "Quick Actions" section was mistakenly displayed twice on the Patient Dashboard—once in the main content area and again in the right sidebar. Both sections contained identical actions (Give Feedback, Download Records, Reschedule), which caused unnecessary duplication.

Changes Made:
- Removed the redundant "Quick Actions" card from the right sidebar column (`public/Medical_App/index.html`).
- The primary "Quick Actions" section remains securely in the center main content area to keep the interface clean and concise.


## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
