### PR TITLE
fix: correct homepage.html link to index.html in RouteMaster

### DIFF
--- a/public/RouteMaster/map.html
+++ b/public/RouteMaster/map.html
@@ -12,7 +12,7 @@
 
 <!-- NAV -->
 <nav>
-  <a class="nav-logo" href="homepage.html">
+  <a class="nav-logo" href="index.html">
     <div class="logo-icon"><i aria-hidden="true" class="fas fa-location-crosshairs"></i></div>
     <span>Way<span class="dot">Finder</span></span>
   </a>

--- a/public/RouteMaster/navigation.html
+++ b/public/RouteMaster/navigation.html
@@ -12,7 +12,7 @@
 
 <!-- TOP BAR -->
 <header class="top-bar">
-  <a class="nav-logo" href="homepage.html">
+  <a class="nav-logo" href="index.html">
     <div class="logo-icon"><i aria-hidden="true" class="fas fa-location-crosshairs"></i></div>
     <span>Way<span class="dot">Finder</span></span>
   </a>


### PR DESCRIPTION
Fixes #10182

## Description
In public/RouteMaster/map.html and public/RouteMaster/navigation.html,
the navigation logo link pointed to homepage.html which does not
exist in the project folder. The actual homepage file is index.html.
Clicking the logo on these pages resulted in a 404 error instead
of navigating back to the home page.

## Fix
Replaced homepage.html with index.html in both map.html and
navigation.html so the logo correctly navigates back to the
RouteMaster homepage.

## Checklist
- [x] Tested locally
- [x] No new console errors
- [x] Follows existing code style