### PR TITLE
fix: replace missing my-channel.jpeg with existing channel-1.jpeg in …

### DIFF
--- a/public/youtube clone/index.html
+++ b/public/youtube clone/index.html
@@ -275,7 +275,7 @@
         </div>
 
         <div class="avatar-container">
-          <img class="user-avatar" src="channel-pictures/my-channel.jpeg" alt="User Profile"
+          <img class="user-avatar" src="channel-pictures/channel-1.jpeg" alt="User Profile"
                onerror="this.src='https://ui-avatars.com/api/?name=P&background=cc0000&color=fff&rounded=true'">
         </div>
       </div>


### PR DESCRIPTION
Fixes #10466

## Description
public/youtube clone/index.html referenced channel-pictures/my-channel.jpeg
but this file does not exist in the channel-pictures folder. Only
channel-1.jpeg through channel-5.jpeg exist. This caused the channel
profile picture to show as a broken image.

## Fix
Replaced the reference to my-channel.jpeg with the existing
channel-1.jpeg so the channel profile picture renders correctly.

## Checklist
- [x] Tested locally
- [x] No new console errors
- [x] Follows existing code style