### PR TITLE
Fix #10190: Resolve duplicate 'The Cube' project entries

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -755,7 +755,7 @@
   },
   {
     "projectNo": 65,
-    "projectName": "The Cube",
+    "projectName": "The Cube (Canvas demo)",
     "projectType": "UI",
     "projectDesc": "3D cube animation showcasing depth and motion interactions.",
     "techStack": [


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Fixes #10190

### Summary
This PR disambiguates duplicate project entries for "The Cube" in `projects.json` to avoid confusion between `public/The Cube` and `public/the_cube` folders. It renames the first entry to `The Cube (Canvas demo)` to make both projects discoverable and distinct.

## 🛠️ Changes Made
- `projects.json`
  - Renamed projectNo 65 `projectName` to `The Cube (Canvas demo)`.

### Notes
- Both `public/The Cube` and `public/the_cube` folders are left intact; this change only updates `projects.json` to avoid duplicate names.
- If you prefer merging the two folders into a single canonical project, I can do that in a follow-up PR.

### Testing & Verification
- Local checks performed:
  - [x] Confirmed `projects.json` contains distinct entries for each folder.

## ✅ Contributor Checklist
- [x] My code follows the project style.
- [x] I performed a self-review of my changes.
- [x] Commit is authored and signed by `sahitya0xsingh`.
- [x] No unrelated files changed.
