### PR TITLE
Fix duplicate css/animations.css link in public/Medical_App/index.html

### DIFF
--- a/public/Medical_App/index.html
+++ b/public/Medical_App/index.html
@@ -26,9 +26,8 @@
 <body>
 
 
-    <link rel="stylesheet" href="css/animations.css">
-
     <link rel="stylesheet" href="css/animation.css">
+    
     <link rel="stylesheet" href="css/hero.css">
     <link rel="stylesheet" href="assets/css/auth.css">
 </head>


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Fixes 10198

### Summary
This PR removes the broken duplicate stylesheet reference from `public/Medical_App/index.html` that caused a `404 Not Found` error for `css/animations.css`.

## 🛠️ Changes Made
- `public/Medical_App/index.html`
  - Removed duplicate `<link rel="stylesheet" href="css/animations.css">` and retained the correct `css/animation.css` import.

### Testing & Verification
- Local checks performed:
  - [x] Confirmed `public/Medical_App/index.html` no longer references `css/animations.css`.
  - [ ] Recommended: preview the Medical_App page in browser and verify there are no 404 console errors for stylesheet loading.

## ✅ Contributor Checklist
- [x] My code follows the project style.
- [x] I performed a self-review of my changes.
- [x] Commit is authored and signed by `sahitya0xsingh`.
- [x] No unrelated files changed.
