### PR TITLE
Fix #10187: Add missing title tag to Well project

### DIFF
--- a/public/Well/index.html
+++ b/public/Well/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Well | 100 Days 100 Web Projects</title>
     <style>
       body {
         margin: 0;


### PR DESCRIPTION
This PR fixes issue #10187 by adding a proper <title> tag to the Well project page. It ensures the page displays a correct browser title and avoids fallback title behavior.