### PR TITLE
fix: restrict protected route to current user

### DIFF
--- a/public/flask_auth_app/app.py
+++ b/public/flask_auth_app/app.py
@@ -141,7 +141,7 @@ def logout():
 @app.route("/protected")
 @token_required
 def protected(current_user):
-    users = User.query.all()
+    users = [current_user]
     return render_template("protected.html", current_user=current_user, users=users)
 
 


### PR DESCRIPTION
## 📝 Pull Request Description

The `/protected` route was exposing the names and email addresses of all registered users to any authenticated user.

### Related Issue
Closes #10957 

### Summary
Restricted the `/protected` route to expose only the authenticated user's profile data instead of returning all registered users.

### Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New project addition
- [ ] 🚀 New feature or UI/UX enhancement
- [ ] ♻️ Code refactoring / clean-up
- [ ] 📝 Documentation update
- [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made
- Replaced `User.query.all()` in the `/protected` route with `[current_user]`.

- Prevented other registered users' names and email addresses from being passed to the protected page.

- Kept the existing authentication flow and template structure unchanged.
 
---

## 🧪 Testing and Verification
- Reproduced the original issue using two separate registered accounts.

- Verified that the authenticated user can access `/protected`.

- Verified that only the logged-in user's name and email are displayed.

- Verified that another registered user's name and email are no longer exposed in the protected page response.

- Tested the behavior with both user accounts.

### Local Validation
- [x] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

---

## 📷 Screenshots / Video Recording
<img width="1468" height="822" alt="Screenshot 2026-08-13 at 8 19 16 PM" src="https://github.com/user-attachments/assets/791da5bf-f593-42f8-991a-a4224aeab027" />

---

## 🤝 Contributor Checklist
- [x] My code follows the code style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation / README files accordingly.
- [ ] My changes generate no new warnings or console errors.
- [ ] There are no unrelated changes or formatter noise in this PR.
