### PR TITLE
fix: improve styling and contrast of difficulty buttons in Captcha pr…

### DIFF
--- a/public/captcha/captcha.css
+++ b/public/captcha/captcha.css
@@ -790,22 +790,21 @@ input[type="text"]:focus {
     font-size: 0.95rem;
     cursor: pointer;
     transition: .25s ease;
-    opacity: 0.55;
+    opacity: 0.7;
     font-family: 'Plus Jakarta Sans', sans-serif;
 }
 
 .diff-btn:hover {
-    opacity: 0.85;
+    opacity: 1;
     transform: translateY(-2px);
     border-color: #60a5fa;
 }
 
-.diff-btn[style*="opacity: 1"],
 .diff-btn.active {
     opacity: 1;
-    background: linear-gradient(135deg, rgba(59, 130, 246, .25), rgba(139, 92, 246, .25));
+    background: linear-gradient(135deg, rgba(59, 130, 246, .35), rgba(139, 92, 246, .35));
     border-color: #60a5fa;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, .2);
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, .3);
 }
 
 .selectors-row {


### PR DESCRIPTION
## 📝 Pull Request Description
### Related Issue
Closes #9687

### Summary
Improved styling and contrast of the Easy/Medium/Hard difficulty buttons in the Captcha project so the active state is clearer and inactive buttons aren't washed out.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature or UI/UX enhancement

---

## 🛠️ Changes Made
- Increased base opacity of `.diff-btn` from 0.55 → 0.7 so inactive buttons are more visible
- Strengthened the `.active` state gradient and box-shadow for clearer visual feedback
- Removed the fragile `[style*="opacity: 1"]` selector in favor of relying solely on the `.active` class

---

## 🧪 Testing and Verification
### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.