### PR TITLE
fix: resolve SVG sprite ID collisions (#10396)

### DIFF
--- a/public/UI_Components/icons-a.svg
+++ b/public/UI_Components/icons-a.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <!-- Widget A's version of icon-check (a checkmark) -->
+  <symbol id="icon-check" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm-2 15l-5-5 1.41-1.41L10 14.17l7.59-7.59L19 8l-9 9z"/>
+  </symbol>
+</svg>

--- a/public/UI_Components/icons-b.svg
+++ b/public/UI_Components/icons-b.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg">
+  <!-- Widget B's version of icon-check (a warning triangle, simulating a collision override) -->
+  <symbol id="icon-check" viewBox="0 0 24 24">
+    <path fill="currentColor" d="M1 21h22L12 2 1 21zm12-3h-2v-2h2v2zm0-4h-2v-4h2v4z"/>
+  </symbol>
+</svg>

--- a/public/UI_Components/index.html
+++ b/public/UI_Components/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SVG Sprite Namespace Utility</title>
+    <style>
+        body {
+            font-family: system-ui, -apple-system, sans-serif;
+            background: #0d1117;
+            color: #c9d1d9;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            margin: 0;
+            padding: 2rem;
+            box-sizing: border-box;
+        }
+        .container {
+            max-width: 800px;
+            width: 100%;
+            background: #161b22;
+            border-radius: 12px;
+            padding: 2rem;
+            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
+            border: 1px solid #30363d;
+        }
+        h1 {
+            color: #58a6ff;
+            margin-top: 0;
+            margin-bottom: 0.5rem;
+        }
+        p {
+            color: #8b949e;
+            line-height: 1.5;
+            margin-bottom: 2rem;
+        }
+        .widgets {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+        }
+        .widget {
+            flex: 1;
+            min-width: 250px;
+            background: #21262d;
+            border: 1px solid #30363d;
+            border-radius: 8px;
+            padding: 1.5rem;
+            text-align: center;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 1rem;
+        }
+        .widget h3 {
+            margin: 0;
+            color: #f0f6fc;
+        }
+        /* Icon styles */
+        .icon {
+            width: 64px;
+            height: 64px;
+            fill: currentColor;
+            display: inline-block;
+        }
+        .widget-a .icon { color: #3fb950; }
+        .widget-b .icon { color: #f85149; }
+        .description {
+            font-size: 0.875rem;
+            color: #8b949e;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>SVG Sprite Namespace Loader</h1>
+        <p>This demo solves the common <strong>ID collision bug</strong> when multiple components inject SVG sprites containing symbols with identical IDs (e.g., <code>id="icon-check"</code>). The utility dynamically namespaces IDs based on the component name.</p>
+        
+        <div class="widgets">
+            <!-- Widget A -->
+            <div class="widget widget-a" id="widget-a">
+                <h3>Widget A (Success)</h3>
+                <div class="icon-container" id="icon-container-a">
+                    <!-- Icon will be injected here -->
+                </div>
+                <div class="description">Should render a checkmark inside a circle.</div>
+            </div>
+
+            <!-- Widget B -->
+            <div class="widget widget-b" id="widget-b">
+                <h3>Widget B (Alert)</h3>
+                <div class="icon-container" id="icon-container-b">
+                    <!-- Icon will be injected here -->
+                </div>
+                <div class="description">Should render a warning triangle.</div>
+            </div>
+        </div>
+    </div>
+
+    <!-- The utility script -->
+    <script src="svg-loader.js" type="module"></script>
+    
+    <!-- Application script -->
+    <script type="module">
+        import { loadAndNamespaceSVG } from './svg-loader.js';
+
+        async function init() {
+            // Both SVGs internally have a symbol with id="icon-check"!
+            // But we will namespace them as 'widget-a' and 'widget-b'.
+
+            // 1. Load Widget A's SVG Sprite
+            await loadAndNamespaceSVG('icons-a.svg', 'widget-a');
+            const containerA = document.getElementById('icon-container-a');
+            containerA.innerHTML = `
+                <svg class="icon" role="img" aria-label="Success">
+                    <use href="#widget-a-icon-check"></use>
+                </svg>
+            `;
+
+            // 2. Load Widget B's SVG Sprite
+            await loadAndNamespaceSVG('icons-b.svg', 'widget-b');
+            const containerB = document.getElementById('icon-container-b');
+            containerB.innerHTML = `
+                <svg class="icon" role="img" aria-label="Alert">
+                    <use href="#widget-b-icon-check"></use>
+                </svg>
+            `;
+        }
+
+        init();
+    </script>
+</body>
+</html>

--- a/public/UI_Components/svg-loader.js
+++ b/public/UI_Components/svg-loader.js
@@ -1,0 +1,91 @@
+/**
+ * SVG Sprite Namespace Loader
+ * 
+ * Fetches an SVG sprite and prefixes all symbol IDs and internal references
+ * with a given namespace. This prevents ID collisions when multiple components
+ * inject the same symbol ID (like 'icon-check') into the DOM.
+ */
+
+export async function loadAndNamespaceSVG(url, namespace) {
+    try {
+        const response = await fetch(url);
+        if (!response.ok) {
+            throw new Error(`Failed to fetch SVG: ${response.statusText}`);
+        }
+        const svgText = await response.text();
+
+        // Parse the SVG string into a DOM document
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(svgText, 'image/svg+xml');
+        const svgElement = doc.querySelector('svg');
+
+        if (!svgElement) {
+            throw new Error('No SVG element found in the fetched file.');
+        }
+
+        // Hide the injected sprite container visually but keep it accessible to the DOM
+        svgElement.style.position = 'absolute';
+        svgElement.style.width = '0';
+        svgElement.style.height = '0';
+        svgElement.style.overflow = 'hidden';
+        svgElement.setAttribute('aria-hidden', 'true');
+
+        // Namespace IDs
+        const elementsWithId = svgElement.querySelectorAll('[id]');
+        const idMap = new Map();
+
+        elementsWithId.forEach(el => {
+            const originalId = el.getAttribute('id');
+            const newId = `${namespace}-${originalId}`;
+            el.setAttribute('id', newId);
+            idMap.set(originalId, newId);
+        });
+
+        // Update internal references (e.g., url(#id), <use href="#id">, clip-path="url(#id)")
+        // 1. Update <use> tags
+        const useElements = svgElement.querySelectorAll('use');
+        useElements.forEach(useEl => {
+            const href = useEl.getAttribute('href') || useEl.getAttribute('xlink:href');
+            if (href && href.startsWith('#')) {
+                const originalId = href.substring(1);
+                if (idMap.has(originalId)) {
+                    const newId = idMap.get(originalId);
+                    if (useEl.hasAttribute('href')) {
+                        useEl.setAttribute('href', `#${newId}`);
+                    }
+                    if (useEl.hasAttribute('xlink:href')) {
+                        useEl.setAttribute('xlink:href', `#${newId}`);
+                    }
+                }
+            }
+        });
+
+        // 2. Update attributes like clip-path, fill, mask that might use url(#id)
+        const allElements = svgElement.querySelectorAll('*');
+        const urlRefRegex = /url\(#([^)]+)\)/g;
+
+        allElements.forEach(el => {
+            Array.from(el.attributes).forEach(attr => {
+                if (attr.value.includes('url(#')) {
+                    const newValue = attr.value.replace(urlRefRegex, (match, id) => {
+                        if (idMap.has(id)) {
+                            return `url(#${idMap.get(id)})`;
+                        }
+                        return match; // keep original if not found in our map
+                    });
+                    if (newValue !== attr.value) {
+                        el.setAttribute(attr.name, newValue);
+                    }
+                }
+            });
+        });
+
+        // Inject into the DOM
+        document.body.appendChild(svgElement);
+        
+        return true;
+    } catch (error) {
+        console.error(`Error loading and namespacing SVG (${url}):`, error);
+        return false;
+    }
+}


### PR DESCRIPTION
Closes #10396

## Description
Multiple components injecting SVG sprites with identical symbol IDs (like `id="icon-check"`) caused global ID collisions, leading to incorrect icons rendering.

This PR introduces a reusable `svg-loader` utility in `UI_Components` that fetches SVG sprite bundles and dynamically namespaces their `id` attributes (and internal `url(#id)` references) per component, ensuring absolute isolation.

## Details
- Created a new vanilla JS module: `public/UI_Components/svg-loader.js`
- Included demo components to showcase collision-free rendering of identical symbols.