### PR TITLE
fix: correct script reference from script.js to app.js in Crypto Tracker

### DIFF
--- a/public/Crypto Tracker & Market Analytics Dashboard/index.html
+++ b/public/Crypto Tracker & Market Analytics Dashboard/index.html
@@ -207,7 +207,7 @@
 
 </div>
 
-<script src="script.js"></script>
+<script src="app.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
Fixes #10358

## Description
public/Crypto Tracker & Market Analytics Dashboard/index.html
referenced script.js at line 210, but the actual JavaScript
file in the folder is app.js. This caused no JavaScript to
load, breaking all crypto tracking functionality completely.

## Fix
Changed <script src="script.js"> to <script src="app.js">
to match the actual filename in the project folder.

## Checklist
- [x] Tested locally
- [x] No new console errors
- [x] Follows existing code style