### PR TITLE
Fix #10188: Use local relative projectPath entries for projects.json

### DIFF
--- a/projects.json
+++ b/projects.json
@@ -149,7 +149,7 @@
       "source-only"
     ],
     "difficulty": "intermediate",
-    "projectPath": "https://github.com/dhairyagothi/100_days_100_web_project/tree/Main/public/loginusingmern"
+    "projectPath": "./public/loginusingmern"
   },
   {
     "projectNo": 14,
@@ -230,7 +230,7 @@
       "javascript"
     ],
     "difficulty": "intermediate",
-    "projectPath": "https://evesparks.onrender.com/"
+    "projectPath": "./public/EveSparks/public/index.html"
   },
   {
     "projectNo": 21,
@@ -751,7 +751,7 @@
       "css"
     ],
     "difficulty": "beginner",
-    "projectPath": "https://github.com/dhairyagothi/100_days_100_web_project/tree/Main/public/zomato-clone"
+    "projectPath": "./public/zomato-clone/public/index.html"
   },
   {
     "projectNo": 65,
@@ -849,7 +849,7 @@
       "source-only"
     ],
     "difficulty": "intermediate",
-    "projectPath": "https://github.com/dhairyagothi/100_days_100_web_project/tree/Main/public/Contact Book"
+    "projectPath": "./public/Contact Book/templates/home.html"
   },
   {
     "projectNo": 73,
@@ -1080,7 +1080,7 @@
       "javascript"
     ],
     "difficulty": "intermediate",
-    "projectPath": "https://github.com/dhairyagothi/100_days_100_web_project/tree/Main/public/Voting_Application_Backend"
+    "projectPath": "./public/Voting_Application_Backend/index.html"
   },
   {
     "projectNo": 92,
@@ -1364,7 +1364,7 @@
       "javascript"
     ],
     "difficulty": "intermediate",
-    "projectPath": "https://event-registration-system-w10a.onrender.com/"
+    "projectPath": "./public/event-registration-system/client/index.html"
   },
   {
     "projectNo": 116,
@@ -2755,7 +2755,7 @@
       "tailwindcss"
     ],
     "difficulty": "advanced",
-    "projectPath": "https://github.com/dhairyagothi/100_days_100_web_project/tree/Main/public/SkillBridge"
+    "projectPath": "./public/SkillBridge/index.html"
   },
   {
     "projectNo": 219,


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Fixes #10188

### Summary
Several entries in `projects.json` used external URLs (GitHub tree links or Render deployments) as their `projectPath`. That breaks the "Open Project" behavior on the site. This change replaces those external links with local relative `./public/...` paths that point to the repository's local project folders so the projects open correctly from the website.

## 🛠️ Changes Made
- Updated `projects.json` to use local relative paths for the following projects:
  - `projectNo: 13` — `./public/loginusingmern`
  - `projectNo: 20` — `./public/EveSparks/public/index.html`
  - `projectNo: 64` — `./public/zomato-clone/public/index.html`
  - `projectNo: 72` — `./public/Contact Book/templates/home.html`
  - `projectNo: 91` — `./public/Voting_Application_Backend/index.html`
  - `projectNo: 115` — `./public/event-registration-system/client/index.html`
  - `projectNo: 218` — `./public/SkillBridge/index.html`

### Testing & Verification
- Verified that the referenced local paths exist in the repository and point to valid HTML entry files or project folders.

## ✅ Contributor Checklist
- [x] Single, focused commit authored and signed by `sahitya0xsingh`.
- [x] No unrelated files changed.
- [x] PR links the related issue.

