### PR TITLE
fix: add visible keyboard focus indicator for project cards

### DIFF
--- a/public/AI-Data-Analyst/style.css
+++ b/public/AI-Data-Analyst/style.css
@@ -247,7 +247,16 @@ body {
     backdrop-filter: blur(24px);
     -webkit-backdrop-filter: blur(24px);
 }
+.project-card:focus-visible {
+    outline: 3px solid var(--accent);
+    outline-offset: 4px;
+    box-shadow: 0 0 0 4px var(--accent-dim);
+}
 
+.project-card:focus-within {
+    outline: 3px solid var(--accent);
+    outline-offset: 4px;
+}
 /* Light theme cards get a subtle shadow instead of glow */
 [data-theme="light"] .card {
     box-shadow: 0 1px 3px rgba(0,0,0,0.06), 0 4px 16px rgba(0,0,0,0.04);


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #10271

### Summary
This PR improves keyboard accessibility by adding a clear and visible focus indicator to project cards. Keyboard users can now easily identify which project card is focused while navigating with the Tab key, improving accessibility without changing the existing UI design.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added a visible keyboard focus indicator for project cards using `:focus-visible` and `:focus-within`.
- Improved accessibility while preserving the existing design and user experience.

---

## 🧪 Testing and Verification

### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [x] Verified responsive layout on Mobile viewports (using DevTools)
- [x] Verified responsive layout on Tablet viewports
- [x] Keyboard navigation and focus outlines checked
- [x] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
Attached screenshots showing the keyboard focus indicator before and after the changes.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.