### PR TITLE
Fix: prevent theme icon crash and escape apostrophes in onclick handl…

### DIFF
--- a/public/Animated Searchbar/app.js
+++ b/public/Animated Searchbar/app.js
@@ -260,7 +260,7 @@ function performGoogleSearch(query) {
     `<strong><i class="fa-brands fa-google"></i> Searching Google for:</strong><br>
     <span style="color:#ffa31a; font-size: 1.2em;">"${escapeHtml(query)}"</span><br><br>
     <small style="color: #888;">Opening in a new tab...</small><br><br>
-    <button onclick="performGoogleSearch('${escapeHtml(query)}')" style="background: #ffa31a; color: #1a1a2e; border: none; padding: 10px 20px; border-radius: 25px; cursor: pointer; font-weight: bold;">
+    <button class="search-again-btn" data-query="${escapeHtml(query)}" style="background: #ffa31a; color: #1a1a2e; border: none; padding: 10px 20px; border-radius: 25px; cursor: pointer; font-weight: bold;">
       <i class="fa-brands fa-google"></i> Search Again
     </button>`,
     'success'
@@ -312,7 +312,7 @@ function handleVoiceSearch() {
       `<strong><i class="fa-solid fa-microphone"></i> Voice Search Detected:</strong><br>
       You said: <span style="color:#ffa31a; font-size: 1.2em;">"${escapeHtml(transcript)}"</span><br>
       <small style="color: #888;">Confidence: ${(confidence * 100).toFixed(1)}%</small><br><br>
-      <button onclick="performGoogleSearch('${escapeHtml(transcript)}')" style="background: #ffa31a; color: #1a1a2e; border: none; padding: 10px 20px; border-radius: 25px; cursor: pointer; font-weight: bold; margin-top: 10px;">
+      <button class="search-again-btn" data-query="${escapeHtml(transcript)}" style="background: #ffa31a; color: #1a1a2e; border: none; padding: 10px 20px; border-radius: 25px; cursor: pointer; font-weight: bold; margin-top: 10px;">
         <i class="fa-brands fa-google"></i> Search on Google
       </button>`,
       'success'
@@ -420,6 +420,16 @@ function showResult(message, type = 'success') {
 `;
 
   document.getElementById('closeResult')?.addEventListener('click', hideResult);
+  
+  // Dynamically attach click event listener to search-again buttons
+  const searchAgainBtn = resultBox.querySelector('.search-again-btn');
+  if (searchAgainBtn) {
+    searchAgainBtn.addEventListener('click', () => {
+      const query = searchAgainBtn.getAttribute('data-query');
+      performGoogleSearch(query);
+    });
+  }
+
   resultBox.classList.add('visible');
   resultBox.style.display = 'block';
 
@@ -491,10 +501,14 @@ let isLightMode = JSON.parse(localStorage.getItem("lightMode")) || false;
 function updateTheme() {
   if (isLightMode) {
     document.body.classList.add("light-theme");
-    themeIcon.textContent = "🌙"; // show moon when light mode active
+    if (themeIcon) {
+      themeIcon.textContent = "🌙"; // show moon when light mode active
+    }
   } else {
     document.body.classList.remove("light-theme");
-    themeIcon.textContent = "☀️"; // show sun when dark mode active
+    if (themeIcon) {
+      themeIcon.textContent = "☀️"; // show sun when dark mode active
+    }
   }
 }
 


### PR DESCRIPTION
 📝 Pull Request Description
 Related Issue
Closes #10694

Summary
Fixes two bugs in the Animated Search Bar's script: a crash when `#themeIcon` doesn't exist on the page, and a broken "Search Again"/voice-search button when the query contains an apostrophe.

 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Wrapped `themeIcon.textContent` assignments in `updateTheme()` with a null check (`if (themeIcon) { ... }`), so the script no longer throws `TypeError: Cannot set properties of null` on pages where `#themeIcon` is absent.
- Removed the inline `onclick="performGoogleSearch('${query}')"` pattern for the "Search Again" / voice-search result buttons. The query is now stored safely in a `data-query` attribute (escaped via `escapeHtml()`), and a proper `addEventListener('click', ...)` handler reads it and calls `performGoogleSearch()`. This avoids breaking out of the inline string when the query contains an apostrophe, since there's no longer an inline JS string to break out of.

---

## 🧪 Testing and Verification
### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check
- [x] Tested and verified in **Google Chrome**
- [x] Tested and verified in **Mozilla Firefox**
- [ ] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks
- [x] Verified responsive layout on Mobile viewports (using DevTools)
- [x] Verified responsive layout on Tablet viewports
- [x] Keyboard navigation and focus outlines checked
- [x] Semantic HTML and ARIA labels checked



## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation / README files accordingly.
- [x] My changes generate no new warnings or console errors.
- [x] There are no unrelated changes or formatter noise in this PR.