### PR TITLE
fix(incident): reset timeline when creating a new incident

### DIFF
--- a/public/IncidentCommunicationWarRoom/script.js
+++ b/public/IncidentCommunicationWarRoom/script.js
@@ -14,6 +14,7 @@ function createIncident() {
   };
 
   renderPublicStatus();
+  renderTimeline();
 }
 
 function renderPublicStatus() {


### PR DESCRIPTION
## Summary

This PR fixes an issue where the incident timeline was not refreshed after creating a new incident.

### Changes Made

* Refreshed the timeline immediately after creating a new incident.
* Ensures stale updates from previous incidents are removed.
* Keeps the timeline synchronized with the currently active incident.

### Benefits

* Prevents outdated information from being displayed.
* Improves UI consistency.
* Provides a better user experience during incident management.

Fixes #10859 
