### PR TITLE
Fix #10191: Remove duplicate script.js load in EchoNotes

### DIFF
--- a/public/EchoNotes/index.html
+++ b/public/EchoNotes/index.html
@@ -878,6 +878,5 @@
     </div>
 
     <script src="./script.js"></script>
-    <script src="script.js?v=2"></script>
   </body>
 </html>


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Fixes #10191

### Summary
This PR removes the duplicate `script.js` import from `public/EchoNotes/index.html`, preventing the page from loading the same script twice and registering duplicate event listeners.

## 🛠️ Changes Made
- `public/EchoNotes/index.html`
  - Removed duplicate `<script src="script.js?v=2"></script>` from the page footer.

### Testing & Verification
- Local checks performed:
  - [x] Confirmed only one `script.js` script tag remains in `public/EchoNotes/index.html`.
  - [x] Verified the page no longer loads `script.js` twice.
- Recommended: open EchoNotes in browser and verify notes input behavior is normal with no duplicate save or delete actions.

## ✅ Contributor Checklist
- [x] My code follows the project style.
- [x] I performed a self-review of my changes.
- [x] Commit is authored and signed by `sahitya0xsingh`.
- [x] No unrelated files changed.
