### PR TITLE
fix: resolve start donating button hover alignment

### DIFF
--- a/public/Share_Byte/style.css
+++ b/public/Share_Byte/style.css
@@ -53,7 +53,6 @@ a{
     color: #fff;
 }
 a:hover{
-   height: 20px;
    border-radius: 20px;
    background :#eef6df ;
    color:#145c26;


### PR DESCRIPTION
## 📝 Pull Request Description

Fixed the hover alignment issue with the **Start Donating** button in the Share_Byte project.

### Changes Made

* Removed the fixed `height: 20px` from the global `a:hover` CSS rule.
* This was causing the **Start Donating** button to shrink vertically when hovered, which clipped the button text.
* The button now maintains its proper height and keeps the text fully visible and vertically aligned on hover.

Before: button text gets clipped on hover ❌
<img width="1846" height="636" alt="image" src="https://github.com/user-attachments/assets/0ed2c41d-51c8-4ef9-8d88-57f649f0f895" />

After: button remains properly sized and text is fully visible ✅
<img width="1876" height="491" alt="Screenshot 2026-08-18 080359" src="https://github.com/user-attachments/assets/205d0e50-7ea5-45af-9a25-4aa35d2ccbbd" />



### Testing

* Tested the **Start Donating** button locally.
* Verified that the text remains fully visible when hovering over the button.
* Confirmed that the existing hover styling still works.

### Related Issue

Closes #11097
