### PR TITLE
Fix: Intl.DateTimeFormat non-Gregorian locale bug (#10401)

### DIFF
--- a/public/CountDown Timer/script.js
+++ b/public/CountDown Timer/script.js
@@ -226,7 +226,7 @@ function handleTimerComplete() {
   const session = {
     type: state.mode === 'pomodoro' ? `Pomodoro ${state.pomoPhase}` : 'Custom',
     duration: formatSeconds(state.totalSeconds),
-    completedAt: new Date().toLocaleString(),
+    completedAt: new Date().toLocaleString(undefined, { calendar: 'gregory' }),
     timestamp: Date.now()
   };
   sessionHistory.unshift(session);

--- a/public/Pomodoro_Timer/script.js
+++ b/public/Pomodoro_Timer/script.js
@@ -66,7 +66,7 @@ function renderHistory() {
     // Group entries by date
     const groups = {};
     history.forEach(entry => {
-        const dateKey = new Date(entry.ts).toLocaleDateString(undefined, { weekday:'long', month:'short', day:'numeric' });
+        const dateKey = new Date(entry.ts).toLocaleDateString(undefined, { calendar: 'gregory', weekday:'long', month:'short', day:'numeric' });
         if (!groups[dateKey]) groups[dateKey] = [];
         groups[dateKey].push(entry);
     });
@@ -90,7 +90,7 @@ function renderHistory() {
 
             const typeEmoji = entry.type === 'pomodoro' ? '🍅' : entry.type === 'short' ? '☕' : '🌿';
             const typeLabel = entry.type === 'pomodoro' ? 'Focus' : entry.type === 'short' ? 'Short Break' : 'Long Break';
-            const time = new Date(entry.ts).toLocaleTimeString(undefined, { hour:'2-digit', minute:'2-digit' });
+            const time = new Date(entry.ts).toLocaleTimeString(undefined, { calendar: 'gregory', hour:'2-digit', minute:'2-digit' });
             const skippedTag = entry.skipped ? '<span class="history-tag-skipped">skipped</span>' : '';
             const taskTag = entry.taskName ? `<span class="history-task-name">${escHtml(entry.taskName)}</span>` : '';
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #10401

### Summary
Resolves an issue where `toLocaleDateString`, `toLocaleTimeString`, and `toLocaleString` APIs break or display incorrectly for users whose OS locale defaults to a non-Gregorian calendar (e.g., Islamic, Persian, Buddhist). By explicitly enforcing `{ calendar: 'gregory' }` in the options for date parsing and display, dates and day-of-week labels will consistently display as expected regardless of the underlying OS locale settings.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Modified `toLocaleDateString` and `toLocaleTimeString` calls in `public/Pomodoro_Timer/script.js` to include `{ calendar: 'gregory' }`.
- Modified `toLocaleString` call in `public/CountDown Timer/script.js` to include `{ calendar: 'gregory' }`.

---

## 🧪 Testing and Verification

### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [ ] Verified responsive layout on Mobile viewports (using DevTools)
- [ ] Verified responsive layout on Tablet viewports
- [ ] Keyboard navigation and focus outlines checked
- [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
*N/A*

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
