### PR TITLE
fix: remove 7 broken nav links in particle-wave-animation

### DIFF
--- a/public/particle-wave-animation/index.html
+++ b/public/particle-wave-animation/index.html
@@ -163,10 +163,6 @@ window.addEventListener(
             <div class="footer-column">
                 <h3>Quick Links</h3>
                 <ul>
-                    <li><a href="animated-cursor.html">Home</a></li>
-                    <li><a href="projects.html">Projects</a></li>
-                    <li><a href="docs.html">Docs</a></li>
-                    <li><a href="contact.html">Contact</a></li>
                 </ul>
             </div>
 
@@ -174,9 +170,6 @@ window.addEventListener(
                 <h3>Resources</h3>
                 <ul>
                     <li><a href="#">GitHub Repository</a></li>
-                    <li><a href="design-assets.html">Design Assets</a></li>
-                    <li><a href="api-references.html">API References</a></li>
-                    <li><a href="community.html">Community Forum</a></li>
                 </ul>
             </div>
 


### PR DESCRIPTION
Fixes #10180

## Description
public/particle-wave-animation/index.html contained 7 navigation
links pointing to pages that do not exist in the project folder.
The only files present are index.html and style.css — there are
no animated-cursor.html, projects.html, docs.html, contact.html,
design-assets.html, api-references.html, or community.html files.
Clicking any nav link resulted in a 404 error.

## Fix
Removed all 7 broken nav links (Home, Projects, Docs, Contact,
Design Assets, API References, Community Forum) since none of
the target pages exist in the project folder.

## Checklist
- [x] Tested locally
- [x] No new console errors
- [x] Follows existing code style