### PR TITLE
Fix Medical_App reschedule.html duplicate reschedule.js script tag

### DIFF
--- a/public/Medical_App/reschedule.html
+++ b/public/Medical_App/reschedule.html
@@ -280,7 +280,6 @@
     <script src="js/toast.js"></script>
     <script src="js/reschedule.js"></script>
 
-    <script src="reschedule.js"></script>
     <script src="js/script.js"></script>
     <script src="js/darkmode.js"></script>
     


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #10199

### Summary
Remove the duplicate and invalid `reschedule.js` script import from `public/Medical_App/reschedule.html`, leaving only the correct `js/reschedule.js` loading path.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

---

## 🛠️ Changes Made
- Removed the broken duplicate `<script src="reschedule.js"></script>` tag from `public/Medical_App/reschedule.html`.
- Confirmed the file now loads `js/reschedule.js` only once from the correct relative path.

---

## 🧪 Testing and Verification

### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [ ] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.