### PR TITLE
fix(navbar): remove redundant cursor toggle and preserve dropdown functionality

### DIFF
--- a/cursor.js
+++ b/cursor.js
@@ -56,6 +56,12 @@
     try { localStorage.setItem(ENABLED_KEY, String(enabled)); } catch (_) {}
   }
 
+  function setNativeCursorVisibility(isCustomCursorActive) {
+    const cursorValue = isCustomCursorActive ? "none" : "auto";
+    document.body.style.cursor = cursorValue;
+    document.documentElement.style.cursor = cursorValue;
+  }
+
   /* ── Create cursor elements ── */
   function ensureCursorElements() {
     outerEl = document.querySelector(".cursor-ring--outer");
@@ -92,7 +98,7 @@
     // If disabled or default style, hide cursor elements and set standard cursor
     if (!isEnabled || id === "default") {
       document.body.classList.remove("custom-cursor-active");
-      document.body.style.cursor = "auto";
+      setNativeCursorVisibility(false);
       outerEl.classList.remove("is-visible");
       outerEl.style.display = "none";
       innerEl.classList.remove("is-visible");
@@ -101,7 +107,7 @@
     }
 
     document.body.classList.add("custom-cursor-active");
-    document.body.style.cursor = "none";
+    setNativeCursorVisibility(true);
     outerEl.classList.add("is-visible");
     outerEl.style.display = "block";
     innerEl.classList.add("is-visible");
@@ -445,7 +451,7 @@
   function disableCursorSystem() {
     isEnabled = false;
     saveEnabled(false);
-    document.body.style.cursor = "auto";
+    setNativeCursorVisibility(false);
     if (outerEl) {
       outerEl.classList.remove("is-visible");
       outerEl.style.display = "none";
@@ -459,16 +465,6 @@
   }
 
   function updateCursorToggleUI() {
-    document.querySelectorAll("#cursorToggleNav").forEach((btn) => {
-      btn.innerHTML = `
-        <span class="mobile-nav-icon"><i class="fas ${isEnabled ? "fa-circle-notch" : "fa-mouse-pointer"}" aria-hidden="true"></i></span>
-        Cursor: ${isEnabled ? "Custom" : "Default"}
-      `;
-      btn.setAttribute(
-        "aria-label",
-        `Toggle custom cursor (currently ${isEnabled ? "Custom" : "Default"})`,
-      );
-    });
   }
 
   init();

--- a/navbar.js
+++ b/navbar.js
@@ -174,15 +174,6 @@ navLinks.forEach(link => {
     Generate README
   </a>`;
 
-  const customCursorEnabled =
-    safeStorage.getItem("customCursorEnabled") !== "false";
-  const cursorBtn = `
-    <button class="btn btn-ghost btn-sm" id="cursorToggleNav" aria-label="Toggle custom cursor (currently ${customCursorEnabled ? "Custom" : "Default"})">
-      <span class="mobile-nav-icon"><i class="fas ${customCursorEnabled ? "fa-circle-notch" : "fa-mouse-pointer"}" aria-hidden="true"></i></span>
-      Cursor: ${customCursorEnabled ? "Custom" : "Default"}
-    </button>
-  `;
-
   let navButtonsHTML = "";
   if (session) {
     const userSection = `
@@ -196,10 +187,10 @@ navLinks.forEach(link => {
       </div>
       <button class="btn btn-ghost btn-sm" id="logoutBtn">Log out</button>
     `;
-    navButtonsHTML = `${themeBtn} ${cursorBtn} ${homeBtn} ${learnBtn} ${contributorsBtn} ${readmeBtn} ${githubBtn} ${userSection}`;
+    navButtonsHTML = `${themeBtn} ${homeBtn} ${learnBtn} ${contributorsBtn} ${readmeBtn} ${githubBtn} ${userSection}`;
   } else {
     const signinBtn = `<button class="btn btn-primary btn-sm" id="navSignInCta">Sign in</button>`;
-    navButtonsHTML = `${themeBtn} ${cursorBtn} ${homeBtn} ${learnBtn} ${contributorsBtn} ${readmeBtn} ${githubBtn} ${signinBtn}`;
+    navButtonsHTML = `${themeBtn} ${homeBtn} ${learnBtn} ${contributorsBtn} ${readmeBtn} ${githubBtn} ${signinBtn}`;
   }
 
   container.innerHTML = `
@@ -350,36 +341,6 @@ navLinks.forEach(link => {
       location.reload();
     });
   }
-
-  // Cursor Toggle Logic
-  document.addEventListener("click", (event) => {
-    const toggle = event.target.closest("#cursorToggleNav");
-    if (!toggle) return;
-    event.preventDefault();
-    const currentlyEnabled =
-      safeStorage.getItem("customCursorEnabled") !== "false";
-    const nextState = !currentlyEnabled;
-    safeStorage.setItem("customCursorEnabled", String(nextState));
-
-    // Call the cursor system to enable/disable
-    if (nextState && window.CursorSystem?.enable) {
-      window.CursorSystem.enable();
-    } else if (!nextState && window.CursorSystem?.disable) {
-      window.CursorSystem.disable();
-    } else {
-      // Fallback if cursor system not loaded yet
-      document.querySelectorAll("#cursorToggleNav").forEach((btn) => {
-        btn.innerHTML = `
-          <span class="mobile-nav-icon"><i class="fas ${nextState ? "fa-circle-notch" : "fa-mouse-pointer"}" aria-hidden="true"></i></span>
-          Cursor: ${nextState ? "Custom" : "Default"}
-        `;
-        btn.setAttribute(
-          "aria-label",
-          `Toggle custom cursor (currently ${nextState ? "Custom" : "Default"})`,
-        );
-      });
-    }
-  });
 
   // Sign In Click Logic
   document.addEventListener("click", (event) => {


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #10278

### Summary
This PR removes the redundant **"Default Cursor / Custom Cursor"** toggle from the navigation bar, leaving the **Cursor Settings** dropdown as the single control for cursor customization. It also preserves all existing cursor functionality, including switching between the default arrow and custom cursor styles, resulting in a cleaner and more intuitive user experience.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

##  Changes Made
- Removed the redundant **Default Cursor / Custom Cursor** toggle from the navigation bar.
- Retained the **Cursor Settings** dropdown as the single cursor customization control.
- Preserved the ability to switch between the default arrow and all custom cursor styles.
- Removed obsolete navbar cursor toggle logic without affecting existing cursor functionality.
- Ensured only one cursor customization control is displayed, eliminating duplicate functionality and UI clutter.

---

## Testing and Verification

### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [x] Tested and verified in **Safari** / **Microsoft Edge**