### PR TITLE
fix: resolve unresolved Git merge conflict markers in Pokedex/index.html

### DIFF
--- a/public/Pokedex/index.html
+++ b/public/Pokedex/index.html
@@ -4,12 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pokedex</title>
-<<<<<<< HEAD
-    <link rel="stylesheet" href="style.css">
-    <link rel="icon" type="image/png" href="./favicon.png">
-</head>
-<body>
-=======
     <link rel="stylesheet" href="style.css" />
     <link rel="icon" href="image.png" />
   </head>
@@ -43,7 +37,6 @@
       >← Back to Home</a
     >
 
->>>>>>> upstream/Main
     <main class="pokedex-app">
       <header class="pokedex-header">
         <h1>Pokédex</h1>


### PR DESCRIPTION
Fixes #10178

## Description
public/Pokedex/index.html contained unresolved Git merge conflict
markers (<<<<<<< HEAD, =======, >>>>>>> upstream/Main) at lines
7, 12, and 46. The conflict was in the <head> section — the HEAD
version had an unclosed <head> tag and was missing the "Back to
Home" navigation button.

## Fix
Resolved the conflict by keeping the upstream/Main version which
has proper self-closing HTML tags and includes the Back to Home
navigation button for better UX.

## Result
- No conflict markers remaining
- Valid HTML structure with properly closed tags
- Back to Home button restored

## Checklist
- [x] Tested locally
- [x] No conflict markers remaining
- [x] Follows existing code style