### PR TITLE
fix(particles): prevent division by zero in force calculation

### DIFF
--- a/public/image-particle-engine/script.js
+++ b/public/image-particle-engine/script.js
@@ -56,7 +56,11 @@ class Particle {
         this.dx = this.effect.mouse.x - this.x;
         this.dy = this.effect.mouse.y - this.y;
         this.distance = this.dx * this.dx + this.dy * this.dy;
-        this.force = -this.effect.mouse.radius / this.distance;
+
+        // Prevent division by zero
+        const safeDistance = Math.max(this.distance, 1);
+
+        this.force = -this.effect.mouse.radius / safeDistance;
 
         if (this.distance < this.effect.mouse.radius) {
             this.angle = Math.atan2(this.dy, this.dx);


### PR DESCRIPTION
## Summary

This PR fixes a particle physics issue where the force calculation could divide by zero when the mouse pointer overlaps a particle.

### Changes Made

* Added a minimum distance threshold before calculating particle force.
* Prevented infinite force values.
* Improved simulation stability during mouse interaction.

### Benefits

* Eliminates division-by-zero scenarios.
* Prevents unstable particle movement.
* Improves overall animation reliability.

Fixes #10867 
