### PR TITLE
 fix: remove broken icons.html and contact.html nav links in Social Media Glowing

### DIFF
--- a/public/Social Media Glowing/index.html
+++ b/public/Social Media Glowing/index.html
@@ -32,10 +32,8 @@
         <a href="index.html">Home</a>
       </li>
       <li>
-        <a href="icons.html">Icons</a>
       </li>
       <li>
-        <a href="contact.html">Contact</a>
       </li>
 
     </ul>


### PR DESCRIPTION
Fixes #10181

## Description
public/Social Media Glowing/index.html contained two navigation
links pointing to pages that do not exist in the project folder.
The "Icons" link pointed to icons.html and the "Contact" link
pointed to contact.html, but neither file exists — only
index.html, glow.css, and style.css are present. Clicking
either nav link resulted in a 404 error.

## Fix
Removed both broken nav links (Icons and Contact) since neither
icons.html nor contact.html exist in the project folder.

## Checklist
- [x] Tested locally
- [x] No new console errors
- [x] Follows existing code style