### PR TITLE
Feat: Add light/dark theme toggle to Calculator page

### DIFF
--- a/public/Calculator/Calculator.css
+++ b/public/Calculator/Calculator.css
@@ -452,3 +452,75 @@ input::placeholder {
     outline-offset:2px;
 
 }
+
+/* ===== Theme Toggle Button ===== */
+.theme-toggle-btn {
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 50%;
+    background: rgba(110, 222, 10, 0.12);
+    color: var(--accent-strong);
+    font-size: 1.3rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: transform 0.25s ease, background 0.25s ease;
+}
+
+.theme-toggle-btn:hover {
+    background: rgba(110, 222, 10, 0.25);
+    transform: rotate(15deg) scale(1.08);
+}
+
+.theme-toggle-btn:active {
+    transform: scale(0.9);
+}
+
+.theme-toggle-btn:focus-visible {
+    outline: 2px solid rgba(110, 222, 10, 0.45);
+    outline-offset: 2px;
+}
+
+/* ===== Light Theme Overrides ===== */
+body.light-theme {
+    --bg-strong: #f4f6fb;
+    --bg-soft: #eceff5;
+    --panel: rgba(255, 255, 255, 0.75);
+    --text: #12131a;
+    --muted: #5b6178;
+    --accent: #3fa300;
+    --accent-strong: #2e8b00;
+    --danger: #d43a2c;
+    --shadow: 0 30px 90px rgba(0, 0, 0, 0.12);
+
+    background: radial-gradient(circle at 18% 16%, rgba(63, 163, 0, 0.10), transparent 18%),
+        radial-gradient(circle at 82% 14%, rgba(73, 103, 255, 0.08), transparent 16%),
+        linear-gradient(180deg, #ffffff 0%, #eef1f8 60%, #f7f8fb 100%);
+}
+
+body.light-theme::before {
+    background: radial-gradient(circle at 30% 30%, rgba(63, 163, 0, 0.05), transparent 16%),
+        radial-gradient(circle at 70% 84%, rgba(95, 104, 255, 0.05), transparent 18%);
+}
+
+body.light-theme input {
+    background: rgba(0, 0, 0, 0.03);
+    box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.05), inset 0 18px 34px rgba(0, 0, 0, 0.04);
+}
+
+body.light-theme .calculator-button {
+    background: linear-gradient(145deg, rgba(0, 0, 0, 0.03), rgba(0, 0, 0, 0.01));
+    box-shadow: 4px 8px 24px rgba(0, 0, 0, 0.08), inset -2px -2px 10px rgba(0, 0, 0, 0.02);
+}
+
+body.light-theme .history-panel {
+    background: rgba(255, 255, 255, 0.65);
+    border: 1px solid rgba(63, 163, 0, 0.18);
+}
+
+body.light-theme .history-item {
+    background: rgba(0, 0, 0, 0.03);
+    border: 1px solid rgba(0, 0, 0, 0.06);
+}

--- a/public/Calculator/Calculator.html
+++ b/public/Calculator/Calculator.html
@@ -15,6 +15,9 @@
 <body>
 <a href="/" class="project-back-button" style="position:fixed;left:18px;top:18px;padding:8px 16px;border-radius:8px;background:#1e293b;color:#3b82f6;border:1px solid #3b82f6;text-decoration:none;z-index:9999;font-weight:700;font-family:Inter, system-ui, sans-serif;transition:all 0.2s ease;" onmouseover="this.style.background='#3b82f6';this.style.color='#fff'" onmouseout="this.style.background='#1e293b';this.style.color='#3b82f6'">← Back to Home</a>
 
+<button class="theme-toggle-btn" onclick="toggleTheme()" id="themeToggleBtn" title="Toggle theme" aria-label="Toggle dark/light theme">
+    🌙
+</button>
 
     <div class="container">
 

--- a/public/Calculator/Calculator.js
+++ b/public/Calculator/Calculator.js
@@ -517,3 +517,27 @@ document.addEventListener('keydown', (e) => {
         deleteButton?.click();
     }
 });
+
+// ===== Theme Toggle =====
+function toggleTheme() {
+    document.body.classList.toggle('light-theme');
+    const isLight = document.body.classList.contains('light-theme');
+    localStorage.setItem('calculatorTheme', isLight ? 'light' : 'dark');
+    updateToggleIcon(isLight);
+}
+
+function updateToggleIcon(isLight) {
+    const btn = document.getElementById('themeToggleBtn');
+    if (btn) btn.textContent = isLight ? '☀️' : '🌙';
+}
+
+// Run on page load, before anything else visible
+(function initTheme() {
+    const savedTheme = localStorage.getItem('calculatorTheme');
+    if (savedTheme === 'light') {
+        document.body.classList.add('light-theme');
+    }
+    document.addEventListener('DOMContentLoaded', () => {
+        updateToggleIcon(document.body.classList.contains('light-theme'));
+    });
+})();


### PR DESCRIPTION
### Description
Adds a light/dark theme toggle button to the Calculator page, allowing users to switch between themes. The choice persists across page reloads via `localStorage`.

Closes #8604

### Changes
- Added a `theme-toggle-btn` styled consistently with existing UI elements (e.g. `close-history-btn`)
- Introduced `body.light-theme` CSS override block that redefines existing CSS custom properties (`--bg-strong`, `--text`, `--panel`, etc.), so the whole page re-themes without duplicating component styles
- Added `toggleTheme()`, `updateToggleIcon()`, and theme initialization logic in `Calculator.js`
- Theme preference is saved in `localStorage` and restored on page load (prevents flash of wrong theme)

### Screenshots

<img width="1460" height="812" alt="image" src="https://github.com/user-attachments/assets/02fa1943-c725-4893-b881-e8d3a177f264" />

<img width="935" height="503" alt="image" src="https://github.com/user-attachments/assets/4b143c24-639f-4c8a-94de-918a844ff5ca" />



### How to Test
1. Open `Calculator.html`
2. Click the theme toggle button (top left, sun/moon icon)
3. Confirm colors switch and all elements remain readable
4. Refresh the page — confirm the chosen theme persists


## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
