### PR TITLE
fix: correct image folder case from Img to img in Razorpay

### DIFF
--- a/public/Razorpay/index.html
+++ b/public/Razorpay/index.html
@@ -260,7 +260,7 @@
         <div class="w-full grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mt-12">
           <!--box 1-->
           <div class="w-full min-h-[15rem] relative cursor-pointer">
-            <img src="./Img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
+            <img src="./img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
           transition-all duration-200">
 
             <!--box shape-->
@@ -305,7 +305,7 @@
 
           <!--box 2-->
           <div class="w-full min-h-[15rem] relative cursor-pointer">
-            <img src="./Img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
+            <img src="./img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
           transition-all duration-200">
 
             <!--box shape-->
@@ -349,7 +349,7 @@
 
           <!--box 3-->
           <div class="w-full min-h-[15rem] relative cursor-pointer">
-            <img src="./Img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
+            <img src="./img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
           transition-all duration-200">
 
             <!--box shape-->
@@ -393,7 +393,7 @@
 
           <!--box 4-->
           <div class="w-full min-h-[15rem] relative cursor-pointer">
-            <img src="./Img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
+            <img src="./img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
           transition-all duration-200">
 
             <!--box shape-->
@@ -435,7 +435,7 @@
           </div>
           <!--box 5-->
           <div class="w-full min-h-[15rem] relative cursor-pointer">
-            <img src="./Img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
+            <img src="./img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
           transition-all duration-200">
 
             <!--box shape-->
@@ -478,7 +478,7 @@
 
           <!--box 6-->
           <div class="w-full min-h-[15rem] relative cursor-pointer">
-            <img src="./Img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
+            <img src="./img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
           transition-all duration-200">
 
             <!--box shape-->
@@ -530,7 +530,7 @@
 
 
     <!--features section 2 start -->
-    <section class="bg-[url(./Img/feature-section-2BG.svg)] bg-no-repeat bg-cover pb-[500px] mt-14 pt-[20rem]">
+    <section class="bg-[url(./img/feature-section-2BG.svg)] bg-no-repeat bg-cover pb-[500px] mt-14 pt-[20rem]">
 
       <div class="w-10/12 max-w-[1080px] mx-auto relative pt-4">
 
@@ -624,7 +624,7 @@
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 w-full gap-4 my-14">
           <!--box 1-->
           <div class="w-full min-h-[15rem] relative cursor-pointer">
-            <img src="./Img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
+            <img src="./img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
           transition-all duration-200">
 
             <!--box shape-->
@@ -666,7 +666,7 @@
           </div>
           <!--box 2-->
           <div class="w-full min-h-[15rem] relative cursor-pointer">
-            <img src="./Img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
+            <img src="./img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
           transition-all duration-200">
 
             <!--box shape-->
@@ -709,7 +709,7 @@
 
           <!--box 3-->
           <div class="w-full min-h-[15rem] relative cursor-pointer">
-            <img src="./Img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
+            <img src="./img/payment-link-icon.svg" alt="" class="bg-lightBlue absolute right-3 top-3 w-12 h-12 rounded-full z-[8]
           transition-all duration-200">
 
             <!--box shape-->
@@ -806,7 +806,7 @@
         bg-no-repeat hover:scale-105 transition-all duration-200  border shadow-lg
         hover:bg-[url(/Images/instant-settlement-bghover.svg)]
         bg-white">
-            <img src="./Img/razorpayXicon.svg" alt="" class="w-10 h-10">
+            <img src="./img/razorpayXicon.svg" alt="" class="w-10 h-10">
             <h3 class="font-mullish text-lg font-bold pt-4">Corporate Cards</h3>
             <p class="font-mullish py-3 text-grayText leading-normal">Simplify your recurring, international and team
               expenses with savings on every spend. Save upto 10 lacs every month.</p>
@@ -824,7 +824,7 @@
          bg-no-repeat hover:scale-105 transition-all duration-200  border shadow-lg
          hover:bg-[url(/Images/instant-settlement-bghover.svg)]
          bg-white">
-            <img src="./Img/razorpayXicon.svg" alt="" class="w-10 h-10">
+            <img src="./img/razorpayXicon.svg" alt="" class="w-10 h-10">
             <h3 class="font-mullish text-lg font-bold pt-4">Corporate Cards</h3>
             <p class="font-mullish py-3 text-grayText leading-normal">Simplify your recurring, international and team
               expenses with savings on every spend. Save upto 10 lacs every month.</p>
@@ -842,7 +842,7 @@
          bg-no-repeat hover:scale-105 transition-all duration-200  border shadow-lg
          hover:bg-[url(/Images/instant-settlement-bghover.svg)]
          bg-white">
-            <img src="./Img/razorpayXicon.svg" alt="" class="w-10 h-10">
+            <img src="./img/razorpayXicon.svg" alt="" class="w-10 h-10">
             <h3 class="font-mullish text-lg font-bold pt-4">Corporate Cards</h3>
             <p class="font-mullish py-3 text-grayText leading-normal">Simplify your recurring, international and team
               expenses with savings on every spend. Save upto 10 lacs every month.</p>
@@ -860,7 +860,7 @@
          bg-no-repeat hover:scale-105 transition-all duration-200 border shadow-lg
          hover:bg-[url(/Images/instant-settlement-bghover.svg)]
          bg-white">
-            <img src="./Img/razorpayXicon.svg" alt="" class="w-10 h-10">
+            <img src="./img/razorpayXicon.svg" alt="" class="w-10 h-10">
             <h3 class="font-mullish text-lg font-bold pt-4">Corporate Cards</h3>
             <p class="font-mullish py-3 text-grayText leading-normal">Simplify your recurring, international and team
               expenses with savings on every spend. Save upto 10 lacs every month.</p>
@@ -877,7 +877,7 @@
          bg-no-repeat hover:scale-105 transition-all duration-200 border shadow-lg
          hover:bg-[url(/Images/instant-settlement-bghover.svg)]
          bg-white">
-            <img src="./Img/razorpayXicon.svg" alt="" class="w-10 h-10">
+            <img src="./img/razorpayXicon.svg" alt="" class="w-10 h-10">
             <h3 class="font-mullish text-lg font-bold pt-4">Corporate Cards</h3>
             <p class="font-mullish py-3 text-grayText leading-normal">Simplify your recurring, international and team
               expenses with savings on every spend. Save upto 10 lacs every month.</p>
@@ -899,7 +899,7 @@
 
 
     <!--core feature section start -->
-    <section class="w-full bg-[url(/Img/core-features-sectionBg.svg)]
+    <section class="w-full bg-[url(/img/core-features-sectionBg.svg)]
   bg-no-repeat bg-cover bg-center mt-14 relative corefeaturesection">
       <div class="relative w-11/12 max-w-[1080px] mx-auto pt-4">
         <h2 class="font-mullish font-bold text-2xl text-center text-white">Features</h2>
@@ -1211,7 +1211,7 @@
       <!-- column - 1 -->
       <div class="flex flex-col md:max-w-[340px] lg:max-w-[260px]">
         <img alt=""
-          src="./Img/logo-dark.svg"
+          src="./img/logo-dark.svg"
           loading="lazy"
           width="120px"
           height="24px"
@@ -1269,14 +1269,14 @@
         </form>
         <div class="flex items-start space-x-4">
           <img alt=""
-            src="./Img/footer-certificate-1.png"
+            src="./img/footer-certificate-1.png"
             loading="lazy"
             width="92"
             height="40"
             class="cursor-pointer"
           />
           <img alt=""
-            src="./Img/footer-certificate-2.jpg"
+            src="./img/footer-certificate-2.jpg"
             loading="lazy"
             width="122"
             height="80"
@@ -1805,7 +1805,7 @@
               <li class="cursor-pointer">
                 <a>
                   <img alt=""
-                    src="./Img/facebook-icon.svg"
+                    src="./img/facebook-icon.svg"
                     width="24"
                     height="24"
                     loading="lazy"
@@ -1815,7 +1815,7 @@
               <li class="cursor-pointer">
                 <a>
                   <img alt=""
-                    src="./Img/twitter-icon.svg"
+                    src="./img/twitter-icon.svg"
                     width="24"
                     height="24"
                     loading="lazy"
@@ -1825,7 +1825,7 @@
               <li class="cursor-pointer">
                 <a>
                   <img alt=""
-                    src="./Img/instagram-icon.svg"
+                    src="./img/instagram-icon.svg"
                     width="24"
                     height="24"
                     loading="lazy"
@@ -1835,7 +1835,7 @@
               <li class="cursor-pointer">
                 <a>
                   <img alt=""
-                    src="./Img/github-icon.svg"
+                    src="./img/github-icon.svg"
                     width="24"
                     height="24"
                     loading="lazy"
@@ -1845,7 +1845,7 @@
               <li class="cursor-pointer">
                 <a>
                   <img alt=""
-                    src="./Img/linkedin-icon.svg"
+                    src="./img/linkedin-icon.svg"
                     width="24"
                     height="24"
                     loading="lazy"


### PR DESCRIPTION

Fixes #10465

## Description
public/Razorpay/index.html referenced images using ./Img/ (capital I)
but the actual folder on disk is img/ (lowercase). On case-sensitive
servers like Vercel/Linux this caused all affected images to 404.
Fixed all occurrences including both src attributes and CSS
background-url references.

## Fix
Replaced all ./Img/ and /Img/ references with ./img/ and /img/
to match the actual folder name on disk.

## Checklist
- [x] Tested locally
- [x] No new console errors
- [x] Follows existing code style