### PR TITLE
fix: prevent auth credentials from being persisted

### DIFF
--- a/public/mini-postman/js/app.js
+++ b/public/mini-postman/js/app.js
@@ -219,6 +219,27 @@ function getAuthFieldsFromUI() {
   });
   return fields;
 }
+function sanitizeAuthFields(authType, authFields = {}) {
+  if (authType === 'basic') {
+    return { username: authFields.username || '' };
+  }
+
+  if (authType === 'api-key') {
+    return { header: authFields.header || '' };
+  }
+
+  return {};
+}
+
+function sanitizeAuthHeaders(authType, authFields, headers) {
+  const generatedHeaders = buildAuthHeaders(authType, authFields);
+
+  return headers.filter(header =>
+    !generatedHeaders.some(
+      generated => generated.key === header.key && generated.value === header.value
+    )
+  );
+}
 
 function buildAuthHeaders(authType, authFields) {
   if (authType === 'bearer' && authFields.token) {
@@ -279,7 +300,16 @@ async function sendRequest() {
     UI.showResponseResult(result);
 
     // Persist to history
-    const histEntry = { method, url, headers, body, bodyType, authType, authFields, status: result.status };
+    const histEntry = {
+      method,
+      url,
+      headers: sanitizeAuthHeaders(authType, authFields, headers),
+      body,
+      bodyType,
+      authType,
+      authFields: sanitizeAuthFields(authType, authFields),
+      status: result.status
+    };
     Storage.addHistory(histEntry);
     Storage.addUrl(url);
     CollectionsModule.renderHistory();
@@ -632,7 +662,7 @@ document.addEventListener('DOMContentLoaded', () => {
     Storage.addRequestToCollection(colId, {
       name, method: tab.method, url: tab.url,
       headers: tab.headers, body: tab.body, bodyType: tab.bodyType,
-      authType: tab.authType, authFields: tab.authFields,
+      authType: tab.authType, authFields: sanitizeAuthFields(tab.authType, tab.authFields),
     });
     CollectionsModule.renderCollections();
     closeModal('save-modal');


### PR DESCRIPTION
## 📝 Pull Request Description

### Related Issue

Closes #10958

### Summary

Prevent authentication credentials from being persisted in plaintext in Mini Postman request history and saved collections.

### Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [ ] ✨ New project addition
* [ ] 🚀 New feature or UI/UX enhancement
* [ ] ♻️ Code refactoring / clean-up
* [ ] 📝 Documentation update
* [ ] ⚙️ GitHub Workflow automation or DX improvements

---

## 🛠️ Changes Made

* Added sanitization for authentication fields before persisting requests.
* Prevented Bearer tokens, Basic Auth passwords, and API key values from being stored in plaintext.
* Prevented generated authentication headers containing credentials from being persisted in request history.
* Applied credential sanitization when saving requests to collections.
* Preserved non-sensitive authentication information such as Basic Auth usernames and API key header names.

---

## 🧪 Testing and Verification

### Local Validation

* [ ] I have run `node scripts/validateProjects.js` locally and it passed with zero errors.

### Browser Compatibility Check

* [x] Tested and verified in **Google Chrome**
* [ ] Tested and verified in **Mozilla Firefox**
* [x] Tested and verified in **Safari** / **Microsoft Edge**

### Responsive & Accessibility Checks

* [ ] Verified responsive layout on Mobile viewports (using DevTools)
* [ ] Verified responsive layout on Tablet viewports
* [ ] Keyboard navigation and focus outlines checked
* [ ] Semantic HTML and ARIA labels checked

---

## 📷 Screenshots / Video Recording

Not applicable — this is a security/data-persistence fix with no visual UI changes.

---

## 🤝 Contributor Checklist

* [x] My code follows the code style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have updated the documentation / README files accordingly.
* [x] My changes generate no new warnings or console errors.
* [x] There are no unrelated changes or formatter noise in this PR.
