### PR TITLE
Fix: Memory leak from route change (#10402)

### DIFF
--- a/public/live-code-playground/script.js
+++ b/public/live-code-playground/script.js
@@ -496,35 +496,35 @@ const setupEventListeners = () => {
     button.addEventListener('click', () => togglePanel(button.dataset.collapse, button));
   });
 
-window.addEventListener('message', (event) => {
-  const previewFrame = elements.previewFrame;
+  const handleMessage = (event) => {
+    const previewFrame = elements.previewFrame;
 
-  // Ensure iframe exists
-  if (!previewFrame?.contentWindow) return;
+    // Ensure iframe exists
+    if (!previewFrame?.contentWindow) return;
 
-  // Accept messages only from the sandbox preview iframe
-  if (event.source !== previewFrame.contentWindow) return;
+    // Accept messages only from the sandbox preview iframe
+    if (event.source !== previewFrame.contentWindow) return;
 
-  const data = event.data;
+    const data = event.data;
 
-  // Validate payload
-  if (!data || data.source !== 'live-code-playground') return;
+    // Validate payload
+    if (!data || data.source !== 'live-code-playground') return;
 
-  // Allow only expected console levels
-  const allowedLevels = ['log', 'warn', 'error', 'info'];
+    // Allow only expected console levels
+    const allowedLevels = ['log', 'warn', 'error', 'info'];
 
-  const level = allowedLevels.includes(data.level)
-    ? data.level
-    : 'log';
+    const level = allowedLevels.includes(data.level)
+      ? data.level
+      : 'log';
 
-  const values = Array.isArray(data.values)
-    ? data.values
-    : [];
+    const values = Array.isArray(data.values)
+      ? data.values
+      : [];
 
-  appendConsoleLine(level, values);
-});
+    appendConsoleLine(level, values);
+  };
 
-  window.addEventListener('keydown', (event) => {
+  const handleKeydown = (event) => {
     const modifierPressed = event.ctrlKey || event.metaKey;
     if (!modifierPressed) return;
 
@@ -538,9 +538,18 @@ window.addEventListener('message', (event) => {
       event.preventDefault();
       resetPlayground();
     }
-  });
+  };
 
+  window.addEventListener('message', handleMessage);
+  window.addEventListener('keydown', handleKeydown);
   window.addEventListener('beforeunload', saveState);
+
+  // Return a cleanup function to prevent memory leaks on unmount or route change
+  return () => {
+    window.removeEventListener('message', handleMessage);
+    window.removeEventListener('keydown', handleKeydown);
+    window.removeEventListener('beforeunload', saveState);
+  };
 };
 
 const cacheElements = () => {


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #10402

### Summary
Resolves a memory leak occurring on route change/unmount in the Live Code Playground by refactoring global `window` event listeners. Anonymous listeners were transformed into named functions (`handleMessage`, `handleKeydown`) and properly returned within a cleanup function to ensure they are unsubscribed correctly, preventing CPU/memory degradation over multiple navigations.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Transformed inline anonymous event handler for `message` events into a named `handleMessage` function in `public/live-code-playground/script.js`.
- Transformed inline anonymous event handler for `keydown` events into a named `handleKeydown` function in `public/live-code-playground/script.js`.
- Returned a cleanup function from `setupEventListeners` that removes all global window listeners.

---

## 🧪 Testing and Verification

### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
*N/A*

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
