### PR TITLE
prevent theme flash and fix light-mode contrast in AI Data Analyst

### DIFF
--- a/public/AI-Data-Analyst/index.html
+++ b/public/AI-Data-Analyst/index.html
@@ -1,6 +1,21 @@
 <!doctype html>
 <html lang="en" data-theme="dark">
   <head>
+    <script>
+      (function () {
+        try {
+          var KEY = "ai-data-analyst-theme";
+          var stored = localStorage.getItem(KEY);
+          var theme =
+            stored ||
+            (window.matchMedia("(prefers-color-scheme: dark)").matches
+              ? "dark"
+              : "light");
+          document.documentElement.setAttribute("data-theme", theme);
+          document.documentElement.classList.add("theme-preload");
+        } catch (e) {}
+      })();
+    </script>
     <link rel="icon" type="image/png" href="./assets/icons/favicon.png" />
     <script src="https://unpkg.com/lucide@latest"></script>
     <meta charset="UTF-8" />

--- a/public/AI-Data-Analyst/script.js
+++ b/public/AI-Data-Analyst/script.js
@@ -14,10 +14,19 @@ function getStoredTheme() {
   return localStorage.getItem(THEME_KEY);
 }
 
+function updateThemeToggleAria(theme) {
+  const btn = document.getElementById("themeToggleBtn");
+  if (!btn) return;
+  const label = theme === "dark" ? "Switch to light mode" : "Switch to dark mode";
+  btn.setAttribute("aria-label", label);
+  btn.setAttribute("title", label);
+}
+
 function setTheme(theme) {
   document.documentElement.setAttribute("data-theme", theme);
   localStorage.setItem(THEME_KEY, theme);
   updateChartTheme(theme);
+  updateThemeToggleAria(theme);
 }
 
 function initTheme() {
@@ -27,8 +36,19 @@ function initTheme() {
   // Don't call updateChartTheme here; charts don't exist yet.
 }
 
-// Apply theme immediately (before DOM is fully ready to avoid flash)
+// Theme is already applied by the inline snippet in <head> before this
+// script loads. Re-running keeps state in sync without causing a flash.
 initTheme();
+
+// Re-enable transitions after the first paint so the initial theme
+// resolution doesn't animate.
+document.addEventListener("DOMContentLoaded", () => {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      document.documentElement.classList.remove("theme-preload");
+    });
+  });
+});
 
 // Listen for OS-level theme changes (only if no stored preference)
 window
@@ -136,6 +156,10 @@ Chart.defaults.font.family = "'Plus Jakarta Sans', sans-serif";
 const themeToggleBtn = document.getElementById("themeToggleBtn");
 
 if (themeToggleBtn) {
+  updateThemeToggleAria(
+    document.documentElement.getAttribute("data-theme") || "dark",
+  );
+
   themeToggleBtn.addEventListener("click", () => {
     const current =
       document.documentElement.getAttribute("data-theme") || "dark";

--- a/public/AI-Data-Analyst/style.css
+++ b/public/AI-Data-Analyst/style.css
@@ -130,6 +130,14 @@
         box-shadow 0.25s ease;
 }
 
+/* Disable all transitions during initial theme resolution to prevent flicker */
+.theme-preload,
+.theme-preload *,
+.theme-preload *::before,
+.theme-preload *::after {
+    transition: none !important;
+}
+
 /* Don't transition transforms so hover effects still feel snappy */
 .upload-btn,
 .sample-btn,
@@ -307,6 +315,7 @@ body {
 [data-theme="light"] .section-icon {
     background: rgba(99, 102, 241, 0.08);
     border-color: rgba(99, 102, 241, 0.18);
+    color: #2563eb;
 }
 
 .section-icon svg,
@@ -329,6 +338,7 @@ body {
 [data-theme="light"] .section-col-tag {
     background: rgba(139, 92, 246, 0.08);
     border-color: rgba(139, 92, 246, 0.15);
+    color: #7c3aed;
 }
 
 /* ==================================
@@ -628,6 +638,7 @@ body {
 [data-theme="light"] .metric-icon {
     background: rgba(59, 130, 246, 0.08);
     border-color: rgba(59, 130, 246, 0.15);
+    color: #2563eb;
 }
 
 .metric-icon.quality-icon {
@@ -639,6 +650,7 @@ body {
 [data-theme="light"] .metric-icon.quality-icon {
     background: rgba(34, 197, 94, 0.08);
     border-color: rgba(34, 197, 94, 0.15);
+    color: #16a34a;
 }
 
 .metric-icon i { width: 14px; height: 14px; }
@@ -930,6 +942,10 @@ body {
     margin-top: 1px;
 }
 
+[data-theme="light"] .ai-note i {
+    color: #0e7490;
+}
+
 /* ==================================
    VISUALIZATIONS
 ================================== */
@@ -994,6 +1010,10 @@ body {
     text-align: left;
     border-bottom: 1px solid var(--border);
     white-space: nowrap;
+}
+
+[data-theme="light"] #datasetTable th {
+    color: #2563eb;
 }
 
 #datasetTable td {
@@ -1213,6 +1233,7 @@ body {
 [data-theme="light"] .correlation-card .insight-icon {
     background: radial-gradient(circle, rgba(99,102,241,0.12), rgba(99,102,241,0.02));
     border-color: rgba(99,102,241,0.2);
+    color: #2563eb;
 }
 
 .quality-card .insight-icon {
@@ -1224,6 +1245,7 @@ body {
 [data-theme="light"] .quality-card .insight-icon {
     background: radial-gradient(circle, rgba(34,197,94,0.12), rgba(34,197,94,0.02));
     border-color: rgba(34,197,94,0.18);
+    color: #16a34a;
 }
 
 .recommendation-card-insight .insight-icon {
@@ -1247,6 +1269,7 @@ body {
 [data-theme="light"] .trend-card .insight-icon {
     background: radial-gradient(circle, rgba(139,92,246,0.12), rgba(139,92,246,0.02));
     border-color: rgba(139,92,246,0.18);
+    color: #7c3aed;
 }
 
 .insight-content { flex: 1; min-width: 0; }
@@ -1323,6 +1346,10 @@ body {
     color: var(--purple-bright) !important;
     font-weight: 700;
     font-size: 0.95rem;
+}
+
+[data-theme="light"] .accent-text {
+    color: #7c3aed !important;
 }
 
 .recommendation-divider {
@@ -1432,6 +1459,7 @@ body {
 [data-theme="light"] .cleaning-section-icon {
     background: rgba(245, 158, 11, 0.08);
     border-color: rgba(245, 158, 11, 0.15);
+    color: #b45309;
 }
 
 .cleaning-badge-title {
@@ -1585,6 +1613,10 @@ body {
 }
 
 .cleaning-empty-icon i { width: 22px; height: 22px; }
+
+[data-theme="light"] .cleaning-empty-icon {
+    color: #2563eb;
+}
 
 .cleaning-empty-title {
     font-size: 0.95rem;
@@ -1915,6 +1947,10 @@ body {
     color: var(--cyan);
     flex-shrink: 0;
     margin-top: 1px;
+}
+
+[data-theme="light"] .cleaning-assessment i {
+    color: #0e7490;
 }
 
 /* ==================================


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #8602 

### Summary

- Move theme resolution into a synchronous inline script in <head> so data-theme is set before first paint, eliminating a dark→light flash on load
- Disable transitions during that initial resolution via a `.theme-preload` lock class, removed after first paint
- Fix several light-theme color overrides that were still rendering bright dark-mode accents (purple/blue) directly on white backgrounds, failing contrast
- Make the theme toggle button's aria-label/title update dynamically ("Switch to light mode" / "Switch to dark mode")

## Test plan
- [x] Open public/AI-Data-Analyst/index.html with localStorage theme unset — confirm it follows OS preference with no flash
- [x] Toggle theme, reload — confirm choice persists via localStorage
- [x] Inspect toggle button aria-label in both states
- [x] Check table headers, ML recommendation text, and icon badges in light mode for readability

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [x] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---
