### PR TITLE
feat: add Back to Home navigation link on Weather App page

### DIFF
--- a/public/Weather App/index.html
+++ b/public/Weather App/index.html
@@ -55,6 +55,8 @@
             
             <header class="dashboard-header">
                 <div class="header-controls">
+                            <a href="../../index.html" class="back-home-btn" aria-label="Back to Home"> Back to Home</a>
+
                     <div class="unit-toggle">
                         <button id="celsiusBtn" class="active">°C</button>
                         <button id="fahrenheitBtn">°F</button>

--- a/public/Weather App/style.css
+++ b/public/Weather App/style.css
@@ -29,7 +29,23 @@ body.dark-theme {
     --shadow-sm: 0 1px 3px rgba(0,0,0,0.5);
     --shadow-md: 0 4px 6px -1px rgba(0,0,0,0.4);
 }
+.back-home-btn {
+    background-color: var(--bg-body);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-sm);
+    padding: 8px 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.9rem;
+    text-decoration: none;
+    color: inherit;
+    transition: background-color 0.2s ease;
+}
 
+.back-home-btn:hover {
+    background-color: var(--border-color);
+}
 /* =========================================================
    RESET & TYPOGRAPHY
    ========================================================= */


### PR DESCRIPTION
## 📝 Pull Request Description
### Related Issue
Closes #10236

### Summary
Added a "Back to Home" navigation link on the Weather App page, linking to the main project index.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added a "🏠 Back to Home" link in the dashboard header, pointing to `../../index.html` (main repo index)
- Created a dedicated `.back-home-btn` CSS class instead of reusing `.icon-btn` (which is a fixed 45×45px circular icon button not suited for text content), so the link renders correctly with proper padding and hover state

---

## 🧪 Testing and Verification
### Local Validation
- [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [x] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
*Before: no way to navigate back to main index. After: "🏠 Back to Home" link visible in the dashboard header, styled to match the existing theme.*

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.