### PR TITLE
feature/Add custom bet input chip and win/loss history tracking to Bl…

### DIFF
--- a/public/BlackJack/blackJ.css
+++ b/public/BlackJack/blackJ.css
@@ -1,59 +1,277 @@
 /* =============================================================
    BlackJack — Stylesheet
-   Theme  : Casino dark-green felt
+   Themes : 10 themes via data-theme attribute on <html>
    Fonts  : Playfair Display (headings) + Inter (UI)
    Layout : Mobile-first, single-column → desktop side-by-side
    ============================================================= */
 
-/* ── Design Tokens ─────────────────────────────────────────── */
-:root {
-  --felt:          #1a5c38;
-  --felt-dark:     #0f3d25;
-  --felt-border:   #2d7a50;
-  --gold:          #d4af37;
-  --gold-light:    #f0d060;
-  --card-bg:       #fdfaf3;
-  --bg:            #0b2819;
-  --surface:       #122e1e;
-  --text-primary:  #f5f0e8;
-  --text-muted:    #a8c4b0;
-  --win-green:     #4caf7d;
-  --loss-red:      #e05252;
-  --draw-amber:    #f0b429;
-
-  /* Chip colours */
+/* ── Design Tokens — Classic (default) ──────────────────────── */
+:root,
+[data-theme="classic"] {
+  --felt:         #1a5c38;
+  --felt-dark:    #0f3d25;
+  --felt-border:  #2d7a50;
+  --gold:         #d4af37;
+  --gold-light:   #f0d060;
+  --card-bg:      #fdfaf3;
+  --bg:           #0b2819;
+  --surface:      #122e1e;
+  --text-primary: #f5f0e8;
+  --text-muted:   #a8c4b0;
+  --win-green:    #4caf7d;
+  --loss-red:     #e05252;
+  --draw-amber:   #f0b429;
   --chip-5:   #e24b4a;
   --chip-10:  #378add;
   --chip-25:  #1d9e75;
   --chip-50:  #ba7517;
   --chip-100: #7f77dd;
+  --chip-custom: #c83daf;
+  --body-gradient: radial-gradient(ellipse at 50% 0%, rgba(26,92,56,0.45) 0%, transparent 60%);
+}
 
+/* ── Theme: Dark Mode ────────────────────────────────────────── */
+[data-theme="dark"] {
+  --felt:         #1e1e2e;
+  --felt-dark:    #111120;
+  --felt-border:  #3b3b5c;
+  --gold:         #c9b8ff;
+  --gold-light:   #e2d9ff;
+  --card-bg:      #f8f8ff;
+  --bg:           #0a0a14;
+  --surface:      #14141f;
+  --text-primary: #e8e8f8;
+  --text-muted:   #9090b8;
+  --win-green:    #50fa7b;
+  --loss-red:     #ff5555;
+  --draw-amber:   #ffb86c;
+  --chip-5:   #ff5555;
+  --chip-10:  #8be9fd;
+  --chip-25:  #50fa7b;
+  --chip-50:  #ffb86c;
+  --chip-100: #bd93f9;
+  --chip-custom: #ff79c6;
+  --body-gradient: radial-gradient(ellipse at 50% 0%, rgba(30,30,46,0.6) 0%, transparent 60%);
+}
+
+/* ── Theme: Neon ─────────────────────────────────────────────── */
+[data-theme="neon"] {
+  --felt:         #0d0d0d;
+  --felt-dark:    #050505;
+  --felt-border:  #00ff88;
+  --gold:         #00ffcc;
+  --gold-light:   #80ffdd;
+  --card-bg:      #f0fff8;
+  --bg:           #030303;
+  --surface:      #0a0a0a;
+  --text-primary: #e0ffe8;
+  --text-muted:   #44ff88;
+  --win-green:    #00ff88;
+  --loss-red:     #ff0066;
+  --draw-amber:   #ffff00;
+  --chip-5:   #ff0066;
+  --chip-10:  #00ccff;
+  --chip-25:  #00ff88;
+  --chip-50:  #ffcc00;
+  --chip-100: #cc00ff;
+  --chip-custom: #ff6600;
+  --body-gradient: radial-gradient(ellipse at 50% 0%, rgba(0,255,136,0.12) 0%, transparent 60%);
+}
+
+/* ── Theme: Red Velvet ───────────────────────────────────────── */
+[data-theme="velvet"] {
+  --felt:         #5a0a0a;
+  --felt-dark:    #3a0505;
+  --felt-border:  #8b1a1a;
+  --gold:         #ffc966;
+  --gold-light:   #ffe099;
+  --card-bg:      #fff8f3;
+  --bg:           #220000;
+  --surface:      #300505;
+  --text-primary: #fff0e8;
+  --text-muted:   #cc9988;
+  --win-green:    #66dd88;
+  --loss-red:     #ff4444;
+  --draw-amber:   #ffa040;
+  --chip-5:   #ff6644;
+  --chip-10:  #4488ff;
+  --chip-25:  #44cc77;
+  --chip-50:  #ffaa33;
+  --chip-100: #cc88ff;
+  --chip-custom: #ff44aa;
+  --body-gradient: radial-gradient(ellipse at 50% 0%, rgba(90,10,10,0.55) 0%, transparent 60%);
+}
+
+/* ── Theme: Blue Casino ──────────────────────────────────────── */
+[data-theme="blue"] {
+  --felt:         #0a2a5a;
+  --felt-dark:    #051535;
+  --felt-border:  #1a4a8b;
+  --gold:         #66aaff;
+  --gold-light:   #99ccff;
+  --card-bg:      #f3f8ff;
+  --bg:           #030a1a;
+  --surface:      #081428;
+  --text-primary: #e8f0ff;
+  --text-muted:   #6688cc;
+  --win-green:    #44ddaa;
+  --loss-red:     #ff5566;
+  --draw-amber:   #ffcc44;
+  --chip-5:   #ff5566;
+  --chip-10:  #44aaff;
+  --chip-25:  #44ddaa;
+  --chip-50:  #ffaa33;
+  --chip-100: #aa66ff;
+  --chip-custom: #ff66cc;
+  --body-gradient: radial-gradient(ellipse at 50% 0%, rgba(10,42,90,0.55) 0%, transparent 60%);
+}
+
+/* ── Theme: Midnight ─────────────────────────────────────────── */
+[data-theme="midnight"] {
+  --felt:         #1a1a2e;
+  --felt-dark:    #0d0d1a;
+  --felt-border:  #4a3f6b;
+  --gold:         #e0aaff;
+  --gold-light:   #f0ccff;
+  --card-bg:      #f8f0ff;
+  --bg:           #080812;
+  --surface:      #100e1e;
+  --text-primary: #f0e8ff;
+  --text-muted:   #8877aa;
+  --win-green:    #77ddbb;
+  --loss-red:     #ff6677;
+  --draw-amber:   #ffcc77;
+  --chip-5:   #ff6677;
+  --chip-10:  #88ccff;
+  --chip-25:  #77ddbb;
+  --chip-50:  #ffcc77;
+  --chip-100: #cc99ff;
+  --chip-custom: #ff99cc;
+  --body-gradient: radial-gradient(ellipse at 50% 0%, rgba(26,26,46,0.6) 0%, transparent 60%);
+}
+
+/* ── Theme: Pastel ───────────────────────────────────────────── */
+[data-theme="pastel"] {
+  --felt:         #d4eac8;
+  --felt-dark:    #b8d4aa;
+  --felt-border:  #88bb77;
+  --gold:         #b06090;
+  --gold-light:   #cc88aa;
+  --card-bg:      #fffdf8;
+  --bg:           #f0f7ee;
+  --surface:      #e8f5e2;
+  --text-primary: #334433;
+  --text-muted:   #779966;
+  --win-green:    #448855;
+  --loss-red:     #cc4455;
+  --draw-amber:   #bb8833;
+  --chip-5:   #e06070;
+  --chip-10:  #5588cc;
+  --chip-25:  #448855;
+  --chip-50:  #cc8833;
+  --chip-100: #8855cc;
+  --chip-custom: #aa4499;
+  --body-gradient: radial-gradient(ellipse at 50% 0%, rgba(200,230,190,0.4) 0%, transparent 60%);
+}
+
+/* ── Theme: High Contrast ────────────────────────────────────── */
+[data-theme="hc"] {
+  --felt:         #000000;
+  --felt-dark:    #000000;
+  --felt-border:  #ffffff;
+  --gold:         #ffff00;
+  --gold-light:   #ffff66;
+  --card-bg:      #ffffff;
+  --bg:           #000000;
+  --surface:      #111111;
+  --text-primary: #ffffff;
+  --text-muted:   #cccccc;
+  --win-green:    #00ff00;
+  --loss-red:     #ff0000;
+  --draw-amber:   #ffff00;
+  --chip-5:   #ff0000;
+  --chip-10:  #00ffff;
+  --chip-25:  #00ff00;
+  --chip-50:  #ffff00;
+  --chip-100: #ff00ff;
+  --chip-custom: #ff8800;
+  --body-gradient: none;
+}
+
+/* ── Theme: Gold Luxury ──────────────────────────────────────── */
+[data-theme="gold"] {
+  --felt:         #2a1a00;
+  --felt-dark:    #1a0f00;
+  --felt-border:  #8a6a10;
+  --gold:         #ffcc00;
+  --gold-light:   #ffe566;
+  --card-bg:      #fffcf0;
+  --bg:           #0f0800;
+  --surface:      #1a1000;
+  --text-primary: #fff8e0;
+  --text-muted:   #aa8833;
+  --win-green:    #88dd55;
+  --loss-red:     #ff5533;
+  --draw-amber:   #ffaa00;
+  --chip-5:   #ff5533;
+  --chip-10:  #33aaff;
+  --chip-25:  #88dd55;
+  --chip-50:  #ffaa00;
+  --chip-100: #cc77ff;
+  --chip-custom: #ff66aa;
+  --body-gradient: radial-gradient(ellipse at 50% 0%, rgba(42,26,0,0.7) 0%, transparent 60%);
+}
+
+/* ── Theme: Retro ────────────────────────────────────────────── */
+[data-theme="retro"] {
+  --felt:         #2d4a1e;
+  --felt-dark:    #1a2e10;
+  --felt-border:  #5a8a3a;
+  --gold:         #ffdd44;
+  --gold-light:   #ffee88;
+  --card-bg:      #fef9e7;
+  --bg:           #0e1a08;
+  --surface:      #162210;
+  --text-primary: #f5f0c0;
+  --text-muted:   #8aaa66;
+  --win-green:    #55cc44;
+  --loss-red:     #dd4444;
+  --draw-amber:   #ddaa22;
+  --chip-5:   #cc3333;
+  --chip-10:  #3366cc;
+  --chip-25:  #33aa44;
+  --chip-50:  #cc8822;
+  --chip-100: #8855bb;
+  --chip-custom: #cc4488;
+  --body-gradient: radial-gradient(ellipse at 50% 0%, rgba(45,74,30,0.5) 0%, transparent 60%);
+}
+
+/* ── Common variables (theme-invariant) ─────────────────────── */
+:root {
   --radius-sm: 0.4rem;
   --radius-md: 0.75rem;
   --radius-lg: 1.25rem;
   --radius-xl: 2rem;
-
   --shadow-card: 0 4px 16px rgba(0,0,0,0.55);
   --shadow-btn:  0 2px 8px rgba(0,0,0,0.4);
   --transition:  200ms cubic-bezier(0.16,1,0.3,1);
-
   --font-display: 'Playfair Display', Georgia, serif;
   --font-ui:      'Inter', system-ui, sans-serif;
 }
 
-/* ── Reset & Base ───────────────────────────────────────────── */
+/* ── Reset & Base ────────────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
-
 html { font-size: 16px; scroll-behavior: smooth; -webkit-font-smoothing: antialiased; }
 
 body {
   min-height: 100dvh;
   background-color: var(--bg);
-  background-image: radial-gradient(ellipse at 50% 0%, rgba(26,92,56,0.45) 0%, transparent 60%);
+  background-image: var(--body-gradient);
   color: var(--text-primary);
   font-family: var(--font-ui);
   font-size: 1rem;
   line-height: 1.5;
+  transition: background-color 0.4s ease, color 0.3s ease;
 }
 
 ul { list-style: none; padding: 0; }
@@ -65,13 +283,12 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   border-radius: var(--radius-sm);
 }
 
-/* Screen-reader only utility */
 .sr-only {
   position: absolute; width: 1px; height: 1px;
   overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap;
 }
 
-/* ── Back Button ─────────────────────────────────────────────── */
+/* ── Back Button ──────────────────────────────────────────────── */
 .back-btn {
   position: fixed; top: 1rem; left: 1rem; z-index: 100;
   padding: 8px 16px;
@@ -83,11 +300,110 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
 }
 .back-btn:hover { background: #3b82f6; color: #fff; }
 
-/* ── Site Header ─────────────────────────────────────────────── */
+/* ── Theme Switcher (inside site-header, right-aligned in strip) ── */
+.theme-switcher {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;    /* push button to the right corner */
+  padding: 1rem 1.5rem 1rem 0; /* right padding aligns with header content */
+  margin-top: 0.75rem;
+  border-top: 1px solid rgba(212,175,55,0.15);
+}
+
+/* Wrapper that acts as the positioning context for the panel */
+.theme-btn-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.theme-toggle-btn {
+  display: flex; align-items: center; gap: 6px;
+  padding: 8px 14px;
+  background: var(--surface);
+  border: 1.5px solid var(--gold);
+  border-radius: var(--radius-md);
+  color: var(--gold);
+  font-size: 0.85rem; font-weight: 600;
+  font-family: var(--font-ui);
+  transition: background var(--transition), color var(--transition);
+}
+.theme-toggle-btn:hover { background: var(--felt); }
+.theme-toggle-btn i { font-size: 1.1rem; }
+
+.theme-panel {
+  position: fixed;              /* viewport-relative — bypasses ALL parent clipping */
+  /* top / right set dynamically by JS via getBoundingClientRect */
+  width: min(320px, calc(100vw - 2rem));
+  max-height: 75vh;
+  overflow-y: auto;
+  background: rgba(10,10,20,0.96);
+  border: 1.5px solid var(--gold);
+  border-radius: var(--radius-lg);
+  padding: 1rem;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.7);
+  animation: fadeSlideIn 0.22s ease;
+  z-index: 9999;
+}
+.theme-panel[hidden] { display: none; }
+
+.theme-panel-title {
+  font-family: var(--font-display);
+  color: var(--gold); font-size: 1rem;
+  letter-spacing: 0.05em; text-align: center;
+  margin-bottom: 0.75rem;
+}
+
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
+  overflow: hidden;
+}
+
+.theme-swatch {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  padding: 6px 4px;
+  border-radius: var(--radius-sm);
+  border: 1.5px solid transparent;
+  transition: border-color var(--transition), background var(--transition);
+  cursor: pointer;
+}
+.theme-swatch:hover      { background: rgba(255,255,255,0.08); border-color: rgba(255,255,255,0.2); }
+.theme-swatch--active    { border-color: var(--gold) !important; background: rgba(255,255,255,0.1); }
+
+.swatch-preview {
+  width: 30px; height: 30px;
+  border-radius: 50%;
+  border: 2px solid rgba(255,255,255,0.2);
+  display: block; flex-shrink: 0;
+}
+.swatch-classic  { background: linear-gradient(135deg, #1a5c38 50%, #d4af37 50%); }
+.swatch-dark     { background: linear-gradient(135deg, #1e1e2e 50%, #c9b8ff 50%); }
+.swatch-neon     { background: linear-gradient(135deg, #030303 50%, #00ff88 50%); }
+.swatch-velvet   { background: linear-gradient(135deg, #5a0a0a 50%, #ffc966 50%); }
+.swatch-blue     { background: linear-gradient(135deg, #0a2a5a 50%, #66aaff 50%); }
+.swatch-midnight { background: linear-gradient(135deg, #1a1a2e 50%, #e0aaff 50%); }
+.swatch-pastel   { background: linear-gradient(135deg, #d4eac8 50%, #b06090 50%); }
+.swatch-hc       { background: linear-gradient(135deg, #000 50%, #ffff00 50%); }
+.swatch-gold     { background: linear-gradient(135deg, #2a1a00 50%, #ffcc00 50%); }
+.swatch-retro    { background: linear-gradient(135deg, #2d4a1e 50%, #ffdd44 50%); }
+
+.swatch-name {
+  font-size: 0.58rem; font-weight: 600;
+  color: rgba(255,255,255,0.7);
+  text-align: center;
+  word-break: break-word;
+  line-height: 1.2;
+  max-width: 100%;
+}
+
+/* ── Site Header ──────────────────────────────────────────────── */
 .site-header {
   text-align: center;
-  padding: 2rem 1.5rem 1.5rem;
+  padding: 2rem 1.5rem 0;       /* bottom-padding removed — theme strip provides it */
   border-bottom: 1px solid rgba(212,175,55,0.2);
+  overflow: visible;            /* allow theme panel dropdown to show outside header */
 }
 
 .game-title {
@@ -114,7 +430,7 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
 .rules-btn:hover,
 .rules-btn[aria-expanded="true"] { background: var(--gold); color: var(--bg); }
 
-/* ── Rules Popup ─────────────────────────────────────────────── */
+/* ── Rules Popup ──────────────────────────────────────────────── */
 .rules-box {
   position: absolute; top: 5.5rem; right: 1.5rem;
   width: clamp(18rem, 30vw, 24rem);
@@ -127,7 +443,6 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   animation: fadeSlideIn 0.22s ease;
 }
 .rules-box[hidden] { display: none; }
-
 .rules-box h3 {
   font-family: var(--font-display);
   color: var(--gold); font-size: 1.3rem;
@@ -147,14 +462,12 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   to   { opacity: 1; transform: translateY(0); }
 }
 
-/* ── Game Board ─────────────────────────────────────────────── */
+/* ── Game Board ───────────────────────────────────────────────── */
 .game-board {
-  max-width: 900px;
-  margin: 0 auto;
-  padding: 1.5rem 1rem 3rem;
+  max-width: 900px; margin: 0 auto; padding: 1.5rem 1rem 3rem;
 }
 
-/* ── Status Message ─────────────────────────────────────────── */
+/* ── Status Message ───────────────────────────────────────────── */
 .status-msg {
   text-align: center;
   font-family: var(--font-display);
@@ -167,7 +480,7 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   transition: color var(--transition);
 }
 
-/* ── Card Table ─────────────────────────────────────────────── */
+/* ── Card Table ───────────────────────────────────────────────── */
 .card-table {
   display: flex; flex-direction: column; gap: 0;
   background: var(--felt);
@@ -179,6 +492,7 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   box-shadow: var(--shadow-card), inset 0 1px 0 rgba(255,255,255,0.08);
   overflow: hidden;
   margin-bottom: 1.5rem;
+  transition: background var(--transition), border-color var(--transition);
 }
 
 .table-divider {
@@ -187,7 +501,6 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   margin: 0 1rem;
 }
 
-/* ── Hand Areas ─────────────────────────────────────────────── */
 .hand-area { padding: 1.5rem 1.25rem 1.25rem; min-height: 14rem; }
 
 .hand-label {
@@ -212,7 +525,6 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
 .card-row {
   display: flex; flex-wrap: wrap; gap: 0.5rem; min-height: 8rem;
 }
-
 .card-row img {
   height: 9rem; width: auto;
   border-radius: var(--radius-sm);
@@ -233,22 +545,20 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   .hand-area     { flex: 1; }
 }
 
-/* ── BETTING SECTION ─────────────────────────────────────────── */
+/* ── BETTING SECTION ──────────────────────────────────────────── */
 .betting-section {
   background: var(--surface);
   border: 1px solid rgba(212,175,55,0.15);
   border-radius: var(--radius-lg);
   padding: 1.25rem 1.25rem 1rem;
   margin-bottom: 1.5rem;
+  transition: background var(--transition);
 }
 
 .betting-label {
-  font-size: 0.8rem;
-  font-weight: 600;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-  margin-bottom: 0.6rem;
+  font-size: 0.8rem; font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text-muted); margin-bottom: 0.6rem;
 }
 
 /* Chip Rail */
@@ -275,6 +585,67 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
 .chip--25  { background: var(--chip-25); }
 .chip--50  { background: var(--chip-50); }
 .chip--100 { background: var(--chip-100); }
+.chip--custom {
+  background: var(--chip-custom);
+  font-size: 1.1rem;
+  border-style: solid;
+}
+.chip--custom i { font-size: 1.2rem; }
+
+/* Custom chip wrapper + popup */
+.chip-custom-wrap {
+  position: relative;
+  display: flex; align-items: center;
+}
+
+.custom-chip-popup {
+  position: absolute;
+  /* Stable anchor: aligned to the left edge of the wrapper chip, opens below */
+  top: calc(100% + 8px);
+  left: 0;
+  /* No transform — eliminates the two-step visual jump */
+  background: rgba(10,10,20,0.97);
+  border: 1.5px solid var(--chip-custom);
+  border-radius: var(--radius-md);
+  padding: 0.7rem 0.75rem;
+  display: flex; align-items: center; gap: 6px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.6);
+  z-index: 250;
+  min-width: 230px;
+  animation: fadeSlideIn 0.18s ease;
+}
+.custom-chip-popup[hidden] { display: none; }
+
+.custom-chip-label {
+  font-size: 0.8rem; font-weight: 700;
+  color: var(--chip-custom);
+  white-space: nowrap;
+}
+
+.custom-chip-input {
+  flex: 1;
+  padding: 5px 8px;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.2);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-family: var(--font-ui); font-size: 0.85rem;
+  outline: none;
+  min-width: 0;
+}
+.custom-chip-input::placeholder { color: var(--text-muted); opacity: 0.7; }
+.custom-chip-input:focus { border-color: var(--chip-custom); }
+
+.custom-chip-add {
+  padding: 5px 12px;
+  background: var(--chip-custom);
+  border-radius: var(--radius-sm);
+  color: #fff; font-size: 0.82rem; font-weight: 700;
+  font-family: var(--font-ui);
+  transition: filter var(--transition);
+  white-space: nowrap;
+}
+.custom-chip-add:hover { filter: brightness(1.15); }
 
 /* Bet Stats Row */
 .bet-row {
@@ -314,9 +685,7 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
 .bet-btn--danger:hover { background: rgba(224,82,82,0.15); }
 
 /* Special Actions */
-.special-actions {
-  display: flex; gap: 10px; flex-wrap: wrap;
-}
+.special-actions { display: flex; gap: 10px; flex-wrap: wrap; }
 
 .special-btn {
   display: flex; align-items: center; gap: 7px;
@@ -341,13 +710,9 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   background: rgba(127,119,221,0.2); border-color: var(--chip-100);
 }
 
-/* ── Split Section ───────────────────────────────────────────── */
+/* ── Split Section ────────────────────────────────────────────── */
 .split-section { margin-top: 1rem; }
-
-.split-layout {
-  display: flex; gap: 10px;
-}
-
+.split-layout  { display: flex; gap: 10px; }
 .split-hand {
   flex: 1;
   border: 1.5px solid rgba(255,255,255,0.12);
@@ -357,13 +722,11 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   transition: border-color var(--transition);
 }
 .split-hand--active { border-color: var(--gold); }
-
 .split-hand-label {
   font-size: 0.75rem; font-weight: 600;
   text-transform: uppercase; letter-spacing: 0.07em;
   color: var(--text-muted); margin-bottom: 8px;
 }
-
 .split-cards {
   display: flex; flex-wrap: wrap; gap: 6px;
   min-height: 60px; align-items: flex-start;
@@ -374,13 +737,9 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   box-shadow: 2px 3px 8px rgba(0,0,0,0.4);
   animation: cardDeal 0.25s cubic-bezier(0.22,1,0.36,1);
 }
+.split-score { font-size: 0.85rem; font-weight: 600; color: var(--gold-light); margin-top: 6px; }
 
-.split-score {
-  font-size: 0.85rem; font-weight: 600;
-  color: var(--gold-light); margin-top: 6px;
-}
-
-/* ── Action Buttons ──────────────────────────────────────────── */
+/* ── Action Buttons ───────────────────────────────────────────── */
 .action-buttons {
   display: flex; justify-content: center; flex-wrap: wrap; gap: 1rem;
   margin-bottom: 2rem;
@@ -405,13 +764,14 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
 .btn-deal  { background: #b03030; color: #fff; border-color: #d04040; }
 .btn-deal:hover { background: #c53838; }
 
-/* ── Scoreboard ──────────────────────────────────────────────── */
+/* ── Scoreboard ───────────────────────────────────────────────── */
 .scoreboard {
   background: var(--surface);
   border: 1px solid rgba(212,175,55,0.2);
   border-radius: var(--radius-lg);
   padding: 1.5rem 1.25rem;
   text-align: center;
+  transition: background var(--transition);
 }
 
 .scoreboard-title {
@@ -450,13 +810,15 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
 .draws  .score-num { color: var(--draw-amber); }
 
 .score-actions {
-  display: flex; justify-content: center; gap: 1rem; flex-wrap: wrap;
+  display: flex; justify-content: center; gap: 0.75rem; flex-wrap: wrap;
+  margin-bottom: 0;
 }
 
 .btn-play-again {
   background: var(--felt); color: var(--gold-light);
   border: 1.5px solid var(--gold); border-radius: var(--radius-md);
   padding: 0.5rem 1.5rem; font-size: 0.95rem; font-weight: 600;
+  transition: background var(--transition);
 }
 .btn-play-again:hover { background: var(--felt-dark); }
 
@@ -464,10 +826,124 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   background: transparent; color: var(--text-muted);
   border: 1.5px solid rgba(255,255,255,0.15); border-radius: var(--radius-md);
   padding: 0.5rem 1.5rem; font-size: 0.95rem; font-weight: 600;
+  transition: border-color var(--transition), color var(--transition);
 }
 .btn-reset:hover { border-color: var(--loss-red); color: var(--loss-red); }
 
-/* ── Toast ───────────────────────────────────────────────────── */
+.btn-history-toggle {
+  display: flex; align-items: center; gap: 6px;
+  background: transparent; color: var(--gold);
+  border: 1.5px solid var(--gold); border-radius: var(--radius-md);
+  padding: 0.5rem 1.2rem; font-size: 0.95rem; font-weight: 600;
+  font-family: var(--font-ui);
+  transition: background var(--transition), color var(--transition);
+}
+.btn-history-toggle:hover,
+.btn-history-toggle[aria-expanded="true"] { background: var(--gold); color: var(--bg); }
+
+/* ── History Panel ────────────────────────────────────────────── */
+.history-panel {
+  margin-top: 1.5rem;
+  border-top: 1px solid rgba(255,255,255,0.08);
+  padding-top: 1rem;
+  text-align: left;
+}
+.history-panel[hidden] { display: none; }
+
+.history-header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+.history-title {
+  font-family: var(--font-display);
+  font-size: 1rem; font-weight: 700;
+  color: var(--gold); letter-spacing: 0.05em;
+  display: flex; align-items: center; gap: 6px;
+}
+.history-clear-btn {
+  font-size: 0.78rem; font-weight: 600;
+  color: var(--text-muted);
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: var(--radius-sm);
+  padding: 4px 10px;
+  transition: color var(--transition), border-color var(--transition);
+}
+.history-clear-btn:hover { color: var(--loss-red); border-color: var(--loss-red); }
+
+.history-list {
+  display: flex; flex-direction: column; gap: 10px;
+  max-height: 480px; overflow-y: auto;
+  padding-right: 4px;
+}
+.history-list::-webkit-scrollbar { width: 4px; }
+.history-list::-webkit-scrollbar-track { background: transparent; }
+.history-list::-webkit-scrollbar-thumb { background: rgba(255,255,255,0.15); border-radius: 2px; }
+
+.history-empty {
+  text-align: center; color: var(--text-muted);
+  font-size: 0.9rem; padding: 1.5rem 0;
+}
+
+/* History card */
+.hist-card {
+  background: rgba(0,0,0,0.35);
+  border: 1px solid rgba(255,255,255,0.07);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+  opacity: 0; transform: translateY(6px);
+  transition: opacity 0.28s ease, transform 0.28s ease;
+}
+.hist-card--visible { opacity: 1; transform: translateY(0); }
+
+.hist-top {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+.hist-round {
+  font-size: 0.72rem; font-weight: 600;
+  color: var(--text-muted); letter-spacing: 0.06em;
+  text-transform: uppercase; white-space: nowrap;
+}
+.hist-result {
+  font-size: 0.78rem; font-weight: 700;
+  padding: 2px 8px; border-radius: 99px;
+  text-transform: uppercase; letter-spacing: 0.06em;
+}
+.hist-win  { background: rgba(76,175,125,0.2); color: var(--win-green); }
+.hist-loss { background: rgba(224,82,82,0.2);  color: var(--loss-red); }
+.hist-draw { background: rgba(240,180,41,0.2); color: var(--draw-amber); }
+.hist-split{ background: rgba(127,119,221,0.2);color: #9f97ee; }
+
+.hist-bet {
+  font-size: 0.75rem; color: var(--text-muted);
+}
+.hist-net {
+  font-size: 0.85rem; font-weight: 700; margin-left: auto;
+}
+.hist-scores {
+  font-size: 0.75rem; color: var(--text-muted);
+  width: 100%;
+}
+
+.hist-ai {
+  background: rgba(255,255,255,0.03);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: var(--radius-sm);
+  padding: 0.55rem 0.75rem;
+}
+.hist-ai-label {
+  display: flex; align-items: center; gap: 5px;
+  font-size: 0.68rem; font-weight: 700;
+  color: var(--gold); letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 0.3rem;
+}
+.hist-ai-text {
+  font-size: 0.82rem; color: var(--text-primary);
+  line-height: 1.5; opacity: 0.85;
+}
+
+/* ── Toast ────────────────────────────────────────────────────── */
 .bj-toast {
   position: fixed; bottom: 1.5rem; left: 50%; transform: translateX(-50%);
   background: rgba(10,26,17,0.95);
@@ -482,7 +958,7 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
 }
 .bj-toast.show { opacity: 1; }
 
-/* ── Reduced Motion ──────────────────────────────────────────── */
+/* ── Reduced Motion ───────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {
     animation-duration: 0.01ms !important;
@@ -490,7 +966,7 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   }
 }
 
-/* ── Mobile ──────────────────────────────────────────────────── */
+/* ── Mobile ───────────────────────────────────────────────────── */
 @media (max-width: 420px) {
   .game-title { letter-spacing: 0.1em; }
   .btn        { padding: 0.6rem 1.5rem; font-size: 0.95rem; }
@@ -498,16 +974,19 @@ button { cursor: pointer; border: none; background: none; font: inherit; }
   .card-row img { height: 7rem; }
   .chip       { width: 46px; height: 46px; font-size: 0.68rem; }
   .split-cards img { height: 4.5rem; }
+  .theme-toggle-btn span { display: none; }
 }
 
 @media (max-width: 768px) {
   .site-header {
     display: flex; flex-direction: column; align-items: center;
-    gap: 1rem; padding: 2rem 1rem 1.5rem;
+    gap: 0.75rem; padding: 2rem 1rem 0;
   }
   .rules-btn { position: static; transform: none; margin-top: 0.25rem; }
   .game-title { font-size: clamp(2rem, 10vw, 3.5rem); letter-spacing: 0.12em; text-align: center; line-height: 1.15; }
   .rules-box { top: auto; right: 50%; transform: translateX(50%); width: min(90vw, 22rem); }
   .bet-row   { flex-direction: column; align-items: flex-start; }
   .bet-actions { margin-left: 0; }
+  .custom-chip-popup { min-width: 200px; }
+  .theme-switcher { margin-top: 0.5rem; }
 }

--- a/public/BlackJack/blackJ.html
+++ b/public/BlackJack/blackJ.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="classic">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -40,6 +40,61 @@
         <li><strong>Face cards</strong> (K, Q, J) are worth 10.</li>
       </ul>
     </div>
+
+    <!-- ── Theme Switcher (below dividing line) ──────────────────── -->
+    <div class="theme-switcher" id="themeSwitcher">
+      <div class="theme-btn-wrap">
+        <button class="theme-toggle-btn" id="themeToggleBtn" aria-label="Change theme" title="Change Theme">
+          <i class="ti ti-palette" aria-hidden="true"></i>
+          <span>Theme</span>
+        </button>
+        <div class="theme-panel" id="themePanel" hidden>
+          <p class="theme-panel-title">Choose Theme</p>
+          <div class="theme-grid">
+            <button class="theme-swatch" data-theme="classic" title="Classic Green Felt">
+              <span class="swatch-preview swatch-classic"></span>
+              <span class="swatch-name">Classic</span>
+            </button>
+            <button class="theme-swatch" data-theme="dark" title="Dark Mode">
+              <span class="swatch-preview swatch-dark"></span>
+              <span class="swatch-name">Dark</span>
+            </button>
+            <button class="theme-swatch" data-theme="neon" title="Neon">
+              <span class="swatch-preview swatch-neon"></span>
+              <span class="swatch-name">Neon</span>
+            </button>
+            <button class="theme-swatch" data-theme="velvet" title="Red Velvet">
+              <span class="swatch-preview swatch-velvet"></span>
+              <span class="swatch-name">Velvet</span>
+            </button>
+            <button class="theme-swatch" data-theme="blue" title="Blue Casino">
+              <span class="swatch-preview swatch-blue"></span>
+              <span class="swatch-name">Blue</span>
+            </button>
+            <button class="theme-swatch" data-theme="midnight" title="Midnight">
+              <span class="swatch-preview swatch-midnight"></span>
+              <span class="swatch-name">Midnight</span>
+            </button>
+            <button class="theme-swatch" data-theme="pastel" title="Pastel">
+              <span class="swatch-preview swatch-pastel"></span>
+              <span class="swatch-name">Pastel</span>
+            </button>
+            <button class="theme-swatch" data-theme="hc" title="High Contrast">
+              <span class="swatch-preview swatch-hc"></span>
+              <span class="swatch-name">Hi-Contrast</span>
+            </button>
+            <button class="theme-swatch" data-theme="gold" title="Gold Luxury">
+              <span class="swatch-preview swatch-gold"></span>
+              <span class="swatch-name">Gold</span>
+            </button>
+            <button class="theme-swatch" data-theme="retro" title="Retro">
+              <span class="swatch-preview swatch-retro"></span>
+              <span class="swatch-name">Retro</span>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   </header>
 
   <!-- ── Game Board ──────────────────────────────────────────── -->
@@ -78,6 +133,26 @@
         <button class="chip chip--25"  data-val="25"  aria-label="Add $25 to bet">$25</button>
         <button class="chip chip--50"  data-val="50"  aria-label="Add $50 to bet">$50</button>
         <button class="chip chip--100" data-val="100" aria-label="Add $100 to bet">$100</button>
+
+        <!-- Custom chip -->
+        <div class="chip-custom-wrap" id="customChipWrap">
+          <button class="chip chip--custom" id="customChipBtn" aria-label="Add custom amount to bet" title="Custom amount">
+            <i class="ti ti-pencil-plus" aria-hidden="true"></i>
+          </button>
+          <div class="custom-chip-popup" id="customChipPopup" hidden>
+            <label class="custom-chip-label" for="customChipInput">Custom $</label>
+            <input
+              class="custom-chip-input"
+              id="customChipInput"
+              type="number"
+              min="1"
+              max="50000"
+              placeholder="Amount"
+              aria-label="Custom bet amount"
+            />
+            <button class="custom-chip-add" id="customChipAdd" aria-label="Add custom amount">Add</button>
+          </div>
+        </div>
       </div>
 
       <!-- Bet Stats Row -->
@@ -162,6 +237,20 @@
       <div class="score-actions">
         <button class="btn-play-again" id="play-again">Play Again</button>
         <button class="btn-reset" id="reset-score">Reset Score</button>
+        <button class="btn-history-toggle" id="historyToggleBtn" aria-expanded="false">
+          <i class="ti ti-history" aria-hidden="true"></i> History
+        </button>
+      </div>
+
+      <!-- ── Round History Log ───────────────────────────────── -->
+      <div class="history-panel" id="historyPanel" hidden>
+        <div class="history-header">
+          <span class="history-title"><i class="ti ti-history" aria-hidden="true"></i> Round History</span>
+          <button class="history-clear-btn" id="historyClearBtn" aria-label="Clear history">Clear</button>
+        </div>
+        <div class="history-list" id="historyList" role="log" aria-label="Round history">
+          <p class="history-empty" id="historyEmpty">No rounds played yet.</p>
+        </div>
       </div>
     </div>
 

--- a/public/BlackJack/blackJ.js
+++ b/public/BlackJack/blackJ.js
@@ -1,16 +1,13 @@
 /**
  * blackJ.js — BlackJack game logic, UI state, and event handling.
- * Features: core game, betting system, chip UI, Double Down, Split.
+ * Features: core game, betting system, chip UI, Double Down, Split,
+ *           custom chip, round history, AI explanations, theme switcher.
  */
 
 'use strict';
 
 // ── Card data ────────────────────────────────────────────────────────────────
 
-/**
- * Card face values for all four suits.
- * Aces use [1, 11] — the higher value is applied unless it causes a bust.
- */
 const CARD_VALUES = {
   '2C':2,  '3C':3,  '4C':4,  '5C':5,  '6C':6,  '7C':7,  '8C':8,  '9C':9,
   '10C':10,'KC':10, 'QC':10, 'JC':10, 'AC':[1,11],
@@ -22,7 +19,6 @@ const CARD_VALUES = {
   '10S':10,'KS':10, 'QS':10, 'JS':10, 'AS':[1,11]
 };
 
-/** Returns a fresh 52-card deck. */
 function freshDeck() {
   return [
     '2C','3C','4C','5C','6C','7C','8C','9C','10C','KC','QC','JC','AC',
@@ -32,64 +28,39 @@ function freshDeck() {
   ];
 }
 
-/** Returns the rank portion of a card string (e.g. "10" from "10H", "K" from "KC"). */
-function cardRank(card) {
-  return card.slice(0, -1);
-}
+function cardRank(card) { return card.slice(0, -1); }
 
 // ── Core game state ──────────────────────────────────────────────────────────
 
 const BJgame = {
-  you: {
-    scoreSpan:     '#yourscore',
-    cardContainer: '#your-cards',
-    score: 0,
-    cards: []
-  },
-  dealer: {
-    scoreSpan:     '#dealerscore',
-    cardContainer: '#dealer-cards',
-    score: 0,
-    cards: []
-  },
+  you:    { scoreSpan: '#yourscore',    cardContainer: '#your-cards',   score: 0, cards: [] },
+  dealer: { scoreSpan: '#dealerscore',  cardContainer: '#dealer-cards', score: 0, cards: [] },
   deck:   freshDeck(),
-  wins:   0,
-  losses: 0,
-  draws:  0
+  wins: 0, losses: 0, draws: 0
 };
 
 const You    = BJgame.you;
 const Dealer = BJgame.dealer;
-
-/**
- * true = round in progress; false = awaiting Deal or Play Again.
- */
 let gameActive = false;
 
 // ── Betting state ────────────────────────────────────────────────────────────
 
-const Bet = {
-  balance:    1000,
-  current:    0,
-  last:       0,
-  deducted:   false   // tracks whether the round's bet has been deducted from balance
-};
+const Bet = { balance: 1000, current: 0, last: 0, deducted: false };
 
 // ── Split state ──────────────────────────────────────────────────────────────
 
-const Split = {
-  active:     false,
-  hands:      [[], []],   // each sub-array holds card strings
-  scores:     [0, 0],
-  activeIdx:  0,          // which hand is currently being played
-  bet:        0           // side bet (equals Bet.current at time of split)
-};
+const Split = { active: false, hands: [[], []], scores: [0, 0], activeIdx: 0, bet: 0 };
 
 // ── Double Down state ────────────────────────────────────────────────────────
 
-let doubleDownActive = false;  // true after Double Down is clicked; auto-stand after one card
+let doubleDownActive = false;
 
-// ── Audio ────────────────────────────────────────────────────────────────────
+// ── Round context (for history + AI) ─────────────────────────────────────────
+
+let roundCtx = { playerCards: [], dealerCards: [], playerScore: 0, dealerScore: 0, action: 'stand', bet: 0 };
+const roundHistory = [];
+
+// ── Audio ─────────────────────────────────────────────────────────────────────
 
 const sounds = {
   hit:   document.getElementById('snd-hit'),
@@ -99,24 +70,18 @@ const sounds = {
   lose:  document.getElementById('snd-lose'),
   draw:  document.getElementById('snd-draw')
 };
-
 function playSound(key) {
-  const s = sounds[key];
-  if (!s) return;
-  s.currentTime = 0;
-  s.play().catch(() => {});
+  const s = sounds[key]; if (!s) return;
+  s.currentTime = 0; s.play().catch(() => {});
 }
 
 // ── DOM helpers ───────────────────────────────────────────────────────────────
 
-/** @param {string} selector @returns {Element|null} */
-const $ = selector => document.querySelector(selector);
+const $ = sel => document.querySelector(sel);
 
 function showToast(msg, durationMs = 2400) {
-  const el = document.getElementById('bjToast');
-  if (!el) return;
-  el.textContent = msg;
-  el.classList.add('show');
+  const el = document.getElementById('bjToast'); if (!el) return;
+  el.textContent = msg; el.classList.add('show');
   clearTimeout(el._timer);
   el._timer = setTimeout(() => el.classList.remove('show'), durationMs);
 }
@@ -131,10 +96,8 @@ function renderBetUI() {
 }
 
 function setLastResult(text, color) {
-  const el = document.getElementById('lastResultDisplay');
-  if (!el) return;
-  el.textContent  = text;
-  el.style.color  = color || '';
+  const el = document.getElementById('lastResultDisplay'); if (!el) return;
+  el.textContent = text; el.style.color = color || '';
 }
 
 // ── Chip rail ─────────────────────────────────────────────────────────────────
@@ -145,48 +108,84 @@ function lockChips(locked) {
     c.style.opacity = locked ? '0.4' : '';
     c.style.cursor  = locked ? 'not-allowed' : '';
   });
+  const addBtn = document.getElementById('customChipAdd');
+  const inp    = document.getElementById('customChipInput');
+  if (addBtn) addBtn.disabled = locked;
+  if (inp)    inp.disabled    = locked;
 }
 
 document.getElementById('chipRail').addEventListener('click', e => {
   const chip = e.target.closest('.chip');
   if (!chip || chip.disabled) return;
+  if (chip.id === 'customChipBtn') return; // handled by custom chip setup
 
   const val = parseInt(chip.dataset.val, 10);
-  if (Bet.current + val > Bet.balance) {
-    showToast('Not enough balance for that chip');
-    return;
-  }
+  if (Bet.current + val > Bet.balance) { showToast('Not enough balance for that chip'); return; }
   Bet.current += val;
   renderBetUI();
-
-  // Brief pop animation
   chip.classList.add('chip--pop');
   setTimeout(() => chip.classList.remove('chip--pop'), 200);
 });
 
 document.getElementById('clearBetBtn').addEventListener('click', () => {
   if (gameActive) return;
-  Bet.current = 0;
-  renderBetUI();
+  Bet.current = 0; renderBetUI();
 });
 
 document.getElementById('repeatBetBtn').addEventListener('click', () => {
   if (gameActive) return;
   if (!Bet.last) { showToast('No previous bet to repeat'); return; }
   if (Bet.last > Bet.balance) { showToast('Not enough balance'); return; }
-  Bet.current = Bet.last;
-  renderBetUI();
+  Bet.current = Bet.last; renderBetUI();
 });
 
 document.getElementById('refillBtn').addEventListener('click', () => {
   if (gameActive) { showToast('Finish this round first'); return; }
-  Bet.balance = 1000;
-  Bet.current = 0;
-  Bet.last    = 0;
-  setLastResult('—');
-  renderBetUI();
+  Bet.balance = 1000; Bet.current = 0; Bet.last = 0;
+  setLastResult('—'); renderBetUI();
   showToast('Balance refilled to $1,000');
 });
+
+// ── Custom chip ───────────────────────────────────────────────────────────────
+
+(function setupCustomChip() {
+  const btn    = document.getElementById('customChipBtn');
+  const popup  = document.getElementById('customChipPopup');
+  const input  = document.getElementById('customChipInput');
+  const addBtn = document.getElementById('customChipAdd');
+  if (!btn || !popup || !input || !addBtn) return;
+
+  function togglePopup(force) {
+    const show = (force !== undefined) ? force : popup.hasAttribute('hidden');
+    if (show) { popup.removeAttribute('hidden'); input.focus(); input.select(); }
+    else popup.setAttribute('hidden', '');
+  }
+
+  btn.addEventListener('click', e => {
+    e.stopPropagation();
+    if (btn.disabled) return;
+    togglePopup();
+    btn.classList.add('chip--pop');
+    setTimeout(() => btn.classList.remove('chip--pop'), 200);
+  });
+
+  function applyCustomBet() {
+    const val = parseInt(input.value, 10);
+    if (!val || val < 1) { showToast('Enter a valid amount'); return; }
+    if (Bet.current + val > Bet.balance) { showToast('Amount exceeds your balance'); return; }
+    Bet.current += val; renderBetUI();
+    input.value = '';
+    togglePopup(false);
+    showToast('+$' + val + ' added to bet');
+  }
+
+  addBtn.addEventListener('click', applyCustomBet);
+  input.addEventListener('keydown', e => { if (e.key === 'Enter') applyCustomBet(); });
+  document.addEventListener('click', e => {
+    if (!popup.hasAttribute('hidden') && !popup.contains(e.target) && e.target !== btn)
+      togglePopup(false);
+  });
+})();
 
 // ── Special action buttons ─────────────────────────────────────────────────────
 
@@ -198,15 +197,10 @@ function setSpecialButtons(canDouble, canSplit) {
 }
 
 function evaluateSpecialActions() {
-  // Both actions are only available at the very start of a hand (exactly 2 cards dealt)
-  const twoCards    = You.cards.length === 2;
-  const hasBudget   = Bet.current <= Bet.balance;
+  const twoCards      = You.cards.length === 2;
+  const hasBudget     = Bet.current <= Bet.balance;
   const matchingRanks = twoCards && cardRank(You.cards[0]) === cardRank(You.cards[1]);
-
-  setSpecialButtons(
-    twoCards && hasBudget,
-    twoCards && hasBudget && matchingRanks
-  );
+  setSpecialButtons(twoCards && hasBudget, twoCards && hasBudget && matchingRanks);
 }
 
 // ── Double Down ───────────────────────────────────────────────────────────────
@@ -214,53 +208,37 @@ function evaluateSpecialActions() {
 document.getElementById('doubleBtn').addEventListener('click', () => {
   if (!gameActive || You.cards.length !== 2) return;
   if (Bet.current > Bet.balance) { showToast('Insufficient balance to double'); return; }
-
-  // Deduct the extra bet and double
-  Bet.balance       -= Bet.current;
-  Bet.current       *= 2;
-  doubleDownActive   = true;
+  Bet.balance -= Bet.current;
+  Bet.current *= 2;
+  doubleDownActive = true;
+  roundCtx.action  = 'double';
   renderBetUI();
   setSpecialButtons(false, false);
-
   showToast('Doubled! Drawing one card…');
   drawCard(You);
-
-  if (You.score > 21) {
-    setTimeout(() => endRound(findWinner()), 400);
-  } else {
-    // Auto-stand after the single card
-    setTimeout(() => BJstand(), 700);
-  }
+  if (You.score > 21) { setTimeout(() => endRound(findWinner()), 400); }
+  else                { setTimeout(() => BJstand(), 700); }
 });
 
 // ── Split ─────────────────────────────────────────────────────────────────────
 
 document.getElementById('splitBtn').addEventListener('click', () => {
   if (!gameActive || You.cards.length !== 2) return;
-  if (cardRank(You.cards[0]) !== cardRank(You.cards[1])) {
-    showToast('Can only split matching ranks');
-    return;
-  }
+  if (cardRank(You.cards[0]) !== cardRank(You.cards[1])) { showToast('Can only split matching ranks'); return; }
   if (Bet.current > Bet.balance) { showToast('Insufficient balance for split'); return; }
-
-  // Deduct side bet
   Bet.balance -= Bet.current;
   Split.bet    = Bet.current;
+  roundCtx.action = 'split';
   renderBetUI();
-
-  // Build two hands — each starts with one original card + one newly drawn card
-  Split.hands[0] = [You.cards[0], drawCardFromDeck()];
-  Split.hands[1] = [You.cards[1], drawCardFromDeck()];
+  Split.hands[0]  = [You.cards[0], drawCardFromDeck()];
+  Split.hands[1]  = [You.cards[1], drawCardFromDeck()];
   Split.scores[0] = calcHandScore(Split.hands[0]);
   Split.scores[1] = calcHandScore(Split.hands[1]);
   Split.active    = true;
   Split.activeIdx = 0;
-
-  // Clear the main card display — split section takes over
   $('#your-cards').querySelectorAll('img').forEach(img => img.remove());
   You.score = 0;
-  $( You.scoreSpan).textContent = 0;
-
+  $(You.scoreSpan).textContent = 0;
   showSplitSection();
   setSpecialButtons(false, false);
   lockChips(true);
@@ -285,21 +263,16 @@ function calcHandScore(cards) {
 }
 
 function showSplitSection() {
-  const sec = document.getElementById('splitSection');
-  if (sec) sec.hidden = false;
-  renderSplitHand(0);
-  renderSplitHand(1);
-  activateSplitHand(0);
+  const sec = document.getElementById('splitSection'); if (sec) sec.hidden = false;
+  renderSplitHand(0); renderSplitHand(1); activateSplitHand(0);
 }
 
 function renderSplitHand(idx) {
-  const container = document.getElementById('splitCards' + idx);
-  if (!container) return;
+  const container = document.getElementById('splitCards' + idx); if (!container) return;
   container.innerHTML = '';
   Split.hands[idx].forEach(card => {
     const img = document.createElement('img');
-    img.src  = `./static/${card}.png`;
-    img.alt  = card;
+    img.src = `./static/${card}.png`; img.alt = card;
     img.setAttribute('role', 'listitem');
     container.appendChild(img);
   });
@@ -318,35 +291,18 @@ function activateSplitHand(idx) {
 }
 
 function hideSplitSection() {
-  const sec = document.getElementById('splitSection');
-  if (sec) sec.hidden = true;
+  const sec = document.getElementById('splitSection'); if (sec) sec.hidden = true;
 }
 
-/**
- * Settles both split hands against the dealer's final score.
- * Each hand uses Split.bet independently.
- */
 function settleSplitBets(dealerScore, dealerBust) {
   let netChange = 0;
   const parts   = [];
-
   Split.hands.forEach((hand, i) => {
-    const s    = Split.scores[i];
-    const bust = s > 21;
-    const b    = Split.bet;
-
-    if (!bust && (dealerBust || s > dealerScore)) {
-      netChange += b;
-      parts.push(`Hand ${i + 1}: Win +$${b}`);
-    } else if (!bust && !dealerBust && s === dealerScore) {
-      parts.push(`Hand ${i + 1}: Push`);
-      // bet returned — no netChange
-    } else {
-      netChange -= b;
-      parts.push(`Hand ${i + 1}: Loss -$${b}`);
-    }
+    const s = Split.scores[i], bust = s > 21, b = Split.bet;
+    if (!bust && (dealerBust || s > dealerScore)) { netChange += b; parts.push(`Hand ${i+1}: Win +$${b}`); }
+    else if (!bust && !dealerBust && s === dealerScore) { parts.push(`Hand ${i+1}: Push`); }
+    else { netChange -= b; parts.push(`Hand ${i+1}: Loss -$${b}`); }
   });
-
   Bet.balance += netChange;
   const color = netChange > 0 ? '#1d9e75' : netChange < 0 ? '#e24b4a' : '#ba7517';
   setLastResult(parts.join(' | '), color);
@@ -358,188 +314,248 @@ function settleSplitBets(dealerScore, dealerBust) {
 
 function disableGameButtons() {
   ['#hit', '#stand'].forEach(sel => {
-    const btn = $(sel);
-    if (!btn) return;
-    btn.disabled = true;
-    btn.setAttribute('aria-disabled', 'true');
-    btn.style.opacity = '0.4';
-    btn.style.cursor  = 'not-allowed';
+    const btn = $(sel); if (!btn) return;
+    btn.disabled = true; btn.setAttribute('aria-disabled', 'true');
+    btn.style.opacity = '0.4'; btn.style.cursor = 'not-allowed';
   });
 }
 
 function enableGameButtons() {
   ['#hit', '#stand'].forEach(sel => {
-    const btn = $(sel);
-    if (!btn) return;
-    btn.disabled = false;
-    btn.setAttribute('aria-disabled', 'false');
-    btn.style.opacity = '';
-    btn.style.cursor  = '';
+    const btn = $(sel); if (!btn) return;
+    btn.disabled = false; btn.setAttribute('aria-disabled', 'false');
+    btn.style.opacity = ''; btn.style.cursor = '';
   });
 }
 
 // ── Core logic ────────────────────────────────────────────────────────────────
 
-/**
- * Draws one card from the deck for the given player, renders its image,
- * plays the deal sound, and updates the score.
- */
 function drawCard(activePlayer) {
   const randomIndex   = Math.floor(Math.random() * BJgame.deck.length);
   const [currentCard] = BJgame.deck.splice(randomIndex, 1);
-
   activePlayer.cards.push(currentCard);
-
   const cardImg = document.createElement('img');
   cardImg.src   = `./static/${currentCard}.png`;
   cardImg.alt   = currentCard;
   cardImg.setAttribute('role', 'listitem');
   $(activePlayer.cardContainer).appendChild(cardImg);
-
   playSound('hit');
-
   updateScore(currentCard, activePlayer);
   showScore(activePlayer);
 }
 
-/**
- * Adds the drawn card's value to the player's running total.
- * Aces count as 11 only when that keeps the score ≤ 21.
- */
 function updateScore(card, activePlayer) {
   const value = CARD_VALUES[card];
   if (Array.isArray(value)) {
-    activePlayer.score +=
-      (activePlayer.score + value[1] <= 21) ? value[1] : value[0];
+    activePlayer.score += (activePlayer.score + value[1] <= 21) ? value[1] : value[0];
   } else {
     activePlayer.score += value;
   }
 }
 
-function showScore(activePlayer) {
-  $(activePlayer.scoreSpan).textContent = activePlayer.score;
-}
+function showScore(activePlayer) { $(activePlayer.scoreSpan).textContent = activePlayer.score; }
 
 // ── Round resolution ──────────────────────────────────────────────────────────
 
-/**
- * Compares final scores and returns the winner object (or undefined for draw).
- */
 function findWinner() {
-  const youBust    = You.score > 21;
-  const dealerBust = Dealer.score > 21;
-
-  if (!youBust && (dealerBust || Dealer.score < You.score)) {
-    BJgame.wins++;
-    return You;
-  }
-  if (!youBust && !dealerBust && Dealer.score === You.score) {
-    BJgame.draws++;
-    return undefined;
-  }
-  if (!dealerBust && (youBust || You.score < Dealer.score)) {
-    BJgame.losses++;
-    return Dealer;
-  }
-  BJgame.draws++; // both bust
-  return undefined;
+  const youBust = You.score > 21, dealerBust = Dealer.score > 21;
+  if (!youBust && (dealerBust || Dealer.score < You.score)) { BJgame.wins++;   return You; }
+  if (!youBust && !dealerBust && Dealer.score === You.score){ BJgame.draws++;  return undefined; }
+  if (!dealerBust && (youBust || You.score < Dealer.score)) { BJgame.losses++; return Dealer; }
+  BJgame.draws++; return undefined;
 }
 
 function showResults(winner) {
-  const el = $('#command');
-  if (!el) return;
-
+  const el = $('#command'); if (!el) return;
   if (winner === You) {
-    el.textContent = '🏅 You Won!';
-    el.style.color = '#4caf7d';
-    playSound('win');
-    sounds.cheer && (sounds.cheer.volume = 0.4);
-    playSound('cheer');
+    el.textContent = '🏅 You Won!'; el.style.color = '#4caf7d';
+    playSound('win'); sounds.cheer && (sounds.cheer.volume = 0.4); playSound('cheer');
   } else if (winner === Dealer) {
-    el.textContent = '😖 You Lost!';
-    el.style.color = '#e05252';
-    playSound('lose');
+    el.textContent = '😖 You Lost!'; el.style.color = '#e05252'; playSound('lose');
   } else {
-    el.textContent = "🤝 It's a Draw!";
-    el.style.color = '#f0b429';
-    playSound('draw');
+    el.textContent = "🤝 It's a Draw!"; el.style.color = '#f0b429'; playSound('draw');
   }
 }
 
 function updateScoreboard() {
   [['#wins', BJgame.wins], ['#losses', BJgame.losses], ['#draws', BJgame.draws]].forEach(([sel, val]) => {
-    const el = $(sel);
-    if (!el) return;
-    el.textContent     = val;
-    el.style.transform = 'scale(1.3)';
+    const el = $(sel); if (!el) return;
+    el.textContent = val; el.style.transform = 'scale(1.3)';
     setTimeout(() => { el.style.transform = ''; }, 250);
   });
 }
 
-/**
- * Settles the bet after a normal (non-split) round.
- */
 function settleBet(winner) {
   let netChange = 0;
-
   if (winner === You) {
-    // Check for natural blackjack (Ace + 10-value on opening deal)
     const isBlackjack = You.cards.length === 2 && You.score === 21;
     const payout = isBlackjack ? Math.floor(Bet.current * 2.5) : Bet.current * 2;
     netChange = payout;
     setLastResult(`Win! +$${payout - Bet.current}`, '#1d9e75');
   } else if (winner === undefined) {
-    netChange = Bet.current; // push — return bet
+    netChange = Bet.current;
     setLastResult('Push — bet returned', '#ba7517');
   } else {
-    netChange = 0; // loss — bet already deducted
+    netChange = 0;
     setLastResult(`Loss — -$${Bet.current}`, '#e24b4a');
   }
-
   Bet.last    = Bet.current;
   Bet.balance += netChange;
   Bet.current  = 0;
   Bet.deducted = false;
-
-  renderBetUI();
-  lockChips(false);
-  setSpecialButtons(false, false);
-  doubleDownActive = false;
-
-  if (Bet.balance <= 0) {
-    showToast("You're out of chips! Click Refill to keep playing.", 4000);
-  }
+  renderBetUI(); lockChips(false); setSpecialButtons(false, false); doubleDownActive = false;
+  if (Bet.balance <= 0) showToast("You're out of chips! Click Refill to keep playing.", 4000);
 }
 
-/**
- * Finalises a round: locks game state, disables actions, shows result, settles bet.
- */
 function endRound(winner) {
   gameActive = false;
   disableGameButtons();
   showResults(winner);
   updateScoreboard();
 
+  // Snapshot for history
+  roundCtx.playerScore = You.score;
+  roundCtx.dealerScore = Dealer.score;
+  roundCtx.playerCards = [...You.cards];
+  roundCtx.dealerCards = [...Dealer.cards];
+  if (You.score > 21) roundCtx.action = 'bust';
+  if (You.cards.length === 2 && You.score === 21) roundCtx.action = 'blackjack';
+
   if (Split.active) {
     settleSplitBets(Dealer.score, Dealer.score > 21);
-    // The original bet is already gone (deducted on deal); it was the split side bets at stake
-    Bet.current  = 0;
-    Bet.deducted = false;
-    Split.active = false;
-    renderBetUI();
-    lockChips(false);
-    setSpecialButtons(false, false);
+    Bet.current = 0; Bet.deducted = false; Split.active = false;
+    renderBetUI(); lockChips(false); setSpecialButtons(false, false);
+    addHistoryEntry(winner, roundCtx, true);
   } else {
+    addHistoryEntry(winner, roundCtx, false);
     settleBet(winner);
   }
 }
+
+// ── AI Result Explanation ─────────────────────────────────────────────────────
+
+function generateAIExplanation(winner, ctx, isSplit) {
+  const ps = ctx.playerScore, ds = ctx.dealerScore;
+  const pb = ps > 21, db = ds > 21;
+
+  if (isSplit) {
+    return `You split your hand. Dealer finished on ${ds}${db ? ' (bust)' : ''}. ` +
+           `Each hand was settled independently against the dealer's total.`;
+  }
+  if (ctx.action === 'blackjack') {
+    return `Natural Blackjack! You hit 21 with your opening two cards (${ctx.playerCards.join(', ')}), ` +
+           `paying 1.5× your bet. Dealer stood at ${ds}.`;
+  }
+  if (pb && db) {
+    return `Both you (${ps}) and the dealer (${ds}) busted — a rare double-bust ends in a push.`;
+  }
+  if (pb) {
+    const last = ctx.playerCards[ctx.playerCards.length - 1];
+    return `You busted on ${ps} by drawing ${last}, taking you over 21. ` +
+           `Dealer didn't need to act further — automatic loss.`;
+  }
+  if (db) {
+    return `Dealer busted at ${ds} while drawing to meet the 17+ rule. ` +
+           `Your hand of ${ps} held strong for the win.`;
+  }
+  if (winner === undefined) {
+    return `Both you and the dealer finished on ${ps}. It's a push — no chips change hands.`;
+  }
+  if (winner === You) {
+    if (ctx.action === 'double') {
+      return `Bold double down! You drew to ${ps} — beating the dealer's ${ds}. Doubled payout earned.`;
+    }
+    return `You stood on ${ps} while the dealer drew to ${ds}. ` +
+           `Your higher total wins the round.`;
+  }
+  // Dealer wins
+  if (ctx.action === 'double') {
+    return `You doubled down and drew to ${ps}, but the dealer reached ${ds}. ` +
+           `Despite the bold move, the dealer's higher total takes the round.`;
+  }
+  if (ctx.action === 'stand') {
+    return `You stood on ${ps}, hoping the dealer would bust. ` +
+           `Instead they drew to ${ds}, which beats your hand — a tough one.`;
+  }
+  return `You hit to ${ps}, but the dealer's ${ds} is higher. Better luck next time.`;
+}
+
+// ── History log ───────────────────────────────────────────────────────────────
+
+function addHistoryEntry(winner, ctx, isSplit) {
+  const roundNum = roundHistory.length + 1;
+  const bet = ctx.bet;
+  let resultLabel, resultClass, netText;
+
+  if (isSplit) {
+    resultLabel = 'Split'; resultClass = 'hist-split'; netText = '';
+  } else if (winner === You) {
+    const isBlackjack = ctx.action === 'blackjack';
+    const profit = isBlackjack ? Math.floor(bet * 1.5) : bet;
+    resultLabel = isBlackjack ? 'Blackjack!' : 'Win';
+    resultClass = 'hist-win'; netText = '+$' + profit;
+  } else if (winner === undefined) {
+    resultLabel = 'Push'; resultClass = 'hist-draw'; netText = '$0';
+  } else {
+    resultLabel = 'Loss'; resultClass = 'hist-loss'; netText = '-$' + bet;
+  }
+
+  const explanation = generateAIExplanation(winner, ctx, isSplit);
+  const entry = {
+    roundNum, resultLabel, resultClass, netText,
+    playerScore: ctx.playerScore, dealerScore: ctx.dealerScore,
+    bet, explanation,
+    playerCards: ctx.playerCards.slice(),
+    dealerCards: ctx.dealerCards.slice()
+  };
+  roundHistory.unshift(entry);
+  renderHistoryEntry(entry, true);
+
+  const empty = document.getElementById('historyEmpty');
+  if (empty) empty.style.display = 'none';
+}
+
+function renderHistoryEntry(entry, prepend) {
+  const list = document.getElementById('historyList'); if (!list) return;
+  const card = document.createElement('div');
+  card.className = 'hist-card';
+  card.innerHTML =
+    '<div class="hist-top">' +
+      '<span class="hist-round">Round #' + entry.roundNum + '</span>' +
+      '<span class="hist-result ' + entry.resultClass + '">' + entry.resultLabel + '</span>' +
+      '<span class="hist-bet">Bet: $' + entry.bet.toLocaleString() + '</span>' +
+      '<span class="hist-net ' + entry.resultClass + '">' + entry.netText + '</span>' +
+      '<span class="hist-scores">You: ' + entry.playerScore + ' · Dealer: ' + entry.dealerScore + '</span>' +
+    '</div>' +
+    '<div class="hist-ai">' +
+      '<span class="hist-ai-label"><i class="ti ti-robot" aria-hidden="true"></i> AI Analysis</span>' +
+      '<p class="hist-ai-text">' + entry.explanation + '</p>' +
+    '</div>';
+
+  if (prepend && list.firstChild) { list.insertBefore(card, list.firstChild); }
+  else { list.appendChild(card); }
+  requestAnimationFrame(() => card.classList.add('hist-card--visible'));
+}
+
+document.getElementById('historyToggleBtn').addEventListener('click', () => {
+  const panel = document.getElementById('historyPanel');
+  const btn   = document.getElementById('historyToggleBtn');
+  if (!panel || !btn) return;
+  const isHidden = panel.hasAttribute('hidden');
+  if (isHidden) { panel.removeAttribute('hidden'); btn.setAttribute('aria-expanded', 'true'); }
+  else          { panel.setAttribute('hidden', ''); btn.setAttribute('aria-expanded', 'false'); }
+});
+
+document.getElementById('historyClearBtn').addEventListener('click', () => {
+  roundHistory.length = 0;
+  const list = document.getElementById('historyList');
+  if (list) list.innerHTML = '<p class="history-empty" id="historyEmpty">No rounds played yet.</p>';
+});
 
 // ── Button handlers ───────────────────────────────────────────────────────────
 
 function BJhit() {
   if (!gameActive) return;
-
-  // If split is active, add the card to the current split hand instead
   if (Split.active) {
     const idx  = Split.activeIdx;
     const card = drawCardFromDeck();
@@ -547,122 +563,64 @@ function BJhit() {
     Split.scores[idx] = calcHandScore(Split.hands[idx]);
     renderSplitHand(idx);
     playSound('hit');
-
-    if (Split.scores[idx] > 21) {
-      showToast(`Hand ${idx + 1} bust!`);
-      advanceSplitHand();
-    }
+    if (Split.scores[idx] > 21) { showToast(`Hand ${idx + 1} bust!`); advanceSplitHand(); }
     return;
   }
-
   drawCard(You);
-
-  if (You.score > 21) {
-    setTimeout(() => endRound(findWinner()), 400);
-  } else if (!doubleDownActive) {
-    // Re-evaluate special actions only when not mid double-down
-    evaluateSpecialActions();
-  }
+  if (You.score > 21) { setTimeout(() => endRound(findWinner()), 400); }
+  else if (!doubleDownActive) { evaluateSpecialActions(); }
 }
 
-/**
- * Move to hand 2, or if both hands are done kick off dealer draw.
- */
 function advanceSplitHand() {
-  if (Split.activeIdx === 0) {
-    activateSplitHand(1);
-    showToast('Now playing hand 2');
-  } else {
-    // Both hands played — dealer draws
-    runDealerDraw();
-  }
+  if (Split.activeIdx === 0) { activateSplitHand(1); showToast('Now playing hand 2'); }
+  else { runDealerDraw(); }
 }
 
 function BJstand() {
   if (!gameActive) return;
-
-  if (Split.active) {
-    advanceSplitHand();
-    return;
-  }
-
+  if (Split.active) { advanceSplitHand(); return; }
   runDealerDraw();
 }
 
 function runDealerDraw() {
-  while (Dealer.score < 17) {
-    drawCard(Dealer);
-  }
+  while (Dealer.score < 17) { drawCard(Dealer); }
   setTimeout(() => endRound(findWinner()), 800);
 }
 
 function BJdeal() {
-  if (gameActive) {
-    showToast('Finish your current turn first — Hit or Stand before dealing.');
-    return;
-  }
-
-  if (Bet.current <= 0) {
-    showToast('Place a bet first!');
-    return;
-  }
-  if (Bet.current > Bet.balance) {
-    showToast('Bet exceeds your balance');
-    return;
-  }
-
-  // Deduct bet from balance before dealing
+  if (gameActive) { showToast('Finish your current turn first — Hit or Stand before dealing.'); return; }
+  if (Bet.current <= 0) { showToast('Place a bet first!'); return; }
+  if (Bet.current > Bet.balance) { showToast('Bet exceeds your balance'); return; }
   Bet.balance  -= Bet.current;
   Bet.deducted  = true;
   renderBetUI();
-
   startNewRound();
 }
 
 function startNewRound() {
-  // Clear card displays
   ['#your-cards', '#dealer-cards'].forEach(sel => {
     $(sel).querySelectorAll('img').forEach(img => img.remove());
   });
-
   BJgame.deck = freshDeck();
-
-  // Reset player states
   [You, Dealer].forEach(player => {
-    player.score = 0;
-    player.cards = [];
+    player.score = 0; player.cards = [];
     const el = $(player.scoreSpan);
     if (el) { el.textContent = 0; el.style.color = ''; }
   });
-
-  // Reset split state
-  Split.active    = false;
-  Split.hands     = [[], []];
-  Split.scores    = [0, 0];
-  Split.activeIdx = 0;
-  Split.bet       = 0;
+  Split.active = false; Split.hands = [[], []]; Split.scores = [0, 0];
+  Split.activeIdx = 0; Split.bet = 0;
   hideSplitSection();
-
   doubleDownActive = false;
-
+  roundCtx = { playerCards: [], dealerCards: [], playerScore: 0, dealerScore: 0, action: 'stand', bet: Bet.current };
   const commandEl = $('#command');
   if (commandEl) { commandEl.textContent = "Let's Play!"; commandEl.style.color = ''; }
-
   enableGameButtons();
   gameActive = true;
   lockChips(true);
-
-  // Deal 2 cards each
-  drawCard(You);
-  drawCard(Dealer);
-  drawCard(You);
-  drawCard(Dealer);
-
-  // Evaluate which special actions are available
+  drawCard(You); drawCard(Dealer); drawCard(You); drawCard(Dealer);
   evaluateSpecialActions();
-
-  // Blackjack on deal?
   if (You.score === 21 && You.cards.length === 2) {
+    roundCtx.action = 'blackjack';
     showToast('Blackjack! 🃏');
     setTimeout(() => endRound(findWinner()), 600);
   }
@@ -671,11 +629,10 @@ function startNewRound() {
 // ── Rules toggle ──────────────────────────────────────────────────────────────
 
 function toggleRules() {
-  const box      = document.getElementById('rules-box');
-  const btn      = document.getElementById('rules-btn');
+  const box = document.getElementById('rules-box');
+  const btn = document.getElementById('rules-btn');
   const isHidden = box.hasAttribute('hidden');
-  if (isHidden) box.removeAttribute('hidden');
-  else box.setAttribute('hidden', '');
+  if (isHidden) box.removeAttribute('hidden'); else box.setAttribute('hidden', '');
   btn.setAttribute('aria-expanded', String(isHidden));
 }
 
@@ -684,10 +641,80 @@ document.addEventListener('click', e => {
   const btn = document.getElementById('rules-btn');
   if (!box || !btn) return;
   if (!box.hasAttribute('hidden') && !box.contains(e.target) && e.target !== btn) {
-    box.setAttribute('hidden', '');
-    btn.setAttribute('aria-expanded', 'false');
+    box.setAttribute('hidden', ''); btn.setAttribute('aria-expanded', 'false');
   }
 });
+
+// ── Theme switcher ────────────────────────────────────────────────────────────
+
+(function setupThemeSwitcher() {
+  const THEMES = ['classic','dark','neon','velvet','blue','midnight','pastel','hc','gold','retro'];
+  const htmlEl    = document.documentElement;
+  const toggleBtn = document.getElementById('themeToggleBtn');
+  const panel     = document.getElementById('themePanel');
+  if (!toggleBtn || !panel) return;
+
+  const saved = localStorage.getItem('bj-theme');
+  if (saved && THEMES.includes(saved)) { htmlEl.setAttribute('data-theme', saved); markActive(saved); }
+
+  /**
+   * Positions the fixed panel so its right edge aligns with the button's right edge
+   * and it opens just below the button — always fully visible inside the viewport.
+   */
+  function positionPanel() {
+    const rect       = toggleBtn.getBoundingClientRect();
+    const panelW     = Math.min(320, window.innerWidth - 32); // mirrors CSS min()
+    const topVal     = rect.bottom + 8;
+    // Right edge of panel = right edge of button; clamp so it never exits the viewport
+    const rightVal   = Math.max(8, window.innerWidth - rect.right);
+
+    panel.style.top   = topVal  + 'px';
+    panel.style.right = rightVal + 'px';
+    panel.style.left  = 'auto';
+    panel.style.width = panelW  + 'px';
+  }
+
+  toggleBtn.addEventListener('click', e => {
+    e.stopPropagation();
+    if (panel.hasAttribute('hidden')) {
+      panel.removeAttribute('hidden');
+      positionPanel();          // position on open
+    } else {
+      panel.setAttribute('hidden', '');
+    }
+  });
+
+  // Reposition if the user resizes or scrolls while panel is open
+  window.addEventListener('resize', () => {
+    if (!panel.hasAttribute('hidden')) positionPanel();
+  });
+  window.addEventListener('scroll', () => {
+    if (!panel.hasAttribute('hidden')) positionPanel();
+  }, { passive: true });
+
+  document.querySelectorAll('.theme-swatch').forEach(btn => {
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      const theme = btn.dataset.theme;
+      htmlEl.setAttribute('data-theme', theme);
+      localStorage.setItem('bj-theme', theme);
+      markActive(theme);
+      panel.setAttribute('hidden', '');
+      showToast('Theme: ' + theme.charAt(0).toUpperCase() + theme.slice(1));
+    });
+  });
+
+  document.addEventListener('click', e => {
+    if (!panel.hasAttribute('hidden') && !panel.contains(e.target) && e.target !== toggleBtn)
+      panel.setAttribute('hidden', '');
+  });
+
+  function markActive(theme) {
+    document.querySelectorAll('.theme-swatch').forEach(s => {
+      s.classList.toggle('theme-swatch--active', s.dataset.theme === theme);
+    });
+  }
+})();
 
 // ── Event listeners ───────────────────────────────────────────────────────────
 
@@ -697,24 +724,19 @@ document.getElementById('deal').addEventListener('click',       BJdeal);
 document.getElementById('rules-btn').addEventListener('click',  toggleRules);
 document.getElementById('play-again').addEventListener('click', () => {
   if (Bet.current <= 0 && Bet.last > 0 && Bet.last <= Bet.balance) {
-    Bet.current = Bet.last; // auto-repeat last bet for convenience
-    renderBetUI();
+    Bet.current = Bet.last; renderBetUI();
   }
   BJdeal();
 });
-
 document.getElementById('reset-score').addEventListener('click', () => {
   BJgame.wins = BJgame.losses = BJgame.draws = 0;
   updateScoreboard();
 });
 
-// Hover tink sound on action buttons
 const actionGroup = document.querySelector('.action-buttons');
 if (actionGroup) {
   actionGroup.addEventListener('mouseover', e => {
-    if (e.target.classList.contains('btn') && !e.target.disabled) {
-      playSound('tink');
-    }
+    if (e.target.classList.contains('btn') && !e.target.disabled) playSound('tink');
   });
 }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #9926 

### Summary
Provide a short, reviewer-friendly summary of what changed and why.

Four improvements were made to the BlackJack game across the three core files. A custom bet chip (pencil icon) was added after the $100 chip, letting players type any amount instead of being locked to preset denominations. A round history log was added to the scoreboard, toggled by a History button - showing each past hand's result, bet, and scores in a scrollable list. Inside every history entry, an AI analysis line explains in plain English why the round was won, lost, or pushed, referencing exact scores and player actions like stand, bust, double, or blackjack. Finally, a theme switcher was built into the header (below the title row) offering 10 colour themes - Classic, Dark, Neon, Velvet, Blue, Midnight, Pastel, Hi-Contrast, Gold, and Retro, each driven by CSS custom property blocks on [data-theme] so the entire palette swaps in one attribute change, with the choice persisted in localStorage. 
The switcher dropdown uses position: fixed with JS-calculated coordinates via getBoundingClientRect() so it's never clipped by parent containers and always appears fully visible on screen.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [X] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made

Detailed description of change 1 (blackJ.html)
-

1. The <html> tag gained a data-theme="classic" attribute as the default theme hook. 
2. Inside <header>, a new .theme-switcher div was added as a child element (below the rules popup), wrapping a .theme-btn-wrap div that contains the palette toggle button and the theme panel dropdown with a 5×2 grid of 10 swatch buttons. This placement keeps the switcher in the natural document flow inside the header, below the title/rules row. 
3. In the chip rail, a .chip-custom-wrap div was added after the $100 chip, containing a styled custom chip button and a hidden popup with a number input and an Add button. 
4. In the scoreboard, a third button "History" was added alongside Play Again and Reset, and a .history-panel div was added beneath the scoreboard actions, containing a header row (title + Clear button) and a scrollable .history-list container that starts with an empty-state message.

Detailed description of change 2 (blackJ.css)
-

1. The :root block was split, the classic theme values moved into a [data-theme="classic"] block (with :root as a fallback) and nine additional [data-theme="x"] blocks were added for Dark, Neon, Red Velvet, Blue Casino, Midnight, Pastel, High Contrast, Gold Luxury, and Retro, each fully overriding the felt, background, surface, text, win/loss/draw, chip, and gradient tokens.
2. A --chip-custom variable was added to every theme. 
3. The .theme-switcher rule changed from position: fixed to a full-width in-flow flex row with justify-content: flex-end and a thin gold top border, placing it naturally below the header's title row without overlapping corner buttons.
4. A new .theme-btn-wrap class (position: relative; display: inline-flex) acts as the positioning context for the panel dropdown.
5. The .theme-panel was changed to position: fixed with z-index: 9999, removing all static coordinate rules, coordinates are injected at runtime by JS. 
6. .chip--custom styles the new pink pencil chip with a solid border. 
7. .chip-custom-wrap is position: relative to anchor the popup. 
8. .custom-chip-popup had its left: 50%; transform: translateX(-50%) replaced with left: 0 to eliminate the visual jump on open. 
9. New history-panel styles were added: .history-panel, .history-header, .history-title, .history-clear-btn, .history-list (with custom scrollbar), .history-empty, .hist-card (with opacity/translate entry animation), .hist-top, .hist-result/.hist-net/.hist-bet/.hist-scores, and .hist-ai with .hist-ai-label and .hist-ai-text, covering the full visual design of the round log. 
10. .site-header gained overflow: visible to allow the dropdown to render outside the header bounds, and its bottom padding was removed since the theme strip provides it. 
11. A .btn-history-toggle style was added alongside the existing scoreboard action buttons.

Detailed description of change 2 (blackJ.js)
-

1. Several new state variables and functions were introduced. A roundCtx object tracks per-round context - player cards, dealer cards, scores, action type (stand/bust/blackjack/double/split), and bet - which is populated at deal time and finalised inside endRound(). 
2. A roundHistory array stores the full log of past entries. 
3. The lockChips() function was extended to also disable/enable the custom chip's Add button and input. 
4. A setupCustomChip() IIFE handles the custom chip popup: toggling its visibility on button click, applying the bet amount on Add or Enter, and closing on outside click, with the popup anchored via left: 0 to avoid the two-step visual jump that translateX(-50%) caused. 
5. endRound() was updated to snapshot the roundCtx and call addHistoryEntry() after settling bets, covering both normal and split rounds. 
6. addHistoryEntry() builds a history record with result label, colour class, net change, and calls generateAIExplanation() to produce a plain-English sentence describing why the round ended the way it did - handling all outcomes: natural blackjack, bust, dealer bust, double-down win/loss, standing vs drawing, push, and double bust.
7. renderHistoryEntry() creates a DOM card for each entry and inserts it at the top of the list with a CSS fade-in animation.
8. Event listeners were added for the History toggle (show/hide panel) and the Clear button (wipe roundHistory and reset the list). 
9. The setupThemeSwitcher() IIFE was updated with a positionPanel() helper that uses toggleBtn.getBoundingClientRect() to compute the panel's top and right as fixed viewport coordinates every time the panel opens, and again on window resize and scroll, ensuring the dropdown is never clipped by any parent container.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [X] Tested and verified in **Google Chrome**
- [X] Tested and verified in **Mozilla Firefox**
- [X] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [X] Keyboard navigation and focus outlines checked
- [X] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
*Please attach screenshots or screen recordings showing before vs after behavior if this PR includes visual changes.*

|Before|
|-------|

<img width="3420" height="1904" alt="yess 2026-06-29 at 2 38 02 PM" src="https://github.com/user-attachments/assets/f7f2fa46-055a-4965-b71a-e1e13108362d" />

<img width="3420" height="1904" alt="yess 2026-06-29 at 2 38 17 PM" src="https://github.com/user-attachments/assets/a6aba06d-68c2-4cce-ad46-225ae7692072" />

|After|
|-----|

<img width="3420" height="1904" alt="yess 2026-06-30 at 7 41 17 AM" src="https://github.com/user-attachments/assets/1d34e1ff-1e4c-4754-b7cf-495033b456d6" />

<img width="3420" height="1904" alt="yess 2026-06-30 at 7 41 37 AM" src="https://github.com/user-attachments/assets/c0332053-5035-4a7b-9508-12c9852d6dbe" />

<img width="3420" height="1904" alt="yess 2026-06-30 at 7 41 50 AM" src="https://github.com/user-attachments/assets/115ba2a7-3812-43de-b3f8-aff4ea7993c9" />

---

## 🤝 Contributor Checklist
- [X] My code follows the code style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation / README files accordingly.
- [X] My changes generate no new warnings or console errors.
- [X] There are no unrelated changes or formatter noise in this PR.
