### PR TITLE
fix: correct Focus Time and Pomodoros stat filters in CountDown Timer (#10335)

### DIFF
--- a/public/CountDown Timer/script.js
+++ b/public/CountDown Timer/script.js
@@ -522,8 +522,13 @@ document.addEventListener('fullscreenchange', () => {
 // =============================================
 function openStats() {
   const total = sessionHistory.length;
+  // Focus Time = work-phase pomodoros + Custom timers. Pomodoro rows are
+  // stored as `Pomodoro work` / `Pomodoro break` / `Pomodoro longbreak` at
+  // save time (line 227), so the old filter `s.type.includes('Focus')` never
+  // matched any pomodoro row and Focus Time was capped at Custom-only.
+  // See issue #10335.
   const totalFocusMs = sessionHistory
-    .filter(s => s.type.includes('Focus') || s.type === 'Custom')
+    .filter(s => s.type === 'Custom' || s.type === 'Pomodoro work')
     .reduce((sum, s) => {
       const parts = s.duration.split(':').map(Number);
       const secs = parts.length === 3
@@ -532,7 +537,10 @@ function openStats() {
       return sum + secs;
     }, 0);
 
-  const pomoSessions = sessionHistory.filter(s => s.type.includes('Pomodoro')).length;
+  // Only work phases count as pomodoros. The old `includes('Pomodoro')`
+  // filter also matched `Pomodoro break` and `Pomodoro longbreak`, so one
+  // work + one short break made the counter say "2 pomodoros".
+  const pomoSessions = sessionHistory.filter(s => s.type === 'Pomodoro work').length;
 
   els.statsGrid.innerHTML = [
     ['📅', 'Total Sessions', total],


### PR DESCRIPTION
### Summary

Two related bugs in the Pomodoro stats overlay:

1. **Focus Time was capped at Custom timers only.** \`handleTimerComplete\` saves pomodoro rows as \`Pomodoro work\` / \`Pomodoro break\` / \`Pomodoro longbreak\`. None of those strings contain \`"Focus"\`, so \`s.type.includes('Focus')\` never matched anything and the entire point of Pomodoro (deep-focus tracking) was missing from the Focus Time card.

2. **Pomodoros counter was inflated by breaks.** \`s.type.includes('Pomodoro')\` matched work AND break AND longbreak. A single 25/5 work+break cycle showed the counter as \`2 pomodoros\`.

### What changed

- Focus Time filter → \`s.type === 'Custom' || s.type === 'Pomodoro work'\`
- Pomodoros counter filter → \`s.type === 'Pomodoro work'\`

Explicit type matching, no fragile substring includes. 10 lines added, 2 removed.

### Scope note

The issue also proposed skipping the \`sessionHistory.unshift(session)\` call in \`handleTimerComplete\` when the phase is a break. That's a data-layer change vs the stat-calculation fix here — happy to open as a follow-up if you'd like. This PR is narrow to the statistical correctness.

### Test plan

- [x] verified pomodoro rows are stored as \`Pomodoro work\` / \`Pomodoro break\` / \`Pomodoro longbreak\`
- [ ] once approved: run 1 work + 1 short break → confirm Focus Time shows the 25-min work, Pomodoros shows \`1\` (not \`2\`)

Fixes #10335