### PR TITLE
fix/Visibility bug, the light theme has multiple visibility issues.

### DIFF
--- a/public/Carousel Solar System/index.css
+++ b/public/Carousel Solar System/index.css
@@ -34,6 +34,11 @@ body{
   --glass-bg: rgba(255,255,255,0.08);
   --border-color: rgba(255,255,255,0.1);
   --accent: #8ca8ff;
+  --logo-gradient-start: #ffffff;
+  --logo-gradient-end: #7aa7ff;
+  --control-btn-bg: rgba(255,255,255,0.08);
+  --control-btn-hover-bg: #ffffff;
+  --control-btn-hover-color: #020412;
 }
 
 body.light-theme{
@@ -46,6 +51,11 @@ body.light-theme{
   --glass-bg: rgba(255,255,255,0.85);
   --border-color: rgba(15,23,42,0.1);
   --accent: #2563eb;
+  --logo-gradient-start: #0f172a;
+  --logo-gradient-end: #2563eb;
+  --control-btn-bg: rgba(15,23,42,0.08);
+  --control-btn-hover-bg: #0f172a;
+  --control-btn-hover-color: #ffffff;
 }
 /* =========================
    MAIN CONTAINER
@@ -109,7 +119,7 @@ body.light-theme{
   font-weight:700;
   letter-spacing:4px;
 
-  background:linear-gradient(to right,#ffffff,#7aa7ff);
+  background:linear-gradient(to right, var(--logo-gradient-start), var(--logo-gradient-end));
   background-clip: text;
   -webkit-background-clip:text;
   -webkit-text-fill-color:transparent;
@@ -133,7 +143,7 @@ body.light-theme{
 
 .line{
   height:3px;
-  background:white;
+  background:var(--text-primary);
   border-radius:20px;
   transition:0.4s;
 }
@@ -244,7 +254,7 @@ body.light-theme{
 }
 
 .planet-item span{
-    color:white;
+    color:var(--text-primary);
 
     font-size:0.9rem;
     font-weight:500;
@@ -502,21 +512,24 @@ span{
 .control-btn{
   padding:14px 28px;
 
-  border:none;
+  border:1px solid var(--border-color);
   border-radius:50px;
 
-  background:rgba(255,255,255,0.08);
-  color:white;
+  background:var(--control-btn-bg);
+  color:var(--text-primary);
 
   backdrop-filter:blur(12px);
 
   cursor:pointer;
   transition:0.35s;
+
+  font-weight:600;
+  letter-spacing:1px;
 }
 
 .control-btn:hover{
-  background:white;
-  color:#020412;
+  background:var(--control-btn-hover-bg);
+  color:var(--control-btn-hover-color);
 
   transform:translateY(-3px);
 }
@@ -638,13 +651,32 @@ span{
   }
 
   .planet-mini-list{
-    flex-direction:row;
-    flex-wrap:wrap;
-    width:240px;
-    justify-content:center;
+    display:grid;
+    grid-template-columns:1fr 1fr;
+    width:220px;
     max-height:none;
     overflow-y:visible;
-    padding:18px;
+    padding:12px;
+    gap:8px;
+  }
+
+  .planet-item{
+    flex-direction:column;
+    align-items:center;
+    justify-content:center;
+    gap:6px;
+    padding:8px 6px;
+    text-align:center;
+  }
+
+  .planet-item span{
+    font-size:0.75rem;
+    letter-spacing:0.5px;
+  }
+
+  .mini-planet{
+    width:36px;
+    height:36px;
   }
 }
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #10037 

### Summary
Provide a short, reviewer-friendly summary of what changed and why.

1. "CELESTIAL" heading was invisible in light mode The logo text colour was hardcoded to white, so it disappeared on a light background. Now it automatically switches to a dark navy-to-blue colour in light mode.

2. Hamburger menu lines (☰) were invisible in light mode The three horizontal lines were always white. Now they change color based on the theme: dark in light mode, white in dark mode.

3. PREV & NEXT buttons were invisible in light mode The buttons had white text on a nearly white background. Now the text and button style adapts to the theme: dark text in light mode, white text in dark mode.

4. Mobile dropdown planet list was misaligned When you tapped the ☰ icon on mobile, the planets appeared in a jumbled layout because they were using a "wrap" layout without proper structure. Now it uses a clean 2-column grid, planet image on top, name below, so everything lines up neatly.


### Type of Change
- [X] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made

Detailed description of change 1 (index.css)
-

1. Added new colour variables for logo, buttons so they adapt to dark/light theme.
2. "CELESTIAL" heading now shows dark colours in light mode instead of being invisible.
3. Hamburger lines (☰) now turn dark in light mode instead of staying white.
4. PREV / NEXT buttons now show correct text colour based on the theme.
5. Planet names in the dropdown menu now use theme colour instead of hardcoded white.
6. Mobile dropdown layout changed from a messy wrap to a clean 2-column grid.
7. Button hover colours also flip correctly per theme now.

8. Added 5 new CSS variables: --logo-gradient-start/end, --control-btn-bg, --control-btn-hover-bg/colour in both :root and body.light-theme.
9. .logo gradient changed from hardcoded #ffffff, #7aa7ff to var(--logo-gradient-start), var(--logo-gradient-end).
10. .line background changed from white → var(--text-primary).
11. .control-btn colour/background replaced with CSS variables; added border: 1px solid var(--border-colour).
12. .planet-item span colour changed from hardcoded white → var(--text-primary).
13. Mobile .planet-mini-list switched from flex-wrap to display: grid; grid-template-columns: 1fr 1fr.
14. .planet-item overridden in mobile to flex-direction: column with text-align: centre.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [X] Tested and verified in **Google Chrome**
- [X] Tested and verified in **Mozilla Firefox**
- [X] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [X] Keyboard navigation and focus outlines checked
- [X] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
*Please attach screenshots or screen recordings showing before vs after behavior if this PR includes visual changes.*

|Before|
|-------|

<img width="3420" height="1904" alt="yess 2026-06-30 at 2 05 41 PM" src="https://github.com/user-attachments/assets/50568e3e-a455-4ece-91f4-13645f0aae47" />

<img width="3420" height="1904" alt="yess 2026-06-30 at 2 06 32 PM" src="https://github.com/user-attachments/assets/cf676bf7-faca-42c4-a329-d7029b10fbf8" />

<img width="3420" height="1904" alt="yess 2026-06-30 at 2 05 50 PM" src="https://github.com/user-attachments/assets/757937d6-4904-4982-ab80-326f92363700" />

|After|
|-----|

<img width="3420" height="1904" alt="yess 2026-07-01 at 9 53 58 PM" src="https://github.com/user-attachments/assets/6c5c0d76-c2b5-400d-826b-849868043b10" />

<img width="3420" height="1904" alt="yess 2026-07-01 at 9 54 08 PM" src="https://github.com/user-attachments/assets/1e4701db-3ff8-4388-92f5-4134e923c95f" />

<img width="3420" height="1904" alt="yess 2026-07-01 at 9 54 21 PM" src="https://github.com/user-attachments/assets/24e0b5a6-1778-47cc-a8b4-403ece7bb876" />

---

## 🤝 Contributor Checklist
- [X] My code follows the code style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have updated the documentation / README files accordingly.
- [X] My changes generate no new warnings or console errors.
- [X] There are no unrelated changes or formatter noise in this PR.