### PR TITLE
feat: add keyboard shortcuts for showcase navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -303,7 +303,7 @@
             >
               All <span class="chip-count" id="allCount" aria-live="polite">Projects</span>
             </button>
-            <button
+            <button                 
               class="chip"
               data-filter="game"
               id="filterGame"
@@ -363,6 +363,17 @@
             >
               &times;
             </button>
+            <button
+              id="shortcutHelpBtn"
+              class="shortcut-help-btn"
+              type="button"
+              aria-label="Show keyboard shortcuts"
+              aria-haspopup="dialog"
+              aria-controls="shortcutHelpModal"
+              aria-expanded="false"
+            >
+              <i class="fas fa-keyboard" aria-hidden="true"></i>
+            </button>
             <select id="sortProjects" aria-label="Sort projects">
               <option value="default">Sort By</option>
               <option value="az">A-Z</option>
@@ -395,6 +406,33 @@
           <button id="clearAllFiltersBtn" class="clear-filters-btn" aria-label="Clear all filters">
             <i class="fas fa-filter-circle-xmark" aria-hidden="true"></i> Clear Filters
           </button>
+        </div>
+
+        <div class="shortcut-help-modal" id="shortcutHelpModal" role="dialog" aria-modal="true" aria-labelledby="shortcutHelpTitle" hidden>
+          <div class="shortcut-help-backdrop" data-close-modal="true"></div>
+          <div class="shortcut-help-panel">
+            <div class="shortcut-help-header">
+              <div>
+                <p class="section-label">Keyboard shortcuts</p>
+                <h3 id="shortcutHelpTitle">Navigate the showcase faster</h3>
+              </div>
+              <button
+                id="shortcutHelpCloseBtn"
+                class="view-all-btn"
+                type="button"
+                aria-label="Close keyboard shortcuts"
+              >
+                Close
+              </button>
+            </div>
+            <ul class="shortcut-help-list">
+              <li><span class="shortcut-key">/</span><span>Focus search</span></li>
+              <li><span class="shortcut-key">Esc</span><span>Clear search and remove selection</span></li>
+              <li><span class="shortcut-key">↑</span><span>Move to the previous visible project</span></li>
+              <li><span class="shortcut-key">↓</span><span>Move to the next visible project</span></li>
+              <li><span class="shortcut-key">Enter</span><span>Open the selected project</span></li>
+            </ul>
+          </div>
         </div>
 
         <div class="project-grid" id="projectGrid"></div>

--- a/index.js
+++ b/index.js
@@ -777,6 +777,8 @@ function renderGrid() {
   const noResults = document.getElementById("noResults");
   if (!grid) return;
 
+  clearKeyboardSelection();
+
   if (typeof updateClearFiltersBtnVisibility === "function") {
     updateClearFiltersBtnVisibility();
   }
@@ -1779,6 +1781,122 @@ function initTechStackSearch() {
    ============================================================ */
 const searchInput = document.getElementById("searchInput");
 const clearSearchBtn = document.getElementById("clearSearch");
+const shortcutHelpBtn = document.getElementById("shortcutHelpBtn");
+const shortcutHelpModal = document.getElementById("shortcutHelpModal");
+const shortcutHelpCloseBtn = document.getElementById("shortcutHelpCloseBtn");
+let keyboardSelectedCard = null;
+let keyboardSelectionIndex = -1;
+let lastFocusedShortcutTrigger = null;
+
+function isEditableTarget(target) {
+  if (!target) return false;
+
+  const element = target instanceof Element ? target : target.parentElement;
+  if (!element) return false;
+
+  return Boolean(
+    element.closest("input, textarea, [contenteditable=''], [contenteditable='true']"),
+  );
+}
+
+function clearKeyboardSelection() {
+  if (keyboardSelectedCard) {
+    keyboardSelectedCard.classList.remove("is-keyboard-selected");
+    keyboardSelectedCard.removeAttribute("aria-selected");
+  }
+
+  keyboardSelectedCard = null;
+  keyboardSelectionIndex = -1;
+}
+
+function getVisibleProjectCards() {
+  const grid = document.getElementById("projectGrid");
+  if (!grid) return [];
+
+  return Array.from(grid.querySelectorAll(".project-card.visible"));
+}
+
+function selectVisibleProjectCard(direction) {
+  const cards = getVisibleProjectCards();
+  if (!cards.length) {
+    clearKeyboardSelection();
+    return;
+  }
+
+  if (!keyboardSelectedCard) {
+    keyboardSelectionIndex = direction > 0 ? -1 : cards.length;
+  }
+
+  const nextIndex = keyboardSelectionIndex + direction;
+  const validIndex = Math.min(Math.max(nextIndex, 0), cards.length - 1);
+  const nextCard = cards[validIndex];
+
+  if (!nextCard) return;
+
+  if (keyboardSelectedCard && keyboardSelectedCard !== nextCard) {
+    keyboardSelectedCard.classList.remove("is-keyboard-selected");
+    keyboardSelectedCard.removeAttribute("aria-selected");
+  }
+
+  keyboardSelectedCard = nextCard;
+  keyboardSelectionIndex = validIndex;
+  keyboardSelectedCard.classList.add("is-keyboard-selected");
+  keyboardSelectedCard.setAttribute("aria-selected", "true");
+  keyboardSelectedCard.scrollIntoView({
+    block: "nearest",
+    behavior: "smooth",
+  });
+}
+
+function openCurrentlySelectedProject() {
+  const card = keyboardSelectedCard || getVisibleProjectCards()[0];
+  if (!card) return;
+
+  const primaryLink = card.querySelector(".open-project");
+  if (primaryLink) {
+    primaryLink.click();
+  } else {
+    card.click();
+  }
+}
+
+function closeShortcutHelpModal() {
+  if (!shortcutHelpModal) return;
+
+  shortcutHelpModal.hidden = true;
+  if (shortcutHelpBtn) {
+    shortcutHelpBtn.setAttribute("aria-expanded", "false");
+  }
+
+  if (lastFocusedShortcutTrigger && typeof lastFocusedShortcutTrigger.focus === "function") {
+    lastFocusedShortcutTrigger.focus({ preventScroll: true });
+  }
+}
+
+function openShortcutHelpModal() {
+  if (!shortcutHelpModal) return;
+
+  lastFocusedShortcutTrigger =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  shortcutHelpModal.hidden = false;
+  if (shortcutHelpBtn) {
+    shortcutHelpBtn.setAttribute("aria-expanded", "true");
+  }
+
+  shortcutHelpCloseBtn?.focus({ preventScroll: true });
+}
+
+function clearSearchInputAndApply() {
+  if (!searchInput) return;
+
+  searchInput.value = "";
+  searchQuery = "";
+  currentPage = 1;
+  clearKeyboardSelection();
+  renderGrid();
+  syncProjectCounts();
+  searchInput.focus();
+}
 
 function updateCategoryCounts(projects = PROJECTS) {
   const counts = {};
@@ -1848,19 +1966,78 @@ function syncProjectCounts() {
 
 if (searchInput && clearSearchBtn) {
   clearSearchBtn.addEventListener("click", () => {
-    searchInput.value = "";
-    searchInput.dispatchEvent(new Event("input"));
-    searchInput.focus();
+    clearSearchInputAndApply();
   });
 
   searchInput.addEventListener("keydown", (e) => {
     if (e.key === "Escape") {
-      searchInput.value = "";
-      searchInput.dispatchEvent(new Event("input"));
-      searchInput.focus();
+      e.preventDefault();
+      clearSearchInputAndApply();
     }
   });
 }
+
+if (shortcutHelpBtn && shortcutHelpModal) {
+  shortcutHelpBtn.addEventListener("click", () => {
+    if (shortcutHelpModal.hidden) {
+      openShortcutHelpModal();
+    } else {
+      closeShortcutHelpModal();
+    }
+  });
+
+  shortcutHelpCloseBtn?.addEventListener("click", closeShortcutHelpModal);
+
+  shortcutHelpModal.addEventListener("click", (e) => {
+    if (e.target instanceof HTMLElement && e.target.dataset.closeModal === "true") {
+      closeShortcutHelpModal();
+    }
+  });
+}
+
+document.addEventListener("keydown", (e) => {
+  const modalOpen = shortcutHelpModal && !shortcutHelpModal.hidden;
+
+  if (e.key === "Escape") {
+    if (modalOpen) {
+      e.preventDefault();
+      closeShortcutHelpModal();
+      return;
+    }
+
+    if (searchInput) {
+      e.preventDefault();
+      clearSearchInputAndApply();
+    }
+    return;
+  }
+
+  if (isEditableTarget(e.target)) return;
+
+  if (e.key === "/" && !e.metaKey && !e.ctrlKey && !e.altKey) {
+    e.preventDefault();
+    searchInput?.focus();
+    searchInput?.select?.();
+    return;
+  }
+
+  if (e.key === "ArrowDown") {
+    e.preventDefault();
+    selectVisibleProjectCard(1);
+    return;
+  }
+
+  if (e.key === "ArrowUp") {
+    e.preventDefault();
+    selectVisibleProjectCard(-1);
+    return;
+  }
+
+  if (e.key === "Enter" && keyboardSelectedCard) {
+    e.preventDefault();
+    openCurrentlySelectedProject();
+  }
+});
 
 /* ============================================================
    NAVBAR — dynamic based on login state

--- a/style.css
+++ b/style.css
@@ -1365,6 +1365,114 @@ body.light-mode .hero-terminal-text {
   max-width: 650px;
 }
 
+.shortcut-help-btn {
+  width: 42px;
+  height: 42px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: var(--t);
+}
+
+.shortcut-help-btn:hover,
+.shortcut-help-btn:focus-visible {
+  background: var(--bg-surface);
+  border-color: var(--border-accent);
+  color: var(--accent);
+}
+
+.shortcut-help-modal {
+  position: fixed;
+  inset: 0;
+  z-index: 1200;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.shortcut-help-modal[hidden] {
+  display: none;
+}
+
+.shortcut-help-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(3, 8, 20, 0.7);
+  backdrop-filter: blur(8px);
+}
+
+.shortcut-help-panel {
+  position: relative;
+  width: min(100%, 440px);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+  padding: 1.25rem;
+  z-index: 1;
+}
+
+.shortcut-help-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.shortcut-help-header h3 {
+  margin: 0.25rem 0 0;
+  color: var(--text-primary);
+  font-size: 1.05rem;
+}
+
+.shortcut-help-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.shortcut-help-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text-muted);
+}
+
+.shortcut-key {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 42px;
+  padding: 0.35rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(15, 242, 200, 0.14);
+  color: var(--accent);
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.8rem;
+  font-weight: 700;
+}
+
+.project-card.is-keyboard-selected {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+  box-shadow: 0 0 0 1px rgba(15, 242, 200, 0.2), 0 12px 28px rgba(15, 242, 200, 0.18);
+  transform: translateY(-2px);
+}
+
 #sortProjects,
 #difficultyFilter,
 #techStackFilter {


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #10497 

### Summary

Added keyboard shortcuts to improve navigation across the main showcase website. Users can now quickly focus the search bar, clear search results, navigate project cards using the keyboard, open projects with Enter, and view available shortcuts through a help modal.

### Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New project addition
- [✅] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made

- Added `/` shortcut to focus the search bar.
- Added `Esc` shortcut to clear the search and close the shortcuts modal.
- Added Arrow Up/Down navigation for visible project cards.
- Added `Enter` shortcut to open the selected project.
- Added a responsive keyboard shortcuts help modal.
- Improved keyboard accessibility and focus management.
- Preserved all existing mouse interactions and search functionality.

---

## 🧪 Testing and Verification

### Local Validation

- [✅] Ran `node scripts/validateProjects.js` successfully.

### Browser Compatibility

- [✅] Google Chrome
- [✅] Microsoft Edge

### Responsive & Accessibility

- [✅] Tested on desktop, tablet, and mobile.
- [✅] Verified keyboard-only navigation.
- [✅] Checked ARIA attributes and visible focus styles.

---

## 📷 Screenshots / Video Recording

Include screenshots showing:
1. Search bar focused using `/`.
2. Keyboard shortcuts help modal open.
3. Arrow-key selection highlighting a project card.
4. Opening a project with `Enter`.

---

## 🤝 Contributor Checklist

- [✅] My code follows the code style guidelines.
- [✅] I have performed a self-review.
- [✅] My changes introduce no console errors.
- [✅] There are no unrelated changes.