### PR TITLE
Fix accessibility by adding focus rings to skipped interactive elements (#10390)

### DIFF
--- a/style.css
+++ b/style.css
@@ -1385,6 +1385,14 @@ body.light-mode .hero-terminal-text {
   flex-shrink: 0;
 }
 
+#sortProjects:focus-visible,
+#difficultyFilter:focus-visible,
+#techStackFilter:focus-visible {
+  outline: 3px solid #0ff26c;
+  outline-offset: 3px;
+  border-radius: 6px;
+}
+
 #sortProjects option,
 #difficultyFilter option,
 #techStackFilter option {


### PR DESCRIPTION
Closes #10390

## Description

Several interactive elements remove the browser's default focus outline using `outline: none` without providing an accessible replacement. As a result, keyboard users cannot easily determine which element is currently focused, making navigation difficult and reducing accessibility.

Affected controls include filter dropdowns such as:

- `#sortProjects`
- `#difficultyFilter`
- `#techStackFilter`

## Expected Behavior

- Interactive elements should display a visible focus indicator during keyboard navigation.
- Keyboard users should be able to identify the currently focused element.
- The application should follow WCAG accessibility guidelines.

## Possible Solution

Provide a custom focus style using `:focus-visible`:

```css
:focus-visible {
  outline: 2px solid var(--primary-color);
  outline-offset: 2px;
}
```

This restores keyboard accessibility while maintaining the project's visual design.

## Fixes

- Restores visible keyboard focus indicators.
- Improves accessibility for keyboard-only users.
- Enhances WCAG compliance without affecting mouse interactions.