### PR TITLE
Remove broken profiler.js reference in Whack-a-Mole

### DIFF
--- a/public/Whack-a-Mole Game/index.html
+++ b/public/Whack-a-Mole Game/index.html
@@ -25,6 +25,5 @@
 
 </body>
 <script src="mole.js"></script>
-<script src="profiler.js"></script>
 
 </html>


### PR DESCRIPTION
## 📝 Pull Request Description

Fixes #10192

### Summary
This PR removes the broken `profiler.js` script reference from `public/Whack-a-Mole Game/index.html`.

## 🛠️ Changes Made
- `public/Whack-a-Mole Game/index.html`
  - Removed the invalid `<script src="profiler.js"></script>` tag from the page footer.

### Testing & Verification
- Local checks performed:
  - [x] Confirmed the page no longer includes the missing profiler script reference.
  - [x] Verified the game loads without a console `GET profiler.js net::ERR_FILE_NOT_FOUND` error.
- Recommended: open the Whack-a-Mole game in browser and confirm gameplay starts correctly.

## ✅ Contributor Checklist
- [x] My code follows the project style.
- [x] I performed a self-review of my changes.
- [x] Commit is authored and signed by `sahitya0xsingh`.
- [x] No unrelated files changed.
