### PR TITLE
fix: reject invalid guesses before counting them (#10334)

### DIFF
--- a/public/Number Guessing Game/GuessNumber.js
+++ b/public/Number Guessing Game/GuessNumber.js
@@ -23,15 +23,27 @@ if(playGame){
 }
 
 function validateGuess(guess){
+    // Bail out on invalid input BEFORE incrementing any counter or writing
+    // to the guessed list. The old chain used `} if (` (not `else if`) so
+    // execution fell through and every invalid input still ran displayGuess
+    // + checkGuess, burning a guess and printing "NaN" into the tray
+    // (issue #10334).
     if(isNaN(guess)){
         alert("Please enter a valid number")
-    } else if(guess<=0){
+        return
+    }
+    if(guess<=0){
         alert("Please enter a number greater than 0")
-    } else if(guess>100){
+        return
+    }
+    if(guess>100){
         alert("Please enter a number less than 100")
-    } else {
-        prevGuess.push(guess)
-    } if(numGuess>10){
+        return
+    }
+
+    prevGuess.push(guess)
+
+    if(numGuess>10){
         displayGuess(guess)
         displayMessage(`Game Over. Random Number Was ${randomNumber}`)
         endGame()


### PR DESCRIPTION
### Summary

\`validateGuess\` used a broken \`} if (numGuess>10)\` chain instead of \`} else if(...)\`. The closing \`}\` before the second \`if\` ended the validation block, so every invalid input (NaN, empty, ≤0, >100) showed an alert and then fell through into \`displayGuess\` + \`checkGuess\`, which incremented \`numGuess\`, wrote \`"NaN"\` into the guessed-list, and burned one of the 10 allotted guesses.

Repro: type \`abc\` and click Guess. Alert fires, but \`NaN\` still lands in the guessed row and the remaining counter drops from 10 to 9. Do it 10 times → game over without a single legit guess.

### What changed

Restructured \`validateGuess\` so each bounds-check \`return\`s early. Only run \`displayGuess\` / game-over / \`checkGuess\` when validation passes. 17 lines added, 5 removed.

### Test plan

- [x] type \`abc\` → alert fires, remaining stays at 10, guessed list stays empty
- [x] leave input blank → same
- [x] type \`0\` and \`101\` → both rejected without counting
- [x] type a real valid number → still works normally

Fixes #10334