### PR TITLE
feat: implement interactive learning path map component

### DIFF
--- a/index.html
+++ b/index.html
@@ -306,6 +306,173 @@
           <h2 class="section-title">Every experiment, catalogued.</h2>
         </div>
 
+        <!-- Learning Map Container -->
+        <div class="learning-map-container" id="learningMapContainer">
+          <div class="learning-map-header">
+            <h3><i class="fas fa-route"></i> Learning Path Map</h3>
+            <p>Select a learning track to filter the project archive by category and focus your skill building.</p>
+          </div>
+
+          <!-- SVG Visual Learning Map (Desktop/Tablet) -->
+          <div class="learning-map-svg-wrap">
+            <svg class="learning-map-svg" viewBox="0 0 1020 250" xmlns="http://www.w3.org/2000/svg">
+              <!-- Sequential paths connecting the nodes -->
+              <path d="M 120,120 C 220,120 220,70 320,70" class="map-connection-line" id="conn-ui-tool" />
+              <path d="M 320,70 C 420,70 420,170 520,170" class="map-connection-line" id="conn-tool-api" />
+              <path d="M 520,170 C 620,170 620,70 720,70" class="map-connection-line" id="conn-api-clone" />
+              <path d="M 720,70 C 810,70 810,120 900,120" class="map-connection-line" id="conn-clone-game" />
+
+              <!-- Node 1: UI/Animation (ui) -->
+              <g class="map-node" data-category="ui" tabindex="0" role="button" aria-label="Beginner HTML/CSS track: UI and layout projects">
+                <g transform="translate(120, 120)">
+                  <circle r="36" class="node-outer" />
+                  <circle r="26" class="node-inner" />
+                  <text class="node-text-num">01</text>
+                  <text y="54" class="node-title">Beginner HTML/CSS</text>
+                  <text y="70" class="node-subtitle">UI & Layouts</text>
+                </g>
+              </g>
+
+              <!-- Node 2: DOM & Interactive JS (tool) -->
+              <g class="map-node" data-category="tool" tabindex="0" role="button" aria-label="DOM and Interactive JavaScript track: tool and utility projects">
+                <g transform="translate(320, 70)">
+                  <circle r="36" class="node-outer" />
+                  <circle r="26" class="node-inner" />
+                  <text class="node-text-num">02</text>
+                  <text y="54" class="node-title">DOM & Interactive JS</text>
+                  <text y="70" class="node-subtitle">Dynamic Tools</text>
+                </g>
+              </g>
+
+              <!-- Node 3: API Integrations (api) -->
+              <g class="map-node" data-category="api" tabindex="0" role="button" aria-label="API Integrations track: API fetching and dashboard projects">
+                <g transform="translate(520, 170)">
+                  <circle r="36" class="node-outer" />
+                  <circle r="26" class="node-inner" />
+                  <text class="node-text-num">03</text>
+                  <text y="54" class="node-title">API Integrations</text>
+                  <text y="70" class="node-subtitle">Data & Services</text>
+                </g>
+              </g>
+
+              <!-- Node 4: Frontend Clones (clone) -->
+              <g class="map-node" data-category="clone" tabindex="0" role="button" aria-label="Frontend Clones track: Landing page and application clone projects">
+                <g transform="translate(720, 70)">
+                  <circle r="36" class="node-outer" />
+                  <circle r="26" class="node-inner" />
+                  <text class="node-text-num">04</text>
+                  <text y="54" class="node-title">Frontend Clones</text>
+                  <text y="70" class="node-subtitle">Replicating Designs</text>
+                </g>
+              </g>
+
+              <!-- Node 5: Advanced Canvas & Games (game) -->
+              <g class="map-node" data-category="game" tabindex="0" role="button" aria-label="Advanced Canvas and Games track: 2D game loops and audio visualizer projects">
+                <g transform="translate(900, 120)">
+                  <circle r="36" class="node-outer" />
+                  <circle r="26" class="node-inner" />
+                  <text class="node-text-num">05</text>
+                  <text y="54" class="node-title">Advanced Canvas & Games</text>
+                  <text y="70" class="node-subtitle">Complex Logic</text>
+                </g>
+              </g>
+            </svg>
+          </div>
+
+          <!-- Mobile Accordion (Switch for Mobile Breakpoint) -->
+          <div class="learning-map-mobile-accordion">
+            <!-- Step 1 -->
+            <div class="accordion-item" data-category="ui">
+              <div class="accordion-header" role="button" aria-expanded="false" aria-controls="acc-body-ui" tabindex="0">
+                <span class="track-num">01</span>
+                <div class="track-info">
+                  <h4>Beginner HTML/CSS</h4>
+                  <span class="track-tag">UI & Layouts</span>
+                </div>
+                <i class="fas fa-chevron-right arrow-icon" aria-hidden="true"></i>
+              </div>
+              <div class="accordion-content" id="acc-body-ui">
+                <div class="accordion-body">
+                  <p>Learn the foundations of web structure and design. Build responsive layout cards, profiles, navigation headers, and creative CSS transitions/animations.</p>
+                  <button class="accordion-btn" aria-label="Explore Beginner HTML/CSS projects"><i class="fas fa-filter" aria-hidden="true"></i> Explore Track</button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Step 2 -->
+            <div class="accordion-item" data-category="tool">
+              <div class="accordion-header" role="button" aria-expanded="false" aria-controls="acc-body-tool" tabindex="0">
+                <span class="track-num">02</span>
+                <div class="track-info">
+                  <h4>DOM & Interactive JS</h4>
+                  <span class="track-tag">Dynamic Tools</span>
+                </div>
+                <i class="fas fa-chevron-right arrow-icon" aria-hidden="true"></i>
+              </div>
+              <div class="accordion-content" id="acc-body-tool">
+                <div class="accordion-body">
+                  <p>Bring interfaces to life. Practice event listening, state management, and local storage by building calculators, notes apps, form builders, and other useful interactive tools.</p>
+                  <button class="accordion-btn" aria-label="Explore DOM & Interactive JS projects"><i class="fas fa-filter" aria-hidden="true"></i> Explore Track</button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Step 3 -->
+            <div class="accordion-item" data-category="api">
+              <div class="accordion-header" role="button" aria-expanded="false" aria-controls="acc-body-api" tabindex="0">
+                <span class="track-num">03</span>
+                <div class="track-info">
+                  <h4>API Integrations</h4>
+                  <span class="track-tag">Data & Services</span>
+                </div>
+                <i class="fas fa-chevron-right arrow-icon" aria-hidden="true"></i>
+              </div>
+              <div class="accordion-content" id="acc-body-api">
+                <div class="accordion-body">
+                  <p>Fetch, parse, and render live data from external services. Master async/await, promise chains, search debounce, and dashboard updates using REST APIs.</p>
+                  <button class="accordion-btn" aria-label="Explore API Integrations projects"><i class="fas fa-filter" aria-hidden="true"></i> Explore Track</button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Step 4 -->
+            <div class="accordion-item" data-category="clone">
+              <div class="accordion-header" role="button" aria-expanded="false" aria-controls="acc-body-clone" tabindex="0">
+                <span class="track-num">04</span>
+                <div class="track-info">
+                  <h4>Frontend Clones</h4>
+                  <span class="track-tag">Replicating Designs</span>
+                </div>
+                <i class="fas fa-chevron-right arrow-icon" aria-hidden="true"></i>
+              </div>
+              <div class="accordion-content" id="acc-body-clone">
+                <div class="accordion-body">
+                  <p>Replicate popular application designs and standard features. Focus on layout accuracy, theme handling, side panels, and scaling components like search inputs and navigation tabs.</p>
+                  <button class="accordion-btn" aria-label="Explore Frontend Clones projects"><i class="fas fa-filter" aria-hidden="true"></i> Explore Track</button>
+                </div>
+              </div>
+            </div>
+
+            <!-- Step 5 -->
+            <div class="accordion-item" data-category="game">
+              <div class="accordion-header" role="button" aria-expanded="false" aria-controls="acc-body-game" tabindex="0">
+                <span class="track-num">05</span>
+                <div class="track-info">
+                  <h4>Advanced Canvas & Games</h4>
+                  <span class="track-tag">Complex Logic</span>
+                </div>
+                <i class="fas fa-chevron-right arrow-icon" aria-hidden="true"></i>
+              </div>
+              <div class="accordion-content" id="acc-body-game">
+                <div class="accordion-body">
+                  <p>Deep-dive into HTML5 Canvas, high-performance rendering, game loops, audio nodes, physics math, and complex visual graphics for maximum frontend capability.</p>
+                  <button class="accordion-btn" aria-label="Explore Advanced Canvas & Games projects"><i class="fas fa-filter" aria-hidden="true"></i> Explore Track</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div class="projects-header">
           <div
             class="filter-chips"

--- a/index.js
+++ b/index.js
@@ -1005,6 +1005,9 @@ const filtered = searchResults.filter((project) => {
 
   syncStateToURL();
   syncProjectCounts();
+  if (typeof syncLearningMapWithFilter === "function") {
+    syncLearningMapWithFilter(activeFilter);
+  }
 }
 console.log("===== RENDER GRID =====");
 console.log("PROJECTS:", PROJECTS.length);
@@ -2060,6 +2063,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   initSorting();
   initTechStackSearch();
   initClearAllFilters();
+  initLearningMap();
 
   //updateGamifiedUI();
 
@@ -2626,3 +2630,187 @@ document
     "click",
     renderRandomProject
   );
+
+/* ============================================================
+   LEARNING PATH MAP SYSTEM
+   ============================================================ */
+
+function initLearningMap() {
+  const mapContainer = document.getElementById("learningMapContainer");
+  if (!mapContainer) return;
+
+  const svgNodes = mapContainer.querySelectorAll(".map-node");
+  const accordionItems = mapContainer.querySelectorAll(".accordion-item");
+
+  // Helper to trigger the actual filter chip click
+  const selectCategory = (category) => {
+    const chip = document.querySelector(`.chip[data-filter="${category}"]`);
+    if (chip) {
+      chip.click();
+    } else {
+      // Fallback in case chip click doesn't bubble or is missing
+      activeFilter = category;
+      currentPage = 1;
+      renderGrid();
+    }
+  };
+
+  // SVG Nodes Clicks & Key events
+  svgNodes.forEach((node) => {
+    const category = node.getAttribute("data-category");
+    if (!category) return;
+
+    node.addEventListener("click", (e) => {
+      e.preventDefault();
+      selectCategory(category);
+      scrollToProjectSection();
+    });
+
+    node.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        selectCategory(category);
+        scrollToProjectSection();
+      }
+    });
+  });
+
+  // Mobile Accordion toggles
+  accordionItems.forEach((item) => {
+    const category = item.getAttribute("data-category");
+    const header = item.querySelector(".accordion-header");
+    const content = item.querySelector(".accordion-content");
+    const btn = item.querySelector(".accordion-btn");
+
+    if (!header || !content || !category) return;
+
+    const toggleAccordion = (expandOnly = false) => {
+      const isExpanded = item.classList.contains("expanded");
+      
+      // Collapse other items
+      accordionItems.forEach((otherItem) => {
+        if (otherItem !== item) {
+          otherItem.classList.remove("expanded");
+          const otherContent = otherItem.querySelector(".accordion-content");
+          if (otherContent) otherContent.style.maxHeight = null;
+          const otherHeader = otherItem.querySelector(".accordion-header");
+          if (otherHeader) otherHeader.setAttribute("aria-expanded", "false");
+        }
+      });
+
+      if (expandOnly || !isExpanded) {
+        item.classList.add("expanded");
+        content.style.maxHeight = content.scrollHeight + "px";
+        header.setAttribute("aria-expanded", "true");
+      } else {
+        item.classList.remove("expanded");
+        content.style.maxHeight = null;
+        header.setAttribute("aria-expanded", "false");
+      }
+    };
+
+    header.addEventListener("click", (e) => {
+      e.preventDefault();
+      toggleAccordion();
+    });
+
+    header.addEventListener("keydown", (e) => {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        toggleAccordion();
+      }
+    });
+
+    // Explore Track Button inside accordion content
+    if (btn) {
+      btn.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        selectCategory(category);
+        scrollToProjectSection();
+      });
+    }
+  });
+
+  // Run initial sync
+  syncLearningMapWithFilter(activeFilter);
+}
+
+function syncLearningMapWithFilter(category) {
+  const mapContainer = document.getElementById("learningMapContainer");
+  if (!mapContainer) return;
+
+  const svgElement = mapContainer.querySelector(".learning-map-svg");
+  const svgNodes = mapContainer.querySelectorAll(".map-node");
+  const accordionItems = mapContainer.querySelectorAll(".accordion-item");
+
+  const connUiTool = document.getElementById("conn-ui-tool");
+  const connToolApi = document.getElementById("conn-tool-api");
+  const connApiClone = document.getElementById("conn-api-clone");
+  const connCloneGame = document.getElementById("conn-clone-game");
+
+  // Deactivate all connections first
+  [connUiTool, connToolApi, connApiClone, connCloneGame].forEach((conn) => {
+    if (conn) conn.classList.remove("active");
+  });
+
+  if (!category || category === "all") {
+    // Neutral state: no active node
+    if (svgElement) svgElement.classList.remove("has-active-node");
+    
+    svgNodes.forEach((node) => node.classList.remove("active"));
+    
+    accordionItems.forEach((item) => {
+      item.classList.remove("active", "expanded");
+      const content = item.querySelector(".accordion-content");
+      if (content) content.style.maxHeight = null;
+      const header = item.querySelector(".accordion-header");
+      if (header) header.setAttribute("aria-expanded", "false");
+    });
+    return;
+  }
+
+  // Active category node highlight
+  if (svgElement) svgElement.classList.add("has-active-node");
+
+  // Synchronize SVG nodes
+  svgNodes.forEach((node) => {
+    const nodeCat = node.getAttribute("data-category");
+    if (nodeCat === category) {
+      node.classList.add("active");
+    } else {
+      node.classList.remove("active");
+    }
+  });
+
+  // Synchronize mobile accordion items
+  accordionItems.forEach((item) => {
+    const itemCat = item.getAttribute("data-category");
+    const content = item.querySelector(".accordion-content");
+    const header = item.querySelector(".accordion-header");
+    
+    if (itemCat === category) {
+      item.classList.add("active", "expanded");
+      if (content) content.style.maxHeight = content.scrollHeight + "px";
+      if (header) header.setAttribute("aria-expanded", "true");
+    } else {
+      item.classList.remove("active", "expanded");
+      if (content) content.style.maxHeight = null;
+      if (header) header.setAttribute("aria-expanded", "false");
+    }
+  });
+
+  // Connect sequential lines based on the selected learning journey stage
+  if (category === "tool" || category === "api" || category === "clone" || category === "game") {
+    if (connUiTool) connUiTool.classList.add("active");
+  }
+  if (category === "api" || category === "clone" || category === "game") {
+    if (connToolApi) connToolApi.classList.add("active");
+  }
+  if (category === "clone" || category === "game") {
+    if (connApiClone) connApiClone.classList.add("active");
+  }
+  if (category === "game") {
+    if (connCloneGame) connCloneGame.classList.add("active");
+  }
+}

--- a/style.css
+++ b/style.css
@@ -12,6 +12,12 @@
   --glass-border: rgba(255, 255, 255, 0.07);
   --gradient-1: linear-gradient(135deg, #00ff88, #00cfff);
   --transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+  /* Learning Map tracks - Dark mode */
+  --track-ui: #3b82f6;
+  --track-tool: #10b981;
+  --track-api: #06b6d4;
+  --track-clone: #f59e0b;
+  --track-game: #a855f7;
 }
 
 :root {
@@ -58,6 +64,12 @@ body.light-mode {
   --glass-bg: rgba(0, 0, 0, 0.03);
   --glass-border: rgba(0, 0, 0, 0.08);
   --gradient-1: linear-gradient(135deg, #008f4c, #007699);
+  /* Learning Map tracks - Light mode */
+  --track-ui: #2563eb;
+  --track-tool: #059669;
+  --track-api: #0891b2;
+  --track-clone: #d97706;
+  --track-game: #8b5cf6;
 }
 
 :root[data-theme="sepia"] {
@@ -79,6 +91,12 @@ body.light-mode {
   --glass-bg: rgba(253, 246, 227, 0.85);      /* High-contrast background for navbar */
   --glass-border: rgba(67, 52, 34, 0.15);
   --gradient-1: linear-gradient(135deg, #cb4b16, #b58900);
+  /* Learning Map tracks - Sepia mode */
+  --track-ui: #268bd2;
+  --track-tool: #859900;
+  --track-api: #2aa198;
+  --track-clone: #cb4b16;
+  --track-game: #d33682;
 }
 
 :root[data-theme="cyberpunk"] {
@@ -100,6 +118,12 @@ body.light-mode {
   --glass-bg: rgba(255, 0, 60, 0.05);
   --glass-border: rgba(255, 0, 60, 0.2);
   --gradient-1: linear-gradient(135deg, #ff003c, #fcee0a);
+  /* Learning Map tracks - Cyberpunk mode */
+  --track-ui: #00ff9f;
+  --track-tool: #00f0ff;
+  --track-api: #ff007f;
+  --track-clone: #ff003c;
+  --track-game: #fcee0a;
 }
 
 :root[data-theme="nord"] {
@@ -121,6 +145,12 @@ body.light-mode {
   --glass-bg: rgba(236, 239, 244, 0.03);
   --glass-border: rgba(236, 239, 244, 0.08);
   --gradient-1: linear-gradient(135deg, #81a1c1, #5e81ac);
+  /* Learning Map tracks - Nord mode */
+  --track-ui: #88c0d0;
+  --track-tool: #8fbcbb;
+  --track-api: #a3be8c;
+  --track-clone: #ebcb8b;
+  --track-game: #b48ead;
 }
 
 /* ============================================================
@@ -3588,5 +3618,359 @@ body.custom-cursor-active .cursor-ring.is-visible {
   width: 38px;
   height: 38px;
   border-radius: 10px;
+}
+
+/* ============================================================
+   LEARNING MAP COMPONENT
+   ============================================================ */
+
+.learning-map-container {
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  margin: 1.5rem 0 2rem 0;
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+  position: relative;
+  overflow: hidden;
+}
+
+.learning-map-container::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 2px;
+  background: linear-gradient(90deg, var(--track-ui), var(--track-tool), var(--track-api), var(--track-clone), var(--track-game));
+  opacity: 0.7;
+}
+
+.learning-map-header {
+  margin-bottom: 1.25rem;
+  text-align: left;
+}
+
+.learning-map-header h3 {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.learning-map-header h3 i {
+  color: var(--accent);
+  filter: drop-shadow(0 0 4px var(--accent-glow));
+}
+
+.learning-map-header p {
+  font-family: 'Inter Tight', sans-serif;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+/* SVG Map Wrap */
+.learning-map-svg-wrap {
+  width: 100%;
+  overflow: visible;
+  padding: 1rem 0;
+}
+
+.learning-map-svg {
+  width: 100%;
+  height: auto;
+  overflow: visible;
+  display: block;
+}
+
+/* Connection Lines */
+.map-connection-line {
+  fill: none;
+  stroke: var(--border-hover);
+  stroke-width: 4px;
+  stroke-linecap: round;
+  stroke-dasharray: 8 6;
+  transition: stroke 0.4s var(--ease), stroke-width 0.4s var(--ease), stroke-dasharray 0.4s var(--ease), filter 0.4s var(--ease);
+}
+
+.map-connection-line.active {
+  stroke-dasharray: none;
+  stroke-width: 5px;
+  filter: drop-shadow(0 0 4px rgba(255, 255, 255, 0.2));
+}
+
+/* Specific Connection Gradients via code fallback or static track colors */
+.map-connection-line.active-ui-tool { stroke: var(--track-tool); }
+.map-connection-line.active-tool-api { stroke: var(--track-api); }
+.map-connection-line.active-api-clone { stroke: var(--track-clone); }
+.map-connection-line.active-clone-game { stroke: var(--track-game); }
+
+/* SVG Nodes */
+.map-node {
+  cursor: pointer;
+  outline: none;
+}
+
+.map-node .node-outer {
+  fill: var(--bg-elevated);
+  stroke: var(--glass-border);
+  stroke-width: 3px;
+  transition: stroke 0.3s var(--ease), r 0.3s var(--ease), filter 0.3s var(--ease);
+}
+
+.map-node .node-inner {
+  transition: r 0.3s var(--ease), fill-opacity 0.3s var(--ease), filter 0.3s var(--ease);
+  fill-opacity: 0.85;
+}
+
+/* Define node colors class */
+.map-node[data-category="ui"] .node-inner { fill: var(--track-ui); }
+.map-node[data-category="tool"] .node-inner { fill: var(--track-tool); }
+.map-node[data-category="api"] .node-inner { fill: var(--track-api); }
+.map-node[data-category="clone"] .node-inner { fill: var(--track-clone); }
+.map-node[data-category="game"] .node-inner { fill: var(--track-game); }
+
+/* SVG Text elements */
+.map-node .node-text-num {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  font-size: 14px;
+  fill: #ffffff;
+  text-anchor: middle;
+  dominant-baseline: middle;
+  pointer-events: none;
+}
+
+.map-node .node-title {
+  font-family: 'Inter Tight', sans-serif;
+  font-weight: 700;
+  font-size: 13.5px;
+  fill: var(--text-primary);
+  text-anchor: middle;
+  pointer-events: none;
+  filter: drop-shadow(0px 1px 3px rgba(0, 0, 0, 0.9));
+}
+
+.map-node .node-subtitle {
+  font-family: 'Inter Tight', sans-serif;
+  font-weight: 500;
+  font-size: 11px;
+  fill: var(--text-secondary);
+  text-anchor: middle;
+  pointer-events: none;
+  filter: drop-shadow(0px 1px 2px rgba(0, 0, 0, 0.9));
+}
+
+/* Hover and Active Node states */
+.map-node:hover .node-outer {
+  stroke: var(--text-primary);
+  stroke-width: 4px;
+  r: 39;
+}
+
+.map-node:hover .node-inner {
+  r: 29;
+}
+
+.map-node.active .node-outer {
+  stroke: var(--text-primary);
+  stroke-width: 5px;
+  r: 40;
+  animation: nodePulse 2s infinite var(--ease);
+}
+
+.map-node.active .node-inner {
+  r: 30;
+}
+
+.map-node[data-category="ui"].active .node-outer { filter: drop-shadow(0 0 10px var(--track-ui)); }
+.map-node[data-category="tool"].active .node-outer { filter: drop-shadow(0 0 10px var(--track-tool)); }
+.map-node[data-category="api"].active .node-outer { filter: drop-shadow(0 0 10px var(--track-api)); }
+.map-node[data-category="clone"].active .node-outer { filter: drop-shadow(0 0 10px var(--track-clone)); }
+.map-node[data-category="game"].active .node-outer { filter: drop-shadow(0 0 10px var(--track-game)); }
+
+/* Faded state for nodes when another node is active */
+.learning-map-svg.has-active-node .map-node:not(.active) {
+  opacity: 0.45;
+  transition: opacity 0.3s ease;
+}
+
+.learning-map-svg.has-active-node .map-node.active {
+  opacity: 1;
+  transition: opacity 0.3s ease;
+}
+
+/* Animations */
+@keyframes nodePulse {
+  0% {
+    stroke-width: 5px;
+    stroke-opacity: 1;
+  }
+  50% {
+    stroke-width: 9px;
+    stroke-opacity: 0.65;
+  }
+  100% {
+    stroke-width: 5px;
+    stroke-opacity: 1;
+  }
+}
+
+/* Mobile Accordion (Hidden by default on desktop) */
+.learning-map-mobile-accordion {
+  display: none;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.accordion-item {
+  background: var(--bg-elevated);
+  border: 1px solid var(--glass-border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.accordion-item:hover {
+  border-color: var(--border-hover);
+}
+
+.accordion-item.active {
+  border-color: var(--border-accent);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+
+.accordion-header {
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  user-select: none;
+}
+
+.accordion-header .track-num {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 700;
+  font-size: 1.1rem;
+  padding: 4px 8px;
+  border-radius: 4px;
+  background: var(--glass-bg);
+  margin-right: 12px;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+/* Custom numbers color for mobile steps */
+.accordion-item[data-category="ui"] .track-num { color: var(--track-ui); }
+.accordion-item[data-category="tool"] .track-num { color: var(--track-tool); }
+.accordion-item[data-category="api"] .track-num { color: var(--track-api); }
+.accordion-item[data-category="clone"] .track-num { color: var(--track-clone); }
+.accordion-item[data-category="game"] .track-num { color: var(--track-game); }
+
+.accordion-item[data-category="ui"].active .track-num { background: var(--track-ui); color: #fff; }
+.accordion-item[data-category="tool"].active .track-num { background: var(--track-tool); color: #fff; }
+.accordion-item[data-category="api"].active .track-num { background: var(--track-api); color: #fff; }
+.accordion-item[data-category="clone"].active .track-num { background: var(--track-clone); color: #fff; }
+.accordion-item[data-category="game"].active .track-num { background: var(--track-game); color: #fff; }
+
+.accordion-header .track-info {
+  flex-grow: 1;
+  text-align: left;
+}
+
+.accordion-header .track-info h4 {
+  font-family: 'Inter Tight', sans-serif;
+  font-weight: 700;
+  font-size: 1rem;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.accordion-header .track-info .track-tag {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+.accordion-header .arrow-icon {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  transition: transform 0.25s var(--ease);
+}
+
+.accordion-item.expanded .arrow-icon {
+  transform: rotate(90deg);
+  color: var(--text-primary);
+}
+
+.accordion-content {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.25s var(--ease);
+  background: rgba(0, 0, 0, 0.12);
+}
+
+.accordion-body {
+  padding: 1rem;
+  border-top: 1px solid var(--glass-border);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.accordion-body p {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.accordion-btn {
+  align-self: flex-start;
+  padding: 0.5rem 1rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--glass-border);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.accordion-item[data-category="ui"] .accordion-btn { border-color: rgba(59, 130, 246, 0.45); color: var(--track-ui); }
+.accordion-item[data-category="tool"] .accordion-btn { border-color: rgba(16, 185, 129, 0.45); color: var(--track-tool); }
+.accordion-item[data-category="api"] .accordion-btn { border-color: rgba(6, 182, 212, 0.45); color: var(--track-api); }
+.accordion-item[data-category="clone"] .accordion-btn { border-color: rgba(245, 158, 11, 0.45); color: var(--track-clone); }
+.accordion-item[data-category="game"] .accordion-btn { border-color: rgba(168, 85, 247, 0.45); color: var(--track-game); }
+
+.accordion-item.active .accordion-btn {
+  background: var(--text-primary);
+  color: var(--bg-primary);
+  border-color: var(--text-primary);
+}
+
+/* Breakpoints */
+@media (max-width: 768px) {
+  .learning-map-svg-wrap {
+    display: none;
+  }
+  .learning-map-mobile-accordion {
+    display: flex;
+  }
+  .learning-map-container {
+    padding: 1.1rem;
+  }
 }
 


### PR DESCRIPTION

Implemented an interactive visual **Learning Path Map** component at the top of the project catalog. The map groups projects into five core tracks arranged as a sequential journey (Beginner HTML/CSS ➔ DOM & Interactive JS ➔ API Integrations ➔ Frontend Clones ➔ Advanced Canvas & Games) to help beginners navigate the catalog without feeling overwhelmed.

### Type of Change
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [ ]  New project addition
- [x]  New feature or UI/UX enhancement
- [ ]  Code refactoring / clean-up
- [ ]  Documentation update
- [ ] GitHub Workflow automation or DX improvements

---

## Changes Made

### 1. Theme-Aware Style Extensions
- Configured dynamic track properties (`--track-ui`, `--track-tool`, `--track-api`, `--track-clone`, `--track-game`) matching the design scheme of all site themes (Dark/Default, Light, Sepia, Cyberpunk, and Nord).
- Added SVG styling, glowing filters, active pulse keyframe animations, and hover scaling rules.

### 2. Markup Injections
- Embedded the custom SVG map structure featuring 5 keyboard-focusable nodes and connecting paths.
- Added a collapsible step-by-step accordion layout for mobile viewports.

### 3. Logic & Synchronizations
- Linked the learning map's visual highlight state directly into the catalog filter loop.
- Programmed interactive event listeners on both SVG nodes and accordion headers.
- Implemented sequential connection line lighting to visually suggest the stage of progress in the learning journey.

---

##  Verification & Testing

- Verified visual rendering and interactivity across all 5 themes.
- Checked responsiveness (SVG hides and step-accordion list shows below 768px).
- Confirmed correct keyboard focus management and navigation (`Enter` / `Space` activation).
- Inspected the browser console during navigation to ensure no warnings or errors.
