### PR TITLE
feat: add open in new tab icon to project cards

### DIFF
--- a/index.js
+++ b/index.js
@@ -617,7 +617,18 @@ function buildProjectCardHTML({
     : `<a href="${safeDemoUrl}" target="_blank" class="card-link open-project" data-id="${safeDay}" rel="noopener noreferrer" onclick="event.stopPropagation()" aria-label="View demo of ${safeName} (opens in a new tab)">
                         Demo <i class="fas fa-arrow-right" aria-hidden="true"></i>
                     </a>`;
-
+  const openNewTabBtn = `
+<a
+    href="${safeDemoUrl}"
+    target="_blank"
+    rel="noopener noreferrer"
+    class="open-new-tab-btn"
+    onclick="event.stopPropagation()"
+    aria-label="Open ${safeName} in a new tab"
+>
+    <i class="fas fa-up-right-from-square"></i>
+</a>
+`;
   const githubBtn = sourceOnly
     ? ""
     : `<a href="${safeSourceUrl}" target="_blank" class="github-btn" rel="noopener noreferrer" onclick="event.stopPropagation()" aria-label="View source code of ${safeName} on GitHub (opens in a new tab)">
@@ -693,11 +704,30 @@ function buildProjectCardHTML({
                     ${primaryLink}
                 </div>
                 <div class="card-actions-right" style="display: flex; gap: 8px; align-items: center;">
-                    ${githubBtn}
-                    <button class="bookmark-btn ${isBookmarked ? "active" : ""}" data-id="${safeDay}" aria-label="${isBookmarked ? `Remove ${safeName} from bookmarks` : `Bookmark ${safeName}`}">
-                        <i class="${isBookmarked ? "fa-solid" : "fa-regular"} fa-bookmark" aria-hidden="true"></i>
-                    </button>
-                </div>
+
+    <a
+        href="${safeDemoUrl}"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="open-new-tab-btn"
+        onclick="event.stopPropagation()"
+        aria-label="Open ${safeName} in a new tab"
+        title="Open in New Tab"
+    >
+        <i class="fas fa-up-right-from-square" aria-hidden="true"></i>
+    </a>
+
+    ${githubBtn}
+
+    <button
+        class="bookmark-btn ${isBookmarked ? "active" : ""}"
+        data-id="${safeDay}"
+        aria-label="${isBookmarked ? `Remove ${safeName} from bookmarks` : `Bookmark ${safeName}`}"
+    >
+        <i class="${isBookmarked ? "fa-solid" : "fa-regular"} fa-bookmark" aria-hidden="true"></i>
+    </button>
+
+</div>
             </div>
         `,
     demoUrl: safeDemoUrl,

--- a/style.css
+++ b/style.css
@@ -2037,6 +2037,32 @@ body.light-mode .new-badge {
   transform: translateY(-2px);
 }
 
+.open-new-tab-btn{
+    width:36px;
+    height:36px;
+
+    display:flex;
+    align-items:center;
+    justify-content:center;
+
+    border-radius:8px;
+
+    text-decoration:none;
+
+    color:var(--text-secondary);
+
+    transition:0.2s;
+}
+
+.open-new-tab-btn:hover{
+
+    color:var(--accent);
+
+    background:rgba(255,255,255,.08);
+
+    transform:translateY(-2px);
+}
+
 .bookmark-btn {
   width: 38px;
   height: 38px;


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #10274

### Summary
Added an "Open in New Tab" icon to every project card, allowing users to quickly open project demos in a separate browser tab while preserving the existing GitHub and bookmark actions. This improves usability for users who want to compare multiple projects without disrupting the current browsing experience.

### Type of Change
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Added an external-link ("Open in New Tab") icon to every project card.
- Configured the icon to open the project demo in a new browser tab using `target="_blank"` with `rel="noopener noreferrer"` for improved security.
- Styled the new icon to match the existing project card action buttons.
- Preserved the existing GitHub and Bookmark functionality without affecting the current UI layout.

---

## 🧪 Testing and Verification

### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [ ] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [x] Verified responsive layout on Mobile viewports (using DevTools)
- [x] Verified responsive layout on Tablet viewports
- [x] Keyboard navigation and focus outlines checked
- [x] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording
Attached screenshots demonstrating the new "Open in New Tab" icon and its behavior on project cards.

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.