### PR TITLE
Fix #10187: Add missing title tag to Well project

### DIFF
--- a/public/Well/index.html
+++ b/public/Well/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Well | 100 Days 100 Web Projects</title>
     <style>
       body {
         margin: 0;


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Fixes #10187

### Summary
The Well project HTML was missing a `<title>` tag in `public/Well/index.html`, causing the browser tab to display a blank title and hindering accessibility and basic SEO. This PR adds a descriptive title element for the project.

## 🛠️ Changes Made
- `public/Well/index.html`
  - Added `<title>Well | 100 Days 100 Web Projects</title>` inside the document `<head>`.

## ✅ Contributor Checklist
- [x] Single, focused commit authored and signed by `sahitya0xsingh`.
- [x] No unrelated files changed.
- [x] PR links the related issue.
