### PR TITLE
Fix CSP blocking blob and data URIs for image previews (#10399)

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
   script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://esm.sh;
   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com;
   font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com;
-  img-src 'self' data: https:;
+  img-src 'self' data: blob: https:;
   connect-src 'self' https: http: ws: wss:;
 "
     />


### PR DESCRIPTION
Closes #10399

## Description

The current Content Security Policy (CSP) does not allow `blob:` and `data:` sources in the `img-src` directive.

As a result, client-side image previews generated using `URL.createObjectURL()` or Base64 (`data:`) URLs fail to render, preventing users from previewing images before upload.

## Expected Behavior

- Client-generated image previews should display correctly.
- Existing CSP protections should remain intact while allowing safe image preview sources.

## Possible Solution

Update the Content Security Policy to allow `blob:` and `data:` for image sources:

```html
<meta
  http-equiv="Content-Security-Policy"
  content="img-src 'self' blob: data:;"
>
```

This enables local image previews without affecting other CSP directives.

## Fixes

- Restores client-side image previews.
- Supports both `blob:` and `data:` image sources.
- Maintains secure CSP behavior while improving usability.