### PR TITLE
fix(quotes): reset auto-rotation timer after manual navigation

### DIFF
--- a/public/indianflag/script.js
+++ b/public/indianflag/script.js
@@ -1,7 +1,7 @@
 const themeToggleButton = document.getElementById("themeToggle");
 const themeToggleIcon = themeToggleButton?.querySelector(".theme-toggle-icon");
 const themeToggleLabel = themeToggleButton?.querySelector(".theme-toggle-label");
-
+let quoteInterval;
 function syncThemeToggleUI() {
   const isLightTheme = document.body.classList.contains("light-mode");
 
@@ -20,104 +20,110 @@ function syncThemeToggleUI() {
     );
   }
 }
+function startQuoteRotation() {
+  clearInterval(quoteInterval);
+
+  quoteInterval = setInterval(() => {
+    currentQuoteIndex =
+      (currentQuoteIndex + 1) % quotes.length;
+
+    displayQuote();
+  }, 5000);
+}
 
 window.addEventListener("themechange", syncThemeToggleUI);
 syncThemeToggleUI();
 
 const quotes = [
-      {
-        text: "Give me blood and I will give you freedom.",
-        author: "— Subhas Chandra Bose",
-        image: "./img/subhas_bose.png",
-      },
-      {
-        text: "Swaraj is my birthright and I shall have it.",
-        author: "— Bal Gangadhar Tilak",
-        image: "./img/bal_tilak.png",
-      },
-      {
-        text: "Inquilab Zindabad.",
-        author: "— Bhagat Singh",
-        image: "./img/bhagat_singh.jpg",
-      },
-      {
-        text: "Jai Hind!",
-        author: "— Netaji Subhas Chandra Bose",
-        image: "./img/subhas_bose.png",
-      },
-      {
-        text: "Karo ya maro.",
-        author: "— Mahatma Gandhi",
-        image: "./img/gandhi.png",
-      },
-    ];
+  {
+    text: "Give me blood and I will give you freedom.",
+    author: "— Subhas Chandra Bose",
+    image: "./img/subhas_bose.png",
+  },
+  {
+    text: "Swaraj is my birthright and I shall have it.",
+    author: "— Bal Gangadhar Tilak",
+    image: "./img/bal_tilak.png",
+  },
+  {
+    text: "Inquilab Zindabad.",
+    author: "— Bhagat Singh",
+    image: "./img/bhagat_singh.jpg",
+  },
+  {
+    text: "Jai Hind!",
+    author: "— Netaji Subhas Chandra Bose",
+    image: "./img/subhas_bose.png",
+  },
+  {
+    text: "Karo ya maro.",
+    author: "— Mahatma Gandhi",
+    image: "./img/gandhi.png",
+  },
+];
 
-    let currentQuoteIndex = 0;
+let currentQuoteIndex = 0;
 
-    const quoteText = document.getElementById("quote-text");
-    const quoteAuthor = document.getElementById("quote-author");
-    const patriotImage = document.getElementById("patriot-image");
+const quoteText = document.getElementById("quote-text");
+const quoteAuthor = document.getElementById("quote-author");
+const patriotImage = document.getElementById("patriot-image");
 
-    function displayQuote() {
-      const currentQuote = quotes[currentQuoteIndex];
+function displayQuote() {
+  const currentQuote = quotes[currentQuoteIndex];
 
-      quoteText.textContent = currentQuote.text;
-      quoteAuthor.textContent = currentQuote.author;
-      patriotImage.src = currentQuote.image;
-    }
+  quoteText.textContent = currentQuote.text;
+  quoteAuthor.textContent = currentQuote.author;
+  patriotImage.src = currentQuote.image;
+}
+
+displayQuote();
+
+startQuoteRotation();
+
+document
+  .getElementById("prev-quote")
+  .addEventListener("click", () => {
+
+    currentQuoteIndex =
+      (currentQuoteIndex - 1 + quotes.length) %
+      quotes.length;
 
     displayQuote();
+  });
 
-    setInterval(() => {
-      currentQuoteIndex =
-        (currentQuoteIndex + 1) % quotes.length;
+document
+  .getElementById("next-quote")
+  .addEventListener("click", () => {
 
-      displayQuote();
-    }, 5000);
+    currentQuoteIndex =
+      (currentQuoteIndex + 1) %
+      quotes.length;
 
-    document
-      .getElementById("prev-quote")
-      .addEventListener("click", () => {
+    displayQuote();
+    startQuoteRotation();
+  });
 
-        currentQuoteIndex =
-          (currentQuoteIndex - 1 + quotes.length) %
-          quotes.length;
+// Text to Speech
+document
+  .getElementById("speak-quote")
+  .addEventListener("click", () => {
 
-        displayQuote();
-      });
+    const speech = new SpeechSynthesisUtterance(
+      `${quotes[currentQuoteIndex].text} by ${quotes[currentQuoteIndex].author}`
+    );
 
-    document
-      .getElementById("next-quote")
-      .addEventListener("click", () => {
+    speech.rate = 0.95;
+    speech.pitch = 1;
 
-        currentQuoteIndex =
-          (currentQuoteIndex + 1) %
-          quotes.length;
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(speech);
+  });
 
-        displayQuote();
-      });
+// Music autoplay fallback
+const music = document.getElementById("bgMusic");
 
-    // Text to Speech
-    document
-      .getElementById("speak-quote")
-      .addEventListener("click", () => {
-
-        const speech = new SpeechSynthesisUtterance(
-          `${quotes[currentQuoteIndex].text} by ${quotes[currentQuoteIndex].author}`
-        );
-
-        speech.rate = 0.95;
-        speech.pitch = 1;
-
-        window.speechSynthesis.cancel();
-        window.speechSynthesis.speak(speech);
-      });
-
-    // Music autoplay fallback
-    const music = document.getElementById("bgMusic");
-
-    window.addEventListener("load", () => {
-      music.play().catch(() => {
-        console.log("Autoplay blocked");
-      });
-    });
+window.addEventListener("load", () => {
+  music.play().catch(() => {
+    console.log("Autoplay blocked");
+  });
+});


### PR DESCRIPTION
## Summary

This PR fixes an issue where the quote carousel's auto-rotation timer was not reset after users manually navigated between quotes.

### Changes

* Introduced a reusable quote rotation function.
* Stored the interval ID.
* Cleared existing intervals before starting a new one.
* Restarted the timer after manual Previous/Next navigation.

### Benefits

* Improves user experience.
* Prevents unexpected quote changes.
* Keeps automatic and manual navigation synchronized.

Fixes #10856 
