### PR TITLE
Fix/10505 overlapping api requests

### DIFF
--- a/public/github_profile_finder/index.html
+++ b/public/github_profile_finder/index.html
@@ -376,8 +376,8 @@
         });
       });
 
-      // Compare button
-      compareBtn.addEventListener('click', (e) => {
+      // Compare form submit (handles Compare button click AND Enter key in either input)
+      compareForm.addEventListener('submit', (e) => {
         e.preventDefault();
         const a = compareA.value.trim();
         const b = compareB.value.trim();
@@ -424,7 +424,7 @@
 
       // Render heatmap
       function renderHeatmap() {
-        heatmapGrid.innerHTML = '';
+        heatmapGrid.replaceChildren();
         const levels = [0, 1, 2, 3, 4];
         for (let i = 0; i < 53 * 7; i++) {
           const span = document.createElement('span');
@@ -443,60 +443,106 @@
           languagePie.style.background = '#1a2536';
           topLanguagePercent.textContent = '0%';
           topLanguageName.textContent = '—';
-          languageLegend.innerHTML = '<div style="color: var(--muted);">No language data</div>';
+          const emptyNote = document.createElement('div');
+          emptyNote.style.color = 'var(--muted)';
+          emptyNote.textContent = 'No language data';
+          languageLegend.replaceChildren(emptyNote);
           return;
         }
 
         const colors = ['#7c3aed', '#06b6d4', '#22c55e', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899', '#14b8a6'];
         let conic = '';
         let cum = 0;
-        const legendHtml = [];
+        const legendItems = [];
 
         entries.slice(0, 6).forEach(([lang, count], idx) => {
           const pct = (count / total) * 100;
           const color = colors[idx % colors.length];
           conic += `${color} ${cum}% ${cum + pct}%, `;
           cum += pct;
-          legendHtml.push(`
-            <div class="language-legend-item">
-              <div class="language-legend-left">
-                <span class="language-dot" style="background: ${color};"></span>
-                <span>${lang}</span>
-              </div>
-              <span>${pct.toFixed(1)}%</span>
-            </div>
-          `);
+
+          const item = document.createElement('div');
+          item.className = 'language-legend-item';
+
+          const left = document.createElement('div');
+          left.className = 'language-legend-left';
+
+          const dot = document.createElement('span');
+          dot.className = 'language-dot';
+          dot.style.background = color;
+
+          const langLabel = document.createElement('span');
+          langLabel.textContent = lang; // GitHub API value — rendered via textContent, never HTML
+
+          left.appendChild(dot);
+          left.appendChild(langLabel);
+
+          const pctLabel = document.createElement('span');
+          pctLabel.textContent = `${pct.toFixed(1)}%`;
+
+          item.appendChild(left);
+          item.appendChild(pctLabel);
+          legendItems.push(item);
         });
 
         languagePie.style.background = `conic-gradient(${conic.slice(0, -2)})`;
         const top = entries[0];
         topLanguagePercent.textContent = `${((top[1] / total) * 100).toFixed(0)}%`;
         topLanguageName.textContent = top[0];
-        languageLegend.innerHTML = legendHtml.join('');
+        languageLegend.replaceChildren(...legendItems);
       }
 
       // Render repos
       function renderRepos(repos) {
-        reposList.innerHTML = '';
+        reposList.replaceChildren();
         if (!repos.length) {
-          reposList.innerHTML = '<div style="color: var(--muted); grid-column: 1/-1; text-align: center; padding: 40px;">No repositories found</div>';
+          const empty = document.createElement('div');
+          empty.style.color = 'var(--muted)';
+          empty.style.gridColumn = '1/-1';
+          empty.style.textAlign = 'center';
+          empty.style.padding = '40px';
+          empty.textContent = 'No repositories found';
+          reposList.appendChild(empty);
           return;
         }
 
         repos.slice(0, 6).forEach(r => {
           const card = document.createElement('div');
           card.className = 'repo-card';
-          card.innerHTML = `
-            <div class="repo-top">
-              <h4 class="repo-name">${r.name}</h4>
-            </div>
-            <p class="repo-description">${r.description || 'No description available'}</p>
-            <div class="repo-meta">
-              <span class="pill">⭐ ${r.stargazers_count}</span>
-              <span class="pill">🍴 ${r.forks_count}</span>
-              <span class="badge">${r.language || 'N/A'}</span>
-            </div>
-          `;
+
+          const top = document.createElement('div');
+          top.className = 'repo-top';
+          const name = document.createElement('h4');
+          name.className = 'repo-name';
+          name.textContent = r.name; // GitHub API value — textContent, never HTML
+          top.appendChild(name);
+
+          const desc = document.createElement('p');
+          desc.className = 'repo-description';
+          desc.textContent = r.description || 'No description available';
+
+          const meta = document.createElement('div');
+          meta.className = 'repo-meta';
+
+          const stars = document.createElement('span');
+          stars.className = 'pill';
+          stars.textContent = `⭐ ${r.stargazers_count}`;
+
+          const forks = document.createElement('span');
+          forks.className = 'pill';
+          forks.textContent = `🍴 ${r.forks_count}`;
+
+          const lang = document.createElement('span');
+          lang.className = 'badge';
+          lang.textContent = r.language || 'N/A';
+
+          meta.appendChild(stars);
+          meta.appendChild(forks);
+          meta.appendChild(lang);
+
+          card.appendChild(top);
+          card.appendChild(desc);
+          card.appendChild(meta);
           reposList.appendChild(card);
         });
       }
@@ -589,10 +635,10 @@
           const reposA = await fetchRepos(usernameA);
           const reposB = await fetchRepos(usernameB);
 
-          comparisonContainer.innerHTML = `
-            ${createCompareCard(userA, reposA, 'left')}
-            ${createCompareCard(userB, reposB, 'right')}
-          `;
+          comparisonContainer.replaceChildren(
+            createCompareCard(userA, reposA, 'left'),
+            createCompareCard(userB, reposB, 'right')
+          );
 
           hideStatus();
           showStatus(`✅ Comparison complete!`, 'success');
@@ -604,42 +650,80 @@
         }
       }
 
+      function buildCompareStat(label, value) {
+        const stat = document.createElement('div');
+        stat.className = 'compare-stat';
+        const span = document.createElement('span');
+        span.textContent = label;
+        const strong = document.createElement('strong');
+        strong.textContent = value;
+        stat.appendChild(span);
+        stat.appendChild(strong);
+        return stat;
+      }
+
       function createCompareCard(user, repos, side) {
-        return `
-          <div class="compare-card">
-            <div class="compare-header">
-              <img src="${user.avatar_url}" alt="${user.login}" class="compare-avatar" />
-              <div>
-                <h3>${user.name || user.login}</h3>
-                <p>@${user.login}</p>
-              </div>
-            </div>
-            <p class="compare-bio">${user.bio || 'No bio available'}</p>
-            <div class="compare-stats">
-              <div class="compare-stat">
-                <span>📦 Repos</span>
-                <strong>${user.public_repos}</strong>
-              </div>
-              <div class="compare-stat">
-                <span>👥 Followers</span>
-                <strong>${user.followers}</strong>
-              </div>
-              <div class="compare-stat">
-                <span>👤 Following</span>
-                <strong>${user.following}</strong>
-              </div>
-            </div>
-            <div class="compare-repos">
-              <h4>Top Repositories</h4>
-              ${repos.slice(0, 3).map(r => `
-                <div class="mini-repo-card">
-                  <a href="${r.html_url}" target="_blank">${r.name}</a>
-                  <span>⭐ ${r.stargazers_count}</span>
-                </div>
-              `).join('')}
-            </div>
-          </div>
-        `;
+        const card = document.createElement('div');
+        card.className = 'compare-card';
+
+        const header = document.createElement('div');
+        header.className = 'compare-header';
+
+        const img = document.createElement('img');
+        img.src = user.avatar_url;
+        img.alt = user.login; // GitHub API value — set via setAttribute-equivalent property, never HTML
+        img.className = 'compare-avatar';
+
+        const identity = document.createElement('div');
+        const h3 = document.createElement('h3');
+        h3.textContent = user.name || user.login;
+        const handle = document.createElement('p');
+        handle.textContent = `@${user.login}`;
+        identity.appendChild(h3);
+        identity.appendChild(handle);
+
+        header.appendChild(img);
+        header.appendChild(identity);
+
+        const bio = document.createElement('p');
+        bio.className = 'compare-bio';
+        bio.textContent = user.bio || 'No bio available';
+
+        const stats = document.createElement('div');
+        stats.className = 'compare-stats';
+        stats.appendChild(buildCompareStat('📦 Repos', user.public_repos));
+        stats.appendChild(buildCompareStat('👥 Followers', user.followers));
+        stats.appendChild(buildCompareStat('👤 Following', user.following));
+
+        const repoWrap = document.createElement('div');
+        repoWrap.className = 'compare-repos';
+        const repoHeading = document.createElement('h4');
+        repoHeading.textContent = 'Top Repositories';
+        repoWrap.appendChild(repoHeading);
+
+        repos.slice(0, 3).forEach(r => {
+          const mini = document.createElement('div');
+          mini.className = 'mini-repo-card';
+
+          const a = document.createElement('a');
+          a.href = r.html_url;
+          a.target = '_blank';
+          a.rel = 'noreferrer';
+          a.textContent = r.name; // GitHub API value — textContent, never HTML
+
+          const starEl = document.createElement('span');
+          starEl.textContent = `⭐ ${r.stargazers_count}`;
+
+          mini.appendChild(a);
+          mini.appendChild(starEl);
+          repoWrap.appendChild(mini);
+        });
+
+        card.appendChild(header);
+        card.appendChild(bio);
+        card.appendChild(stats);
+        card.appendChild(repoWrap);
+        return card;
       }
 
       // Search form submit

--- a/public/github_profile_finder/script.js
+++ b/public/github_profile_finder/script.js
@@ -251,7 +251,7 @@ function resetProfileUI() {
   UI.analyticsPanel?.classList.add("hidden");
 
   if (UI.reposList)
-    UI.reposList.innerHTML = "";
+    UI.reposList.replaceChildren();
 }
 
 /* =========================================================
@@ -281,11 +281,10 @@ function showCompareLoading() {
     "hidden"
   );
 
-  UI.comparisonContainer.innerHTML = `
-    <div class="compare-loading">
-      Loading profile comparison...
-    </div>
-  `;
+  const loadingNote = document.createElement("div");
+  loadingNote.className = "compare-loading";
+  loadingNote.textContent = "Loading profile comparison...";
+  UI.comparisonContainer.replaceChildren(loadingNote);
 }
 
 /* =========================================================
@@ -495,7 +494,7 @@ async function fetchContributionData(username) {
  */
 function renderContributionHeatmap(contributions) {
 
-  UI.heatmapGrid.innerHTML = "";
+  UI.heatmapGrid.replaceChildren();
 
   // Cap at 371 days (53 weeks) to mirror GitHub's ~12 month view.
   const days = contributions.slice(-371);
@@ -546,7 +545,7 @@ function renderContributionHeatmap(contributions) {
  */
 function showHeatmapError(message) {
 
-  UI.heatmapGrid.innerHTML = "";
+  UI.heatmapGrid.replaceChildren();
 
   const errorNode =
     document.createElement("div");
@@ -574,7 +573,7 @@ async function generateContributionHeatmap(username) {
   loadingNode.style.padding = "10px 0";
   loadingNode.textContent = "Loading contribution activity...";
 
-  UI.heatmapGrid.innerHTML = "";
+  UI.heatmapGrid.replaceChildren();
   UI.heatmapGrid.appendChild(loadingNode);
 
   try {
@@ -680,7 +679,7 @@ async function renderLanguageAnalytics(repos) {
 
     const gradientParts = [];
 
-    UI.languageLegend.innerHTML = "";
+    UI.languageLegend.replaceChildren();
 
     sortedLanguages.forEach(
       ([language, bytes], index) => {
@@ -703,22 +702,35 @@ async function renderLanguageAnalytics(repos) {
         item.className =
           "language-legend-item";
 
-        item.innerHTML = `
-          <div class="language-legend-left">
+        const left =
+          document.createElement("div");
 
-            <span
-              class="language-dot"
-              style="background:${colors[index]}"
-            ></span>
+        left.className =
+          "language-legend-left";
 
-            <span>${language}</span>
+        const dot =
+          document.createElement("span");
 
-          </div>
+        dot.className = "language-dot";
+        dot.style.background = colors[index];
 
-          <strong>
-            ${percent.toFixed(1)}%
-          </strong>
-        `;
+        const langLabel =
+          document.createElement("span");
+
+        // GitHub API value — set via textContent, never HTML
+        langLabel.textContent = language;
+
+        left.appendChild(dot);
+        left.appendChild(langLabel);
+
+        const percentLabel =
+          document.createElement("strong");
+
+        percentLabel.textContent =
+          `${percent.toFixed(1)}%`;
+
+        item.appendChild(left);
+        item.appendChild(percentLabel);
 
         UI.languageLegend.appendChild(item);
       }
@@ -786,15 +798,41 @@ function renderProfile(user) {
         ? user.blog
         : `https://${user.blog}`;
 
-    Nodes.website.innerHTML = `
-      <a
-        href="${blogUrl}"
-        target="_blank"
-        class="repo-link"
-      >
-        ${user.blog}
-      </a>
-    `;
+    // Only build a link for http(s) URLs; otherwise show plain text.
+    // This avoids javascript:/data: URIs ending up in an href.
+    let isSafeUrl = false;
+
+    try {
+
+      isSafeUrl =
+        ["http:", "https:"].includes(
+          new URL(blogUrl).protocol
+        );
+
+    } catch {
+
+      isSafeUrl = false;
+    }
+
+    Nodes.website.replaceChildren();
+
+    if (isSafeUrl) {
+
+      const link =
+        document.createElement("a");
+
+      link.href = blogUrl;
+      link.target = "_blank";
+      link.rel = "noreferrer";
+      link.className = "repo-link";
+      link.textContent = user.blog; // GitHub API value — textContent, never HTML
+
+      Nodes.website.appendChild(link);
+
+    } else {
+
+      Nodes.website.textContent = user.blog;
+    }
 
   } else {
 
@@ -837,15 +875,17 @@ function renderProfile(user) {
 
 function renderRepos(repos) {
 
-  UI.reposList.innerHTML = "";
+  UI.reposList.replaceChildren();
 
   if (!repos.length) {
 
-    UI.reposList.innerHTML = `
-      <div class="repo-card">
-        No repositories found.
-      </div>
-    `;
+    const empty =
+      document.createElement("div");
+
+    empty.className = "repo-card";
+    empty.textContent = "No repositories found.";
+
+    UI.reposList.appendChild(empty);
 
     return;
   }
@@ -857,54 +897,82 @@ function renderRepos(repos) {
 
     card.className = "repo-card";
 
-    card.innerHTML = `
-      <div class="repo-top">
+    const top =
+      document.createElement("div");
 
-        <h4 class="repo-name">
+    top.className = "repo-top";
 
-          <a
-            href="${repo.html_url}"
-            target="_blank"
-            class="repo-link"
-          >
-            ${repo.name}
-          </a>
+    const name =
+      document.createElement("h4");
 
-        </h4>
+    name.className = "repo-name";
 
-        <span class="badge">
-          ★ ${repo.stargazers_count}
-        </span>
+    const nameLink =
+      document.createElement("a");
 
-      </div>
+    nameLink.href = repo.html_url;
+    nameLink.target = "_blank";
+    nameLink.rel = "noreferrer";
+    nameLink.className = "repo-link";
+    nameLink.textContent = repo.name; // GitHub API value — textContent, never HTML
 
-      <p class="repo-description">
+    name.appendChild(nameLink);
 
-        ${safeText(
-          repo.description,
-          "No description available."
-        )}
+    const starBadge =
+      document.createElement("span");
 
-      </p>
+    starBadge.className = "badge";
+    starBadge.textContent =
+      `★ ${repo.stargazers_count}`;
 
-      <div class="repo-meta">
+    top.appendChild(name);
+    top.appendChild(starBadge);
 
-        ${
-          repo.language
-            ? `<span class="pill">${repo.language}</span>`
-            : ""
-        }
+    const description =
+      document.createElement("p");
 
-        <span class="pill">
-          Forks ${repo.forks_count}
-        </span>
+    description.className = "repo-description";
+    description.textContent = safeText(
+      repo.description,
+      "No description available."
+    );
 
-        <span class="pill">
-          Updated ${formatDate(repo.updated_at)}
-        </span>
+    const meta =
+      document.createElement("div");
 
-      </div>
-    `;
+    meta.className = "repo-meta";
+
+    if (repo.language) {
+
+      const languagePill =
+        document.createElement("span");
+
+      languagePill.className = "pill";
+      languagePill.textContent = repo.language; // GitHub API value — textContent
+
+      meta.appendChild(languagePill);
+    }
+
+    const forksPill =
+      document.createElement("span");
+
+    forksPill.className = "pill";
+    forksPill.textContent =
+      `Forks ${repo.forks_count}`;
+
+    const updatedPill =
+      document.createElement("span");
+
+    updatedPill.className = "pill";
+    updatedPill.textContent =
+      `Updated ${formatDate(repo.updated_at)}`;
+
+    meta.appendChild(forksPill);
+    meta.appendChild(updatedPill);
+
+    card.appendChild(top);
+    card.appendChild(description);
+    card.appendChild(meta);
 
     UI.reposList.appendChild(card);
   });
@@ -1103,23 +1171,62 @@ async function fetchProfileData(username) {
 
 function buildRepoListSmall(repos) {
 
-  return repos.map((repo) => `
-    <div class="mini-repo-card">
+  const fragment =
+    document.createDocumentFragment();
 
-      <a
-        href="${repo.html_url}"
-        target="_blank"
-        class="repo-link"
-      >
-        ${repo.name}
-      </a>
+  repos.forEach((repo) => {
 
-      <span>
-        ★ ${repo.stargazers_count}
-      </span>
+    const mini =
+      document.createElement("div");
 
-    </div>
-  `).join("");
+    mini.className = "mini-repo-card";
+
+    const link =
+      document.createElement("a");
+
+    link.href = repo.html_url;
+    link.target = "_blank";
+    link.rel = "noreferrer";
+    link.className = "repo-link";
+    link.textContent = repo.name; // GitHub API value — textContent, never HTML
+
+    const stars =
+      document.createElement("span");
+
+    stars.textContent =
+      `★ ${repo.stargazers_count}`;
+
+    mini.appendChild(link);
+    mini.appendChild(stars);
+
+    fragment.appendChild(mini);
+  });
+
+  return fragment;
+}
+
+function buildComparisonStat(label, value, isWinner) {
+
+  const stat =
+    document.createElement("div");
+
+  stat.className =
+    `compare-stat ${isWinner ? "winner" : ""}`;
+
+  const label_ =
+    document.createElement("span");
+
+  label_.textContent = label;
+
+  const strong =
+    document.createElement("strong");
+
+  strong.textContent = value;
+
+  stat.appendChild(label_);
+  stat.appendChild(strong);
+
+  return stat;
 }
 
 function renderComparisonCard(
@@ -1139,86 +1246,103 @@ function renderComparisonCard(
     data.user.following >
     opponent.user.following;
 
-  return `
-    <article class="compare-card">
+  const article =
+    document.createElement("article");
 
-      <div class="compare-header">
+  article.className = "compare-card";
 
-        <img
-          src="${data.user.avatar_url}"
-          class="compare-avatar"
-        />
+  const header =
+    document.createElement("div");
 
-        <div>
+  header.className = "compare-header";
 
-          <h3>
-            ${safeText(
-              data.user.name,
-              data.user.login
-            )}
-          </h3>
+  const img =
+    document.createElement("img");
 
-          <p>
-            @${data.user.login}
-          </p>
+  img.src = data.user.avatar_url;
+  img.className = "compare-avatar";
 
-        </div>
+  const identity =
+    document.createElement("div");
 
-      </div>
+  const h3 =
+    document.createElement("h3");
 
-      <p class="compare-bio">
+  h3.textContent = safeText(
+    data.user.name,
+    data.user.login
+  );
 
-        ${safeText(
-          data.user.bio,
-          "No bio available."
-        )}
+  const handle =
+    document.createElement("p");
 
-      </p>
+  handle.textContent = `@${data.user.login}`;
 
-      <div class="compare-stats">
+  identity.appendChild(h3);
+  identity.appendChild(handle);
 
-        <div class="compare-stat ${repoWinner ? "winner" : ""}">
+  header.appendChild(img);
+  header.appendChild(identity);
 
-          <span>Repositories</span>
+  const bio =
+    document.createElement("p");
 
-          <strong>
-            ${data.user.public_repos}
-          </strong>
+  bio.className = "compare-bio";
+  bio.textContent = safeText(
+    data.user.bio,
+    "No bio available."
+  );
 
-        </div>
+  const stats =
+    document.createElement("div");
 
-        <div class="compare-stat ${followerWinner ? "winner" : ""}">
+  stats.className = "compare-stats";
 
-          <span>Followers</span>
+  stats.appendChild(
+    buildComparisonStat(
+      "Repositories",
+      data.user.public_repos,
+      repoWinner
+    )
+  );
 
-          <strong>
-            ${data.user.followers.toLocaleString()}
-          </strong>
+  stats.appendChild(
+    buildComparisonStat(
+      "Followers",
+      data.user.followers.toLocaleString(),
+      followerWinner
+    )
+  );
 
-        </div>
+  stats.appendChild(
+    buildComparisonStat(
+      "Following",
+      data.user.following,
+      followingWinner
+    )
+  );
 
-        <div class="compare-stat ${followingWinner ? "winner" : ""}">
+  const repoWrap =
+    document.createElement("div");
 
-          <span>Following</span>
+  repoWrap.className = "compare-repos";
 
-          <strong>
-            ${data.user.following}
-          </strong>
+  const repoHeading =
+    document.createElement("h4");
 
-        </div>
+  repoHeading.textContent = "Top Repositories";
 
-      </div>
+  repoWrap.appendChild(repoHeading);
+  repoWrap.appendChild(
+    buildRepoListSmall(data.repos)
+  );
 
-      <div class="compare-repos">
+  article.appendChild(header);
+  article.appendChild(bio);
+  article.appendChild(stats);
+  article.appendChild(repoWrap);
 
-        <h4>Top Repositories</h4>
-
-        ${buildRepoListSmall(data.repos)}
-
-      </div>
-
-    </article>
-  `;
+  return article;
 }
 
 function renderComparison(
@@ -1230,17 +1354,16 @@ function renderComparison(
     "hidden"
   );
 
-  UI.comparisonContainer.innerHTML = `
-    ${renderComparisonCard(
+  UI.comparisonContainer.replaceChildren(
+    renderComparisonCard(
       leftData,
       rightData
-    )}
-
-    ${renderComparisonCard(
+    ),
+    renderComparisonCard(
       rightData,
       leftData
-    )}
-  `;
+    )
+  );
 
   UI.comparisonPanel.scrollIntoView({
     behavior: "smooth"

--- a/public/github_profile_finder/script.js
+++ b/public/github_profile_finder/script.js
@@ -105,6 +105,50 @@ class DataCacheEngine {
 }
 
 /* =========================================================
+   REQUEST LIFECYCLE (Bug #10505)
+========================================================= */
+
+// Only one profile search or comparison may be "in flight" at a
+// time. currentOperationController lets us abort whatever the
+// previous one was doing the moment a new one starts, and
+// currentOperationId is a generation counter so that async work
+// which can't be aborted (e.g. a fetch that already resolved, or
+// a loop that's mid-iteration) can still recognize it has become
+// stale and refuse to touch the UI.
+let currentOperationController = null;
+let currentOperationId = 0;
+
+// Call at the start of every profile search / comparison. Aborts
+// the previous operation (if any) so its in-flight requests stop
+// and its results can never overwrite what the user just asked
+// for, then hands back a fresh signal + id for the new operation.
+function beginOperation() {
+  if (currentOperationController) {
+    currentOperationController.abort();
+  }
+  currentOperationController = new AbortController();
+  currentOperationId += 1;
+
+  return {
+    signal: currentOperationController.signal,
+    operationId: currentOperationId
+  };
+}
+
+// True once a newer operation has started, meaning this one's
+// results are stale and must not be rendered.
+function isStaleOperation(operationId) {
+  return operationId !== currentOperationId;
+}
+
+// An AbortError means a request was cancelled on purpose (a newer
+// search/comparison took over) - it is not a real failure and
+// must never surface as an error banner to the user.
+function isAbortError(error) {
+  return Boolean(error) && error.name === "AbortError";
+}
+
+/* =========================================================
    UTILITIES
 ========================================================= */
 
@@ -309,9 +353,12 @@ function sleep(ms) {
 
 /**
  * Fetch wrapper with a timeout, since a hung request should
- * never leave the heatmap stuck on "Loading...".
+ * never leave the heatmap stuck on "Loading...". Also accepts the
+ * outer search/comparison operation's signal (externalSignal) so
+ * that cancelling the whole operation aborts this request
+ * immediately too, instead of waiting out its own timeout.
  */
-async function fetchWithTimeout(url, timeoutMs) {
+async function fetchWithTimeout(url, timeoutMs, externalSignal) {
 
   const controller = new AbortController();
 
@@ -320,6 +367,17 @@ async function fetchWithTimeout(url, timeoutMs) {
     timeoutMs
   );
 
+  const abortFromOutside = () => controller.abort();
+
+  if (externalSignal) {
+
+    if (externalSignal.aborted) {
+      controller.abort();
+    } else {
+      externalSignal.addEventListener("abort", abortFromOutside);
+    }
+  }
+
   try {
 
     return await fetch(url, { signal: controller.signal });
@@ -327,6 +385,10 @@ async function fetchWithTimeout(url, timeoutMs) {
   } finally {
 
     clearTimeout(timer);
+
+    if (externalSignal) {
+      externalSignal.removeEventListener("abort", abortFromOutside);
+    }
   }
 }
 
@@ -337,11 +399,12 @@ async function fetchWithTimeout(url, timeoutMs) {
  * { date, count, level } day objects. Only used when
  * GRAPHQL_PROXY_ENDPOINT is configured.
  */
-async function fetchContributionsFromGraphQLProxy(username) {
+async function fetchContributionsFromGraphQLProxy(username, signal) {
 
   const response = await fetchWithTimeout(
     `${GRAPHQL_PROXY_ENDPOINT}?username=${encodeURIComponent(username)}`,
-    CONTRIBUTIONS_FETCH_TIMEOUT_MS
+    CONTRIBUTIONS_FETCH_TIMEOUT_MS,
+    signal
   );
 
   if (!response.ok) {
@@ -371,7 +434,7 @@ async function fetchContributionsFromGraphQLProxy(username) {
  * fabricated data - any unrecoverable failure is thrown so the
  * caller can show an honest error state.
  */
-async function fetchContributionsFromFallbackApi(username) {
+async function fetchContributionsFromFallbackApi(username, signal) {
 
   let lastError = null;
 
@@ -381,7 +444,8 @@ async function fetchContributionsFromFallbackApi(username) {
 
       const response = await fetchWithTimeout(
         `${CONTRIBUTIONS_FALLBACK_API_URL}/${username}?y=last`,
-        CONTRIBUTIONS_FETCH_TIMEOUT_MS
+        CONTRIBUTIONS_FETCH_TIMEOUT_MS,
+        signal
       );
 
       if (response.status === 404) {
@@ -430,11 +494,20 @@ async function fetchContributionsFromFallbackApi(username) {
       const isAbort = error.name === "AbortError";
       const isNotFound = error.status === 404;
 
-      // Don't retry on a bad username or an aborted/timed-out
-      // request that's already exhausted its own budget once;
-      // only retry genuinely transient failures.
+      // If the *outer* search/comparison was cancelled (a newer one
+      // started), this AbortError is an intentional cancellation,
+      // not a transient failure - retrying it would just re-issue
+      // work nobody wants anymore. Only genuine timeouts (this
+      // request's own budget expiring) are retryable.
+      const isExternalCancel = Boolean(signal && signal.aborted);
+
+      // Don't retry on a bad username, an intentionally cancelled
+      // operation, or an aborted/timed-out request that's already
+      // exhausted its own budget once; only retry genuinely
+      // transient failures.
       const isRetryable =
         !isNotFound &&
+        !isExternalCancel &&
         (isAbort ||
           error.status === 429 ||
           error.status >= 500 ||
@@ -442,7 +515,7 @@ async function fetchContributionsFromFallbackApi(username) {
 
       if (!isRetryable || attempt === CONTRIBUTIONS_MAX_RETRIES) {
 
-        if (isAbort) {
+        if (isAbort && !isExternalCancel) {
 
           lastError = new Error(
             "The request timed out while loading contribution activity."
@@ -469,7 +542,7 @@ async function fetchContributionsFromFallbackApi(username) {
  * falls back to the public read-only contributions API. Never
  * falls back to randomly generated or fake data.
  */
-async function fetchContributionData(username) {
+async function fetchContributionData(username, signal) {
 
   const cacheKey = `contributions_${username}`;
 
@@ -478,8 +551,8 @@ async function fetchContributionData(username) {
   if (cached) return cached;
 
   const contributions = GRAPHQL_PROXY_ENDPOINT
-    ? await fetchContributionsFromGraphQLProxy(username)
-    : await fetchContributionsFromFallbackApi(username);
+    ? await fetchContributionsFromGraphQLProxy(username, signal)
+    : await fetchContributionsFromFallbackApi(username, signal);
 
   DataCacheEngine.set(cacheKey, contributions);
 
@@ -560,7 +633,7 @@ function showHeatmapError(message) {
   UI.heatmapGrid.appendChild(errorNode);
 }
 
-async function generateContributionHeatmap(username) {
+async function generateContributionHeatmap(username, signal, operationId) {
 
   if (!UI.heatmapGrid) return;
 
@@ -579,11 +652,20 @@ async function generateContributionHeatmap(username) {
   try {
 
     const contributions =
-      await fetchContributionData(username);
+      await fetchContributionData(username, signal);
+
+    // A newer search/comparison may have started while this was
+    // in flight; ignore the now-stale result instead of rendering
+    // over whatever the newer operation has already shown.
+    if (isStaleOperation(operationId)) return;
 
     renderContributionHeatmap(contributions);
 
   } catch (error) {
+
+    // Cancellation (this operation or the whole page's operation
+    // being superseded) is expected, not an error - stay silent.
+    if (isAbortError(error) || isStaleOperation(operationId)) return;
 
     showHeatmapError(getContributionErrorMessage(error));
   }
@@ -626,7 +708,7 @@ function getContributionErrorMessage(error) {
    LANGUAGE ANALYTICS
 ========================================================= */
 
-async function renderLanguageAnalytics(repos) {
+async function renderLanguageAnalytics(repos, signal, operationId) {
 
   if (!repos || !repos.length) return;
 
@@ -639,7 +721,7 @@ async function renderLanguageAnalytics(repos) {
       if (!repo.languages_url) continue;
 
       const response =
-        await fetch(repo.languages_url);
+        await fetch(repo.languages_url, { signal });
 
       if (!response.ok) continue;
 
@@ -661,6 +743,11 @@ async function renderLanguageAnalytics(repos) {
         .reduce((sum, value) => sum + value, 0);
 
     if (!totalBytes) return;
+
+    // A newer search/comparison may have started while these
+    // per-repo language requests were in flight; don't let a
+    // stale result overwrite the current UI.
+    if (isStaleOperation(operationId)) return;
 
     const sortedLanguages =
       Object.entries(languageBytes)
@@ -753,6 +840,10 @@ async function renderLanguageAnalytics(repos) {
       `${topPercent}%`;
 
   } catch (error) {
+
+    // Cancellation is expected here (a newer operation took over)
+    // and isn't a real failure worth logging.
+    if (isAbortError(error)) return;
 
     console.error(
       "Language analytics failed:",
@@ -1001,12 +1092,18 @@ async function fetchUser(username) {
     return;
   }
 
+  // Cancel any previous profile search/comparison so it can't
+  // finish late and clobber the UI with stale data (Bug #10505),
+  // then run this one under its own signal + generation id.
+  const { signal, operationId } = beginOperation();
+
   showLoading();
 
   try {
 
     const userResponse = await fetch(
-      `https://api.github.com/users/${cleanName}`
+      `https://api.github.com/users/${cleanName}`,
+      { signal }
     );
 
     if (!userResponse.ok) {
@@ -1020,7 +1117,8 @@ async function fetchUser(username) {
       await userResponse.json();
 
     const repoResponse = await fetch(
-      `https://api.github.com/users/${cleanName}/repos?per_page=100`
+      `https://api.github.com/users/${cleanName}/repos?per_page=100`,
+      { signal }
     );
 
     if (!repoResponse.ok) {
@@ -1051,13 +1149,22 @@ async function fetchUser(username) {
       )
       .slice(0, 6);
 
+    // A newer search/comparison may have started while the above
+    // requests were in flight; if so, this result is stale and
+    // must not be rendered over the newer one.
+    if (isStaleOperation(operationId)) return;
+
     renderProfile(user);
 
     renderRepos(sortedRepos);
 
-    await generateContributionHeatmap(cleanName);
+    await generateContributionHeatmap(cleanName, signal, operationId);
 
-    await renderLanguageAnalytics(repos);
+    if (isStaleOperation(operationId)) return;
+
+    await renderLanguageAnalytics(repos, signal, operationId);
+
+    if (isStaleOperation(operationId)) return;
 
     UI.analyticsPanel?.classList.remove(
       "hidden"
@@ -1066,6 +1173,12 @@ async function fetchUser(username) {
     hideStatus();
 
   } catch (error) {
+
+    // An aborted request means a newer search/comparison started
+    // and cancelled this one on purpose - that's not a failure, so
+    // don't show an error banner or reset UI the newer operation
+    // may already own.
+    if (isAbortError(error) || isStaleOperation(operationId)) return;
 
     resetProfileUI();
 
@@ -1080,7 +1193,7 @@ async function fetchUser(username) {
    FETCH PROFILE DATA
 ========================================================= */
 
-async function fetchProfileData(username) {
+async function fetchProfileData(username, signal) {
 
   const cleanName =
     username.trim().replace("@", "");
@@ -1104,7 +1217,8 @@ async function fetchProfileData(username) {
   }
 
   const userResponse = await fetch(
-    `https://api.github.com/users/${cleanName}`
+    `https://api.github.com/users/${cleanName}`,
+    { signal }
   );
 
   if (!userResponse.ok) {
@@ -1118,7 +1232,8 @@ async function fetchProfileData(username) {
     await userResponse.json();
 
   const repoResponse = await fetch(
-    `https://api.github.com/users/${cleanName}/repos?per_page=50`
+    `https://api.github.com/users/${cleanName}/repos?per_page=50`,
+    { signal }
   );
 
   if (!repoResponse.ok) {
@@ -1418,6 +1533,10 @@ if (UI.compareForm) {
         return;
       }
 
+      // Cancel any previous profile search/comparison so it can't
+      // finish late and clobber this comparison's UI (Bug #10505).
+      const { signal, operationId } = beginOperation();
+
       try {
 
         showCompareLoading();
@@ -1428,14 +1547,20 @@ if (UI.compareForm) {
         ] = await Promise.all([
 
           fetchProfileData(
-            leftUsername
+            leftUsername,
+            signal
           ),
 
           fetchProfileData(
-            rightUsername
+            rightUsername,
+            signal
           )
 
         ]);
+
+        // A newer search/comparison may have started while these
+        // requests were in flight; ignore this now-stale result.
+        if (isStaleOperation(operationId)) return;
 
         renderComparison(
           leftData,
@@ -1445,6 +1570,11 @@ if (UI.compareForm) {
         hideStatus();
 
       } catch (error) {
+
+        // An aborted request means a newer search/comparison
+        // started and cancelled this one on purpose - not a real
+        // failure, so stay silent rather than show an error banner.
+        if (isAbortError(error) || isStaleOperation(operationId)) return;
 
         showStatus(
           error.message,

--- a/public/github_profile_finder/style.css
+++ b/public/github_profile_finder/style.css
@@ -464,7 +464,7 @@ body {
 
 .dashboard-grid {
   display: grid;
-  grid-template-columns: 340px 1fr;
+  grid-template-columns: clamp(260px, 20%, 340px) 1fr; /* was: 340px 1fr */
   gap: 28px;
   align-items: start;
   width: 100%;
@@ -634,28 +634,33 @@ body {
    STATS - FULL WIDTH FIXED
 ========================================================= */
 
-.stats-overview {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 20px;
-  width: 100%;
-  margin: 0;
-  padding: 0;
+.stats-overview{
+    display: grid;
+    grid-template-columns: repeat(4, minmax(240px, 1fr));
+    gap: 18px;
+    width: 100%;
 }
 
-.stat-box {
-  background: var(--card);
-  border: 1px solid var(--card-border);
-  border-radius: var(--radius-lg);
-  padding: 28px 20px;
-  backdrop-filter: blur(20px);
-  box-shadow: var(--shadow);
-  transition: var(--transition);
-  text-align: center;
-  position: relative;
-  overflow: hidden;
-  width: 100%;
-  min-width: 0;
+.stat-box{
+    background: var(--card);
+    border: 1px solid var(--card-border);
+    border-radius: var(--radius-lg);
+
+    padding: 24px 30px;
+    min-height: 190px;
+
+    backdrop-filter: blur(20px);
+    box-shadow: var(--shadow);
+    transition: var(--transition);
+
+    position: relative;
+    overflow: hidden;
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
 }
 
 .stat-box::before {
@@ -682,23 +687,23 @@ body {
 
 .stat-icon {
   font-size: 2rem;
-  margin-bottom: 10px;
-  display: block;
+  margin-bottom: 14px;
+  /* display: block; */
 }
 
 .stat-box span {
   display: block;
   color: var(--muted);
-  margin-bottom: 10px;
+  margin-bottom: 14px;
   font-weight: 600;
-  font-size: 0.8rem;
+  font-size: 0.9rem;
   text-transform: uppercase;
   letter-spacing: 0.8px;
   white-space: nowrap;
 }
 
 .stat-box strong {
-  font-size: clamp(2rem, 3vw, 3rem);
+  font-size: 3rem;
   font-weight: 800;
   display: block;
   background: linear-gradient(135deg, var(--primary), var(--secondary));
@@ -844,6 +849,8 @@ body {
   gap:5px;
 
   min-width:900px;
+}
+
 .heatmap-grid {
   display: grid;
   grid-template-columns: repeat(53, 12px);


### PR DESCRIPTION
## Description

Fixes #10505

This PR prevents overlapping GitHub API requests when users rapidly perform profile searches or comparisons.

### Changes Made

- Added a shared request lifecycle using `AbortController` and an operation ID.
- Cancels the previous profile search or comparison when a new one starts.
- Propagates the cancellation signal through profile, repository, contribution, and language API requests.
- Prevents stale requests from updating the UI after a newer request has started.
- Prevents intentionally cancelled requests from displaying error messages.
- Stops contribution-data retries when the operation has been cancelled.
- Preserves the existing timeout and retry behavior for genuine failures.

### Result

Only the most recent search or comparison can update the UI, preventing stale results and unnecessary concurrent API requests.

### Testing

- `git diff --check` ✅
- `node --check public/github_profile_finder/script.js` ✅
- Verified rapid profile searches and comparison flows are protected against stale results.
- Verified only the intended `script.js` file was modified.