### PR TITLE
feat: add dark mode support to Day 245 Flashcard Quiz

### DIFF
--- a/public/Flashcard-Quiz-App/index.html
+++ b/public/Flashcard-Quiz-App/index.html
@@ -37,6 +37,9 @@
                 <button class="nav-tab" data-subject="dsa">
                     DSA
                 </button>
+                <button class="theme-toggle" id="themeToggle" aria-label="Toggle theme">
+                    <span class="theme-icon">🌙</span>
+                </button>
             </div>
         </nav>
     </header>

--- a/public/Flashcard-Quiz-App/script.js
+++ b/public/Flashcard-Quiz-App/script.js
@@ -483,3 +483,49 @@ function setEditingState(disabled) {
 loadBestScore();
 setEditingState(false);
 renderCard();
+
+/* ============================================================
+                    THEME TOGGLE
+============================================================ */
+const themeToggle = document.getElementById("themeToggle");
+const themeIcon = document.querySelector(".theme-icon");
+
+// Check for saved theme preference or default to light
+const savedTheme = localStorage.getItem("theme") || "light";
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+const initialTheme = savedTheme === "dark" || (savedTheme === null && prefersDark) ? "dark" : "light";
+
+// Apply initial theme
+document.documentElement.setAttribute("data-theme", initialTheme);
+updateThemeIcon(initialTheme);
+
+// Toggle theme function
+function toggleTheme() {
+    const currentTheme = document.documentElement.getAttribute("data-theme");
+    const newTheme = currentTheme === "dark" ? "light" : "dark";
+    
+    document.documentElement.setAttribute("data-theme", newTheme);
+    localStorage.setItem("theme", newTheme);
+    updateThemeIcon(newTheme);
+}
+
+// Update icon based on theme
+function updateThemeIcon(theme) {
+    if (themeIcon) {
+        themeIcon.textContent = theme === "dark" ? "☀️" : "🌙";
+    }
+}
+
+// Add event listener to toggle button
+if (themeToggle) {
+    themeToggle.addEventListener("click", toggleTheme);
+}
+
+// Listen for system theme changes
+window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", (e) => {
+    if (!localStorage.getItem("theme")) {
+        const newTheme = e.matches ? "dark" : "light";
+        document.documentElement.setAttribute("data-theme", newTheme);
+        updateThemeIcon(newTheme);
+    }
+});

--- a/public/Flashcard-Quiz-App/style.css
+++ b/public/Flashcard-Quiz-App/style.css
@@ -23,6 +23,17 @@
     --radius: 14px;
     --transition: .3s ease;
 }
+
+[data-theme="dark"] {
+    --background: #0f172a;
+    --surface: #1e293b;
+    --surface-light: #334155;
+    --text: #f1f5f9;
+    --text-light: #94a3b8;
+    --border: #475569;
+    --shadow-sm: 0 4px 10px rgba(0, 0, 0, 0.3);
+    --shadow-md: 0 10px 30px rgba(0, 0, 0, 0.4);
+}
 /* ======================================================
                     RESET
 ====================================================== */
@@ -102,6 +113,28 @@ header{
 .nav-tab.active{
     background:var(--primary);
     color:white;
+}
+
+.theme-toggle{
+    background:var(--surface-light);
+    color:var(--text);
+    border:1px solid var(--border);
+    border-radius:999px;
+    padding:10px 16px;
+    cursor:pointer;
+    transition:var(--transition);
+    font-weight:500;
+    display:flex;
+    align-items:center;
+    gap:6px;
+}
+.theme-toggle:hover{
+    background:var(--primary);
+    color:white;
+    border-color:var(--primary);
+}
+.theme-icon{
+    font-size:1.2rem;
 }
 /* ======================================================
                     MAIN CONTAINER


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #10745

### Summary

Added Dark Mode support to the Day 245 Flashcard Quiz project. Users can now switch between Light and Dark themes for a more comfortable learning experience. The selected theme is saved using `localStorage`, so the preference is retained across page reloads.

### Type of Change

* [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
* [x] 🚀 New feature or UI/UX enhancement
* [ ] ✨ New project addition
* [ ] ♻️ Code refactoring / clean-up
* [ ] 📝 Documentation update
* [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made

* Added a Light/Dark mode toggle button.
* Implemented theme switching using CSS variables/classes.
* Stored the selected theme in `localStorage`.
* Applied the selected theme across the Flashcard Quiz interface.
* Ensured the toggle works correctly on desktop and mobile devices while preserving the existing functionality.

---

## 🧪 Testing and Verification

### Local Validation

* [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check

* [x] Tested and verified in **Google Chrome**
* [ ] Tested and verified in **Mozilla Firefox**
* [x] Tested and verified in **Microsoft Edge**

### Responsive & Accessibility Checks

* [x] Verified responsive layout on Mobile viewports (using DevTools)
* [x] Verified responsive layout on Tablet viewports
* [x] Keyboard navigation and focus outlines checked
* [x] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording

<img width="1876" height="902" alt="Screenshot 2026-07-21 223656" src="https://github.com/user-attachments/assets/917163dc-20ef-442a-a731-898d87238757" />


---

## 🤝 Contributor Checklist

* [x] My code follows the code style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code where appropriate.
* [ ] I have updated the documentation / README files accordingly.
* [x] My changes generate no new warnings or console errors.
* [x] There are no unrelated changes or formatter noise in this PR.
