### PR TITLE
Fix: Service worker installs duplicate caches after deploy and serves stale assets #10395

### DIFF
--- a/public/Pomodoro-Garden/service-worker.js
+++ b/public/Pomodoro-Garden/service-worker.js
@@ -51,7 +51,7 @@ self.addEventListener('activate', (event) => {
             .then((keys) =>
                 Promise.all(
                     keys
-                        .filter((key) => key !== CACHE_VERSION)
+                        .filter((key) => key.startsWith('pg-') && key !== CACHE_VERSION)
                         .map((key) => caches.delete(key))
                 )
             )
@@ -69,51 +69,48 @@ self.addEventListener('fetch', (event) => {
 
     const url = new URL(request.url);
 
-    // Same-origin resources: cache-first
     if (url.origin === self.location.origin) {
         event.respondWith(
-            caches.match(request).then(async (cached) => {
-                if (cached) {
-                    return cached;
-                }
-
-                try {
-                    const response = await fetch(request);
-
-                    if (response && response.ok) {
-                        const cache = await caches.open(CACHE_VERSION);
-                        cache.put(request, response.clone());
+            caches.open(CACHE_VERSION).then((cache) =>
+                cache.match(request).then(async (cached) => {
+                    if (cached) {
+                        return cached;
                     }
 
-                    return response;
-                } catch (error) {
-                    console.error('Fetch failed:', error);
+                    try {
+                        const response = await fetch(request);
 
-                    if (request.mode === 'navigate') {
-                        return (
-                            (await caches.match('index.html')) ||
-                            new Response('Offline', {
-                                status: 503,
-                                statusText: 'Service Unavailable',
-                            })
-                        );
-                    }
+                        if (response && response.ok) {
+                            cache.put(request, response.clone());
+                        }
 
-                    return (
-                        cached ||
-                        new Response('Offline', {
+                        return response;
+                    } catch (error) {
+                        console.error('Fetch failed:', error);
+
+                        if (request.mode === 'navigate') {
+                            return (
+                                (await cache.match('index.html')) ||
+                                new Response('Offline', {
+                                    status: 503,
+                                    statusText: 'Service Unavailable',
+                                })
+                            );
+                        }
+
+                        return new Response('Offline', {
                             status: 503,
                             statusText: 'Service Unavailable',
-                        })
-                    );
-                }
-            }).catch((error) => {
-                console.error('Cache match failed:', error);
-                return new Response('Offline', {
-                    status: 503,
-                    statusText: 'Service Unavailable',
-                });
-            })
+                        });
+                    }
+                }).catch((error) => {
+                    console.error('Cache match failed:', error);
+                    return new Response('Offline', {
+                        status: 503,
+                        statusText: 'Service Unavailable',
+                    });
+                })
+            )
         );
 
         return;
@@ -133,7 +130,8 @@ self.addEventListener('fetch', (event) => {
             .catch(async (error) => {
                 console.error('Network request failed:', error);
 
-                const cached = await caches.match(request);
+                const cache = await caches.open(CACHE_VERSION);
+                const cached = await cache.match(request);
 
                 if (cached) {
                     return cached;


### PR DESCRIPTION
Closes #10395

## Description

The current service worker caches assets using cache names that are not scoped to individual projects. After new deployments, old caches may remain alongside newly created ones, causing stale assets to be served and increasing unnecessary storage usage.

Additionally, the cache cleanup logic during the `activate` event may remove unrelated caches or fail to remove outdated ones, resulting in inconsistent behavior across deployments.

## Expected Behavior

- Only the latest cache for the current project should remain active.
- Old project caches should be removed during activation.
- Users should always receive the latest deployed assets.

## Possible Solution

- Use project-specific and versioned cache names.
- Update the `activate` event to delete only outdated caches belonging to the current project.
- Ensure cache cleanup does not affect caches used by other projects.

## Fixes

- Prevents duplicate cache creation after deployments.
- Eliminates stale asset serving from outdated caches.
- Cleans up only obsolete caches while preserving caches for other projects.