### PR TITLE
Removed duplicate toggle button

### DIFF
--- a/public/WanderLust/index.html
+++ b/public/WanderLust/index.html
@@ -47,8 +47,6 @@
         <a href="signup.html">Sign up</a>
 
         <a href="login.html">Log in</a>
-
-        <button id="theme-toggle" aria-label="Toggle Dark Mode">🌙 / ☀️</button>
       </div>
     </nav>
 


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue
Closes #10978 

### Summary
Root cause: both toggle buttons shared id="theme-toggle" (invalid duplicate ID). Since the working toggleTheme() handler was only wired to the first instance, the second button was permanently non-functional. Removed the redundant/broken button.

## 📷 Screenshots 

BEFORE--
<img width="1456" height="817" alt="image" src="https://github.com/user-attachments/assets/3590aca2-1732-46ab-8546-e974b984e9f6" />


AFTER--
<img width="946" height="500" alt="image" src="https://github.com/user-attachments/assets/72333bbf-aadb-4581-96cb-4dee659414d3" />

<img width="945" height="496" alt="image" src="https://github.com/user-attachments/assets/6c7172b5-83da-4805-9df8-4f223dd640b8" />


---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.
