### PR TITLE
Fix: Empty src and href attributes in Url Shortener (#10550, #10549)

### DIFF
--- a/public/url_shortener/frontend/public/index.html
+++ b/public/url_shortener/frontend/public/index.html
@@ -91,8 +91,8 @@
   </div>
 
   <div id="qr-section" class="qr-section hidden">
-    <img id="qr-img" src="" alt="QR Code" />
-    <a id="qr-download" href="" download="qr-code.png" class="btn-download">Download QR</a>
+    <img id="qr-img" alt="QR Code" />
+    <a id="qr-download" download="qr-code.png" class="btn-download">Download QR</a>
   </div>
 </div>
 


### PR DESCRIPTION
Resolves #10550. Resolves #10549.