### PR TITLE
fix: prevent Compare Profiles form from reloading on Enter key

### DIFF
--- a/public/github_profile_finder/index.html
+++ b/public/github_profile_finder/index.html
@@ -376,8 +376,8 @@
         });
       });
 
-      // Compare button
-      compareBtn.addEventListener('click', (e) => {
+      // Compare form submit (handles Compare button click AND Enter key in either input)
+      compareForm.addEventListener('submit', (e) => {
         e.preventDefault();
         const a = compareA.value.trim();
         const b = compareB.value.trim();


### PR DESCRIPTION
## Summary
Fixes the Compare Profiles form reloading the page when submitted using the Enter key.

## Changes
- Handle the form `submit` event instead of only the Compare button `click` event.
- Prevent the browser's default form submission with `event.preventDefault()`.
- Reuse the existing comparison logic so both Enter key submission and button clicks behave identically.

Fixes #10504